### PR TITLE
fix: cache key mismatch in HTML cleanup vs sw.js CACHE

### DIFF
--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -3750,7 +3750,7 @@ navigator.serviceWorker.getRegistrations().then(regs=>{
 regs.forEach(r=>r.update());
 });
 caches.keys().then(ks=>{
-const old=ks.filter(k=>k.startsWith('shlav-a-')&&k!=='shlav-a-v9.10.0');
+const old=ks.filter(k=>k.startsWith('shlav-a-')&&k!=='shlav-a-v9.10');
 old.forEach(k=>{caches.delete(k);console.log('Deleted old cache:',k);});
 });
 navigator.serviceWorker.register('sw.js').then(reg=>{

--- a/tests/serviceWorker.test.js
+++ b/tests/serviceWorker.test.js
@@ -164,4 +164,18 @@ describe("sw.js — version alignment with app", () => {
     const appVersion = appVersionMatch[1];
     expect(swVersion).toContain(appVersion.split(".").slice(0, 2).join("."));
   });
+
+  it("HTML cache cleanup exempts the exact sw.js CACHE key", () => {
+    const cacheKeyMatch = swContent.match(/CACHE\s*=\s*'([^']+)'/);
+    expect(cacheKeyMatch, "CACHE key found in sw.js").not.toBeNull();
+    const swCacheKey = cacheKeyMatch[1];
+
+    // The HTML cleanup code filters old caches: k !== '<current-cache-key>'
+    // This must match the sw.js CACHE exactly or the current cache gets deleted
+    const cleanupMatch = html.match(/ks\.filter\(k=>k\.startsWith\('shlav-a-'\)&&k!=='([^']+)'\)/);
+    expect(cleanupMatch, "Cache cleanup filter found in HTML").not.toBeNull();
+    const htmlExemptKey = cleanupMatch[1];
+
+    expect(htmlExemptKey, `HTML cleanup exempts "${htmlExemptKey}" but sw.js CACHE is "${swCacheKey}"`).toBe(swCacheKey);
+  });
 });


### PR DESCRIPTION
The HTML cache cleanup code exempted 'shlav-a-v9.10.0' but sw.js defines CACHE as 'shlav-a-v9.10' (no .0 suffix). This caused the current cache to be deleted on every page load, forcing unnecessary network fetches and breaking offline functionality.

- Fix cleanup filter to match exact sw.js CACHE key
- Add regression test to ensure HTML cleanup key stays in sync with sw.js

https://claude.ai/code/session_01M3oafVZ95MFEsvKEhLe9q8

## Description
<!-- Provide a brief description of the changes -->

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Code refactoring

## Testing
- [ ] I have tested the changes locally in the browser
- [ ] Questions/data files validated
- [ ] I have added tests for new functionality

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Security
- [ ] No secrets or API keys are exposed
- [ ] No new security warnings

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Any additional information that reviewers should know -->