### PR TITLE
fix: guard isExamTrap() against empty wc object, expand test coverage…

### DIFF
--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -821,7 +821,9 @@ let _diffRating=null; // null,'easy','med','hard'
 function isExamTrap(qIdx){
 const s=S.sr[qIdx];if(!s||!s.wc)return false;
 const totalAttempts=s.tot||0;if(totalAttempts<3)return false;
-const maxWrong=Math.max(...Object.values(s.wc));
+const wrongValues=Object.values(s.wc);
+if(!wrongValues.length)return false;
+const maxWrong=Math.max(...wrongValues);
 return maxWrong/totalAttempts>=0.4;
 }
 function buildPool(){

--- a/tests/appLogic.test.js
+++ b/tests/appLogic.test.js
@@ -81,7 +81,9 @@ function getDueQuestions(sr) {
 function isExamTrap(sr, qIdx) {
   const s = sr[qIdx]; if (!s || !s.wc) return false;
   const totalAttempts = s.tot || 0; if (totalAttempts < 3) return false;
-  const maxWrong = Math.max(...Object.values(s.wc));
+  const wrongValues = Object.values(s.wc);
+  if (!wrongValues.length) return false;
+  const maxWrong = Math.max(...wrongValues);
   return maxWrong / totalAttempts >= 0.4;
 }
 
@@ -413,6 +415,18 @@ describe("isExamTrap", () => {
   it("returns false when wrong answers are spread evenly", () => {
     expect(isExamTrap({ 0: { tot: 10, wc: { 1: 2, 2: 2, 3: 1 } } }, 0)).toBe(false);
   });
+
+  it("returns false when wc object is empty (no wrong choices recorded)", () => {
+    expect(isExamTrap({ 0: { tot: 5, wc: {} } }, 0)).toBe(false);
+  });
+
+  it("returns true when a single wrong choice dominates", () => {
+    expect(isExamTrap({ 0: { tot: 5, wc: { 2: 3 } } }, 0)).toBe(true);
+  });
+
+  it("returns false when high wrong count but below 40% threshold", () => {
+    expect(isExamTrap({ 0: { tot: 10, wc: { 1: 3, 2: 2 } } }, 0)).toBe(false);
+  });
 });
 
 describe("sanitize", () => {
@@ -610,5 +624,175 @@ describe("getEolResult (End-of-Life Decision Tree)", () => {
     const r = getEolResult({ competent: false, directive: false, proxy: false, terminal: true });
     expect(r.standing).toContain("חוק החולה הנוטה למות");
     expect(r.actions.some(a => a.includes("cyclical treatments"))).toBe(true);
+  });
+});
+
+// ─── Mock exam pool building ─────────────────────────────────────────────────
+
+/**
+ * Extracted mock exam pool builder logic from shlav-a-mega.html.
+ * Builds a balanced mock exam with per-topic distribution.
+ */
+function buildMockPool(QZ, totalQuestions) {
+  const topicMap = {};
+  QZ.forEach((q, i) => {
+    const ti = q.ti;
+    if (!topicMap[ti]) topicMap[ti] = [];
+    topicMap[ti].push(i);
+  });
+  const topicKeys = Object.keys(topicMap);
+  if (topicKeys.length === 0) return [];
+  const perTopic = Math.max(1, Math.floor(totalQuestions / topicKeys.length));
+  const pool = [];
+  for (const ti of topicKeys) {
+    const indices = topicMap[ti];
+    // Shuffle and pick up to perTopic
+    const shuffled = [...indices].sort(() => Math.random() - 0.5);
+    pool.push(...shuffled.slice(0, perTopic));
+  }
+  // Shuffle the final pool
+  for (let i = pool.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [pool[i], pool[j]] = [pool[j], pool[i]];
+  }
+  return pool.slice(0, totalQuestions);
+}
+
+describe("buildMockPool — mock exam pool building", () => {
+  it("returns empty array for empty question bank", () => {
+    expect(buildMockPool([], 100)).toEqual([]);
+  });
+
+  it("builds pool with correct maximum size", () => {
+    const QZ = Array.from({ length: 200 }, (_, i) => ({ ti: i % 10 }));
+    const pool = buildMockPool(QZ, 100);
+    expect(pool.length).toBeLessThanOrEqual(100);
+  });
+
+  it("includes questions from multiple topics (per-topic distribution)", () => {
+    const QZ = [];
+    for (let ti = 0; ti < 5; ti++) {
+      for (let j = 0; j < 20; j++) {
+        QZ.push({ ti });
+      }
+    }
+    const pool = buildMockPool(QZ, 50);
+    // Check that multiple topics are represented
+    const topicsInPool = new Set(pool.map(idx => QZ[idx].ti));
+    expect(topicsInPool.size).toBeGreaterThanOrEqual(3);
+  });
+
+  it("handles single-topic question bank", () => {
+    const QZ = Array.from({ length: 50 }, () => ({ ti: 0 }));
+    const pool = buildMockPool(QZ, 20);
+    expect(pool.length).toBeLessThanOrEqual(20);
+    pool.forEach(idx => {
+      expect(QZ[idx].ti).toBe(0);
+    });
+  });
+
+  it("all indices in pool reference valid questions", () => {
+    const QZ = Array.from({ length: 100 }, (_, i) => ({ ti: i % 8 }));
+    const pool = buildMockPool(QZ, 50);
+    pool.forEach(idx => {
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(idx).toBeLessThan(QZ.length);
+    });
+  });
+});
+
+// ─── Streak calculation edge cases ───────────────────────────────────────────
+
+function calcStreak(history) {
+  if (!history || !history.length) return 0;
+  let streak = 0;
+  for (let i = history.length - 1; i >= 0; i--) {
+    if (history[i]) streak++;
+    else break;
+  }
+  return streak;
+}
+
+describe("calcStreak — streak calculation edge cases", () => {
+  it("returns 0 for empty history", () => {
+    expect(calcStreak([])).toBe(0);
+  });
+
+  it("returns 0 for null/undefined history", () => {
+    expect(calcStreak(null)).toBe(0);
+    expect(calcStreak(undefined)).toBe(0);
+  });
+
+  it("returns full length for all-correct streak", () => {
+    expect(calcStreak([true, true, true, true])).toBe(4);
+  });
+
+  it("returns 0 when last answer is wrong", () => {
+    expect(calcStreak([true, true, false])).toBe(0);
+  });
+
+  it("counts only trailing correct answers", () => {
+    expect(calcStreak([false, true, true, true])).toBe(3);
+  });
+
+  it("handles single correct answer", () => {
+    expect(calcStreak([true])).toBe(1);
+  });
+
+  it("handles single wrong answer", () => {
+    expect(calcStreak([false])).toBe(0);
+  });
+
+  it("handles alternating pattern", () => {
+    expect(calcStreak([true, false, true, false, true])).toBe(1);
+  });
+});
+
+// ─── Pool rebuilding when empty ──────────────────────────────────────────────
+
+function rebuildPoolIfEmpty(pool, QZ, usedSet) {
+  if (pool.length > 0) return pool;
+  // Rebuild: all questions not in usedSet, or all if everything used
+  let newPool = QZ.map((_, i) => i).filter(i => !usedSet.has(i));
+  if (newPool.length === 0) {
+    // All questions used — reset
+    usedSet.clear();
+    newPool = QZ.map((_, i) => i);
+  }
+  // Shuffle
+  for (let i = newPool.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [newPool[i], newPool[j]] = [newPool[j], newPool[i]];
+  }
+  return newPool;
+}
+
+describe("rebuildPoolIfEmpty — pool rebuilding when empty", () => {
+  it("returns existing pool if non-empty", () => {
+    const pool = [1, 2, 3];
+    const result = rebuildPoolIfEmpty(pool, [{ ti: 0 }, { ti: 0 }], new Set());
+    expect(result).toBe(pool);
+  });
+
+  it("rebuilds pool from unused questions when empty", () => {
+    const QZ = [{ ti: 0 }, { ti: 1 }, { ti: 2 }, { ti: 3 }];
+    const usedSet = new Set([0, 1]);
+    const result = rebuildPoolIfEmpty([], QZ, usedSet);
+    expect(result.length).toBe(2);
+    expect(result).toContain(2);
+    expect(result).toContain(3);
+  });
+
+  it("resets usedSet and rebuilds full pool when all questions used", () => {
+    const QZ = [{ ti: 0 }, { ti: 1 }, { ti: 2 }];
+    const usedSet = new Set([0, 1, 2]);
+    const result = rebuildPoolIfEmpty([], QZ, usedSet);
+    expect(result.length).toBe(3);
+    expect(usedSet.size).toBe(0);
+  });
+
+  it("handles empty question bank", () => {
+    const result = rebuildPoolIfEmpty([], [], new Set());
+    expect(result.length).toBe(0);
   });
 });

--- a/tests/expandedDataIntegrity.test.js
+++ b/tests/expandedDataIntegrity.test.js
@@ -378,3 +378,133 @@ describe("questions/image_map.json — integrity", () => {
     });
   });
 });
+
+// ─── OSCE — null entry validation ──────────────────────────────────────────
+
+describe("osce.json — no null entries", () => {
+  it("every entry is a valid object (no nulls)", () => {
+    osce.forEach((s, i) => {
+      expect(s, `OSCE[${i}] should not be null`).not.toBeNull();
+      expect(typeof s, `OSCE[${i}] should be an object`).toBe("object");
+    });
+  });
+
+  it("every station has required fields (t, sc, ck, time)", () => {
+    osce.forEach((s, i) => {
+      expect(typeof s.t, `OSCE[${i}].t`).toBe("string");
+      expect(s.t.length, `OSCE[${i}].t non-empty`).toBeGreaterThan(0);
+      expect(typeof s.sc, `OSCE[${i}].sc`).toBe("string");
+      expect(s.sc.length, `OSCE[${i}].sc non-empty`).toBeGreaterThan(0);
+      expect(Array.isArray(s.ck), `OSCE[${i}].ck is array`).toBe(true);
+      expect(s.ck.length, `OSCE[${i}].ck non-empty`).toBeGreaterThan(0);
+      expect(typeof s.time, `OSCE[${i}].time`).toBe("number");
+      expect(s.time, `OSCE[${i}].time > 0`).toBeGreaterThan(0);
+    });
+  });
+});
+
+// ─── Topics — all 40 have non-empty keyword arrays ─────────────────────────
+
+describe("topics.json — keyword completeness", () => {
+  it("has exactly 40 topics", () => {
+    expect(topics.length).toBe(40);
+  });
+
+  it("all 40 topics have non-empty keyword arrays", () => {
+    topics.forEach((t, i) => {
+      expect(Array.isArray(t), `Topic[${i}] is array`).toBe(true);
+      expect(t.length, `Topic[${i}] has at least one keyword`).toBeGreaterThan(0);
+      t.forEach((kw, j) => {
+        expect(typeof kw, `Topic[${i}][${j}] is string`).toBe("string");
+        expect(kw.trim().length, `Topic[${i}][${j}] is non-empty after trim`).toBeGreaterThan(0);
+      });
+    });
+  });
+});
+
+// ─── Tabs — validates tab structure ────────────────────────────────────────
+
+describe("tabs.json — structure validation", () => {
+  it("has required tab fields (id, ic, l)", () => {
+    tabs.forEach((t, i) => {
+      expect(typeof t.id, `Tab[${i}].id`).toBe("string");
+      expect(typeof t.ic, `Tab[${i}].ic`).toBe("string");
+      expect(typeof t.l, `Tab[${i}].l`).toBe("string");
+      expect(t.id.length).toBeGreaterThan(0);
+      expect(t.ic.length).toBeGreaterThan(0);
+      expect(t.l.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("tab IDs are unique", () => {
+    const ids = tabs.map(t => t.id);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(ids.length);
+  });
+});
+
+// ─── Cross-reference: question topic index maps to valid topic ─────────────
+
+describe("cross-reference — question topics to topics.json", () => {
+  it("every question topic index maps to a valid topic in topics.json", () => {
+    const invalid = [];
+    questions.forEach((q, i) => {
+      if (q.ti < 0 || q.ti >= topics.length) {
+        invalid.push({ index: i, ti: q.ti });
+      }
+    });
+    expect(invalid, `Questions with invalid topic index: ${JSON.stringify(invalid)}`).toEqual([]);
+  });
+
+  it("every topic in topics.json is referenced by at least one question", () => {
+    const usedTopics = new Set(questions.map(q => q.ti));
+    for (let i = 0; i < topics.length; i++) {
+      expect(usedTopics.has(i), `Topic ${i} has no questions`).toBe(true);
+    }
+  });
+});
+
+// ─── Notes coverage: every topic has at least one note ─────────────────────
+
+describe("notes coverage — every topic has a note", () => {
+  it("every topic index 0-39 has a corresponding note entry", () => {
+    const noteIds = new Set(notes.map(n => n.id));
+    for (let i = 0; i < 40; i++) {
+      expect(noteIds.has(i), `Topic ${i} should have a note entry`).toBe(true);
+    }
+  });
+
+  it("notes have non-empty content", () => {
+    notes.forEach((n, i) => {
+      expect(n.notes.length, `Note[${i}] "${n.topic}" should have content`).toBeGreaterThan(0);
+    });
+  });
+});
+
+// ─── Flashcard quality: all have non-empty front and back ──────────────────
+
+describe("flashcard quality — front and back validation", () => {
+  it("all flashcards have non-empty front (f)", () => {
+    flashcards.forEach((fc, i) => {
+      expect(typeof fc.f, `Card[${i}].f is string`).toBe("string");
+      expect(fc.f.trim().length, `Card[${i}].f is non-empty after trim`).toBeGreaterThan(0);
+    });
+  });
+
+  it("all flashcards have non-empty back (b)", () => {
+    flashcards.forEach((fc, i) => {
+      expect(typeof fc.b, `Card[${i}].b is string`).toBe("string");
+      expect(fc.b.trim().length, `Card[${i}].b is non-empty after trim`).toBeGreaterThan(0);
+    });
+  });
+
+  it("no flashcard has whitespace-only content", () => {
+    const bad = [];
+    flashcards.forEach((fc, i) => {
+      if (fc.f.trim().length === 0 || fc.b.trim().length === 0) {
+        bad.push({ index: i, f: fc.f.slice(0, 20), b: fc.b.slice(0, 20) });
+      }
+    });
+    expect(bad, `Flashcards with whitespace-only content: ${JSON.stringify(bad)}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
… to 207 tests

- Add explicit empty array guard in isExamTrap() to prevent Math.max() returning -Infinity when s.wc has no entries (shlav-a-mega.html + test copy)
- Add 3 new isExamTrap edge case tests (empty wc, dominating choice, below threshold)
- Add mock exam pool building tests (5 tests: empty bank, size cap, multi-topic, single-topic, valid indices)
- Add streak calculation edge case tests (8 tests: empty, null, all-correct, trailing, alternating)
- Add pool rebuild tests (4 tests: non-empty passthrough, unused rebuild, full reset, empty bank)
- Add expanded data integrity tests: OSCE null validation, topics keyword completeness, tabs structure, cross-reference question-to-topic, notes coverage, flashcard quality

https://claude.ai/code/session_01RmkkP8tgcPbFqHQu4aH1D4

## Description
<!-- Provide a brief description of the changes -->

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Code refactoring

## Testing
- [ ] I have tested the changes locally in the browser
- [ ] Questions/data files validated
- [ ] I have added tests for new functionality

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Security
- [ ] No secrets or API keys are exposed
- [ ] No new security warnings

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Any additional information that reviewers should know -->