### PR TITLE
fix: bump APP_VERSION and SW cache to 8.4 to match implemented features

### DIFF
--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -2751,7 +2751,7 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='8.3';
+const APP_VERSION='8.4';
 function getDiagnostics(){
 const tot=S.qOk+S.qNo;
 return `Shlav A Mega v${APP_VERSION}\n`+

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v8.3';
+const CACHE='shlav-a-v8.4';
 const STATIC=[
   'shlav-a-mega.html',
   'manifest.json',


### PR DESCRIPTION
The v8.4 features (font size controls, annotations, keyboard shortcuts, etc.)
were already implemented but the version strings were still at 8.3.

https://claude.ai/code/session_014rVHAAWurNMb1vjQCjxRUp