### PR TITLE
audit: sanitize AI innerHTML, remove dead code, update counts, bump v9.18

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 - **Live URL**: https://eiasash.github.io/Geriatrics/
 - **Main file**: `shlav-a-mega.html` (~236 KB, ~3,800 lines, self-contained HTML/CSS/JS)
-- **App version**: v9.10
+- **App version**: v9.18
 - **Data**: JSON files in `data/` directory, loaded lazily at runtime
 - **Deployment**: Push to `main` → GitHub Actions validates → GitHub Pages live in ~60s
 
@@ -39,13 +39,13 @@ Data is loaded at runtime from `data/*.json` files. The service worker (`sw.js`)
 
 ```
 /
-├── shlav-a-mega.html        # Main app (THE file — all HTML/CSS/JS, v9.10)
+├── shlav-a-mega.html        # Main app (THE file — all HTML/CSS/JS, v9.18)
 ├── index.html               # GitHub Pages redirect → shlav-a-mega.html
 ├── sw.js                    # Service worker (offline caching + background sync)
 ├── manifest.json            # PWA manifest
 │
 ├── data/                    # Lazy-loaded JSON data — single source of truth
-│   ├── questions.json       # 1,419 MCQs (primary runtime source)
+│   ├── questions.json       # 1,470 MCQs (primary runtime source)
 │   ├── notes.json           # 40 study topic notes
 │   ├── drugs.json           # 53 Beers/ACB drugs database
 │   ├── flashcards.json      # 159 high-yield flashcards
@@ -86,8 +86,11 @@ Data is loaded at runtime from `data/*.json` files. The service worker (`sw.js`)
 │   └── workflows/ci.yml     # Validation CI — JSON schema, duplicates, version sync, etc.
 │
 ├── tests/
-│   ├── dataIntegrity.test.js  # 30 tests: question schema, duplicates, topic coverage
-│   └── appIntegrity.test.js   # 11 tests: HTML structure, SW sync, security
+│   ├── dataIntegrity.test.js        # 25 tests: question schema, duplicates, topic coverage
+│   ├── expandedDataIntegrity.test.js # 50 tests: deeper data validation
+│   ├── appIntegrity.test.js         # 16 tests: HTML structure, SW sync, security
+│   ├── serviceWorker.test.js        # 25 tests: SW cache config, fetch strategy, version sync
+│   └── appLogic.test.js             # 91 tests: quiz engine, FSRS, sanitization, AI, study plan
 │
 ├── supabase-setup.sql        # Supabase RLS schema
 ├── .mcp.json                 # MCP server config (Supabase)
@@ -98,7 +101,7 @@ Data is loaded at runtime from `data/*.json` files. The service worker (`sw.js`)
 └── hazzard_part*.pdf         # Hazzard's Geriatric Medicine 8e (original PDFs)
 ```
 
-### Data Architecture (v9.10)
+### Data Architecture (v9.18)
 
 All runtime data lives in `data/`. The app and service worker load exclusively from `data/*.json`. Build scripts (`scripts/`) also read/write `data/questions.json` directly. There are no root-level JSON duplicates — `data/` is the single source of truth.
 
@@ -194,15 +197,15 @@ No build step needed. Edit and refresh.
 
 ### Service Worker Versioning
 - `APP_VERSION` in `shlav-a-mega.html` must match the cache version in `sw.js`
-- Currently both at version `9.10` (sw.js cache key: `shlav-a-v9.10`)
+- Currently both at version `9.18` (sw.js cache key: `shlav-a-v9.18`)
 - Update both when making changes to ensure users get cache-busted
 
 ### Testing
 ```bash
-npm test             # Run all tests (vitest, 103 tests)
+npm test             # Run all tests (vitest, 207 tests)
 ```
 
-**103 tests across 4 files** — run `npm test` to see current count.
+**207 tests across 5 files** — run `npm test` to see current count.
 
 **Auto-expand rule:** Every feature, improvement, or bug fix MUST include new or updated tests:
 - New data file or field → schema validation test
@@ -211,14 +214,15 @@ npm test             # Run all tests (vitest, 103 tests)
 - Modified data processing → edge case + boundary tests
 - After adding tests, update the test count in this section
 
-**Test file inventory (4 files, 103 tests):**
+**Test file inventory (5 files, 207 tests):**
 
 | File | Tests | Description |
 |------|-------|-------------|
-| `tests/dataIntegrity.test.js` | 24 | Question schema/duplicates/topic coverage, notes, drugs, flashcards, OSCE, topics, cross-file referential integrity |
-| `tests/expandedDataIntegrity.test.js` | 48 | Deeper validation: answer integrity, option bounds, whitespace, year field, topic distribution balance, notes content length, drugs ACB/Beers cross-checks, flashcard length, OSCE null entries, tabs schema, image map integrity |
-| `tests/appIntegrity.test.js` | 11 | HTML structure (RTL, viewport, PWA), SW version sync, security checks (eval, innerHTML), manifest validation |
-| `tests/serviceWorker.test.js` | 20 | SW cache configuration, URL lists, version sync, fetch strategy routing, file existence checks |
+| `tests/dataIntegrity.test.js` | 25 | Question schema/duplicates/topic coverage, notes, drugs, flashcards, OSCE, topics, cross-file referential integrity |
+| `tests/expandedDataIntegrity.test.js` | 50 | Deeper validation: answer integrity, option bounds, whitespace, year field, topic distribution balance, notes content length, drugs ACB/Beers cross-checks, flashcard length, OSCE null entries, tabs schema, image map integrity |
+| `tests/appIntegrity.test.js` | 16 | HTML structure (RTL, viewport, PWA), SW version sync, security checks (eval, innerHTML), manifest validation |
+| `tests/serviceWorker.test.js` | 25 | SW cache configuration, URL lists, version sync, fetch strategy routing, file existence checks |
+| `tests/appLogic.test.js` | 91 | Quiz engine, FSRS spaced repetition, sanitization, AI integration, study plan logic |
 
 **Test coverage by area:**
 
@@ -261,7 +265,7 @@ Runs on push to `main` and all PRs. Python-based data validation + Vitest test s
 | innerHTML sanitization | Audit for unsanitized innerHTML usage |
 | Topic coverage | >= 5 questions per topic (all 40 topics) |
 
-**Vitest tests** (103 tests, 4 files) validate data schemas, app structure, and service worker integrity. Run `npm test` before pushing.
+**Vitest tests** (207 tests, 5 files) validate data schemas, app structure, and service worker integrity. Run `npm test` before pushing.
 
 ---
 

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -974,7 +974,7 @@ async function runExplainOnCall(qIdx){
   try{
     const txt=await callAI([{role:'user',content:'ANSWER KEY: The correct answer is DEFINITIVELY "'+correct+'".\n\nהסבר בעברית (3-4 משפטים) למה זו התשובה הנכונה. עגן בתשובה הנכונה. שאלה: '+q.q+'\nתשובה נכונה: '+correct}],400,'sonnet');
     _exCache[qIdx]=txt;try{localStorage.setItem('samega_ex',JSON.stringify(_exCache));}catch(e){}
-    box.innerHTML='<div style="font-size:12px;color:#475569;line-height:1.7;direction:rtl;text-align:right;margin-top:8px">'+txt+'</div>';
+    box.innerHTML='<div style="font-size:12px;color:#475569;line-height:1.7;direction:rtl;text-align:right;margin-top:8px">'+sanitize(txt)+'</div>';
     btn.remove();
   }catch(e){btn.textContent='🤖 הסבר AI';btn.disabled=false;}
 }
@@ -3887,10 +3887,6 @@ case'track':
   el.innerHTML=renderTrack();break;
 case'search':el.innerHTML=renderSearch();break;
 case'chat':el.innerHTML=renderChat();break;
-case'law':el.innerHTML=renderEOLTree();break;
-case'labs':el.innerHTML=renderLabOverlay();break;
-case'aging':el.innerHTML=renderAgingSheet();break;
-case'basket':el.innerHTML=renderMedBasket();break;
 case'book':case'syl':tab='lib';el.innerHTML=renderLibrary();break;
 default:tab='quiz';el.innerHTML=renderQuiz();break;
 }
@@ -3931,7 +3927,7 @@ else if(navigator.clipboard)navigator.clipboard.writeText(txt).then(()=>{const b
 }
 function shareApp(){
 const url=location.href;
-if(navigator.share){navigator.share({title:'Shlav A Mega — Geriatrics Board Prep',text:'1434 IMA questions + Hazzard\'s 8e + Harrison\'s 22e + Calculators + Spaced Repetition',url:url}).catch(()=>{});}
+if(navigator.share){navigator.share({title:'Shlav A Mega — Geriatrics Board Prep',text:'1,470 IMA questions + Hazzard\'s 8e + Harrison\'s 22e + Calculators + Spaced Repetition',url:url}).catch(()=>{});}
 else if(navigator.clipboard){navigator.clipboard.writeText(url).then(()=>alert('✅ Link copied!'));}
 }
 
@@ -3952,7 +3948,7 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='9.17';
+const APP_VERSION='9.18';
 {const hv=document.getElementById('headerVer');if(hv)hv.textContent='v'+APP_VERSION;}
 // Prevent accidental navigation during mock exam
 window.addEventListener('beforeunload',function(e){
@@ -4101,7 +4097,7 @@ const aiText=await callAI([{role:'user',content:`Geriatric board exam. A student
 const isWrong=aiText.startsWith('VERDICT: WRONG');
 const aiBox=document.getElementById('aiVerifyResult');
 if(aiBox){
-aiBox.innerHTML=`<div style="font-weight:700;margin-bottom:4px;color:${isWrong?'#dc2626':'#059669'}">${isWrong?'⚠️ AI agrees — answer key may be wrong':'✅ AI: answer key is correct'}</div><div>${aiText.replace(/VERDICT: (CORRECT|WRONG)/,'').trim()}</div>`;
+aiBox.innerHTML=`<div style="font-weight:700;margin-bottom:4px;color:${isWrong?'#dc2626':'#059669'}">${isWrong?'⚠️ AI agrees — answer key may be wrong':'✅ AI: answer key is correct'}</div><div>${sanitize(aiText.replace(/VERDICT: (CORRECT|WRONG)/,'').trim())}</div>`;
 aiBox.style.display='block';aiBox.style.background=isWrong?'#fef2f2':'#f0fdf4';aiBox.style.border=`1px solid ${isWrong?'#fecaca':'#bbf7d0'}`;
 }
 if(st){st.textContent=isWrong?'⚠️ AI confirmed error':'✅ AI: answer key OK';st.style.color=isWrong?'#dc2626':'#059669';}
@@ -4132,16 +4128,16 @@ ov.innerHTML=`<div style="max-width:420px;margin:0 auto;background:#fff;border-r
 </div>
 <div style="font-size:10px;color:#64748b;margin-bottom:16px">Israeli Geriatrics Board Exam Prep (שלב א׳ גריאטריה) · P005-2026 · Hazzard's 8e + Harrison's 22e · Works Offline</div>
 <div style="padding:10px;background:#ecfdf5;border:1px solid #bbf7d0;border-radius:10px;margin-bottom:14px">
-<div style="font-weight:700;font-size:11px;margin-bottom:6px;color:#065f46">🆕 What's New in v9.15</div>
+<div style="font-weight:700;font-size:11px;margin-bottom:6px;color:#065f46">🆕 What's New in v9.18</div>
 <div style="font-size:10px;line-height:1.7;color:#047857">
 <b>✅ AI ללא מפתח</b> — כל פיצ'רי ה-AI עובדים דרך proxy משותף. לא צריך מפתח API אישי.<br>
 <b>🏷️ Header</b> — כותרת מעודכנת עם תווית Geriatrics וגרסה דינמית.<br>
 <b>🔧 Cache Fix</b> — ניקוי cache דינמי — לא צריך עדכון ידני בכל שדרוג גרסה.<br>
-<b>📊 1,434 שאלות</b> — כל השאלות מתויגות לפי 40 נושאים. 159 כרטיסיות, 40 סיכומים, 53 תרופות.<br>
+<b>📊 1,470 שאלות</b> — כל השאלות מתויגות לפי 40 נושאים. 159 כרטיסיות, 40 סיכומים, 53 תרופות.<br>
 <b>🧪 207 בדיקות</b> — CI עם 21 בדיקות אוטומטיות + 207 unit tests שעוברים.
 </div></div>
 ${sec('Quiz Filters','📝','#059669',
-'<b>הכל</b> — All 1434 questions, shuffled<br>'+
+'<b>הכל</b> — All 1,470 questions, shuffled<br>'+
 '<b>2022–2025</b> — Filter by exam year<br>'+
 '<b>🔥 Hard</b> — Questions you got wrong, worst-first<br>'+
 '<b>⏱️ Slow</b> — Questions that took you &gt;60s<br>'+

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v9.17';
+const CACHE='shlav-a-v9.18';
 const HTML_URLS=['shlav-a-mega.html','manifest.json'];
 const JSON_DATA_URLS=['data/questions.json','data/topics.json','data/notes.json','data/drugs.json','data/flashcards.json','harrison_chapters.json','data/tabs.json'];
 const ALL_URLS=[...HTML_URLS,...JSON_DATA_URLS];


### PR DESCRIPTION
- Fix XSS: wrap AI response text in sanitize() for both explain and
  verify flows (lines 977, 4104)
- Remove 4 unreachable switch cases (law, labs, aging, basket) with
  no navigation path
- Update stale question count 1,434 → 1,470 in shareApp, help modal,
  and quiz filter description
- Update What's New section from v9.15 to v9.18
- Version bump APP_VERSION 9.17 → 9.18, SW cache shlav-a-v9.18
- Update CLAUDE.md: version, question count, test inventory (207 tests
  across 5 files including appLogic.test.js)

https://claude.ai/code/session_017zQ1MxGZSesTk39axaihja