### PR TITLE
hotfix: fix JS syntax error from commented-out user_id line

### DIFF
--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -394,7 +394,7 @@ await idbSet('samega',JSON.parse(lsData));
 // Keep user_id for Supabase, clear the rest
 const uid=null/*user_id removed*/;
 localStorage.removeItem(LS);
-if(uid)//localStorage.setItem('user_id',uid);
+// user_id removed — no longer needed
 }else{
 await idbSet('samega',S);
 }
@@ -3948,7 +3948,7 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='9.18';
+const APP_VERSION='9.18.1';
 {const hv=document.getElementById('headerVer');if(hv)hv.textContent='v'+APP_VERSION;}
 // Prevent accidental navigation during mock exam
 window.addEventListener('beforeunload',function(e){

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v9.18';
+const CACHE='shlav-a-v9.18.1';
 const HTML_URLS=['shlav-a-mega.html','manifest.json'];
 const JSON_DATA_URLS=['data/questions.json','data/topics.json','data/notes.json','data/drugs.json','data/flashcards.json','harrison_chapters.json','data/tabs.json'];
 const ALL_URLS=[...HTML_URLS,...JSON_DATA_URLS];


### PR DESCRIPTION
The line `if(uid)//localStorage.setItem('user_id',uid);` was introduced in v9.17 Supabase consolidation. The `//` comment swallows the rest of the line, but the `}else{` on the NEXT line becomes orphaned — causing an Unexpected token '}' parse error that prevents the entire app from loading (blank page).

Fix: replace the broken if/comment with a plain comment. Bump v9.18.1 to bust SW cache.

https://claude.ai/code/session_017zQ1MxGZSesTk39axaihja

## Description
<!-- Provide a brief description of the changes -->

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Code refactoring

## Testing
- [ ] I have tested the changes locally in the browser
- [ ] Questions/data files validated
- [ ] I have added tests for new functionality

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Security
- [ ] No secrets or API keys are exposed
- [ ] No new security warnings

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Any additional information that reviewers should know -->