### PR TITLE
fix: tighten version sync checks and add package.json alignment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,13 +169,14 @@ jobs:
           print(f'OK: All {len(fc)} flashcards valid')
           "
 
-      # ── Service Worker Version Sync ──
-      - name: Check service worker cache version matches app
+      # ── Service Worker + package.json Version Sync ──
+      - name: Check all version sources are aligned
         run: |
           python3 << 'PYEOF'
-          import re, sys
+          import json, re, sys
           html = open('shlav-a-mega.html').read()
           sw = open('sw.js').read()
+          pkg = json.load(open('package.json'))
           m_app = re.search(r"APP_VERSION\s*=\s*['\"]([^'\"]+)['\"]", html)
           m_sw = re.search(r"CACHE\s*=\s*['\"]shlav-a-v([^'\"]+)['\"]", sw)
           if not m_app:
@@ -186,10 +187,14 @@ jobs:
               sys.exit(1)
           app_v = m_app.group(1)
           sw_v = m_sw.group(1)
+          pkg_v = pkg.get('version', '')
           if app_v != sw_v:
               print(f'ERROR: Version mismatch — app={app_v}, sw.js={sw_v}', file=sys.stderr)
               sys.exit(1)
-          print(f'OK: App and service worker versions match (v{app_v})')
+          if not pkg_v.startswith(app_v):
+              print(f'ERROR: package.json version "{pkg_v}" does not start with APP_VERSION "{app_v}"', file=sys.stderr)
+              sys.exit(1)
+          print(f'OK: All versions aligned (v{app_v}) — sw.js={sw_v}, package.json={pkg_v}')
           PYEOF
 
       # ── innerHTML Sanitization Audit ──

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ the full decomposition ledger and safe-next-steps list.
 ├── tests/
 │   ├── dataIntegrity.test.js        # 25 tests: question schema, duplicates, topic coverage
 │   ├── expandedDataIntegrity.test.js # 50 tests: deeper data validation
-│   ├── appIntegrity.test.js         # 16 tests: HTML structure, SW sync, security
+│   ├── appIntegrity.test.js         # 17 tests: HTML structure, SW sync, version alignment, security
 │   ├── serviceWorker.test.js        # 25 tests: SW cache config, fetch strategy, version sync
 │   └── appLogic.test.js             # 91 tests: quiz engine, FSRS, sanitization, AI, study plan
 │
@@ -243,7 +243,7 @@ npm test             # Run all tests (vitest, 273 tests)
 |------|-------|-------------|
 | `tests/dataIntegrity.test.js` | 25 | Question schema/duplicates/topic coverage, notes, drugs, flashcards, OSCE, topics, cross-file referential integrity |
 | `tests/expandedDataIntegrity.test.js` | 50 | Deeper validation: answer integrity, option bounds, whitespace, year field, topic distribution balance, notes content length, drugs ACB/Beers cross-checks, flashcard length, OSCE null entries, tabs schema, image map integrity |
-| `tests/appIntegrity.test.js` | 16 | HTML structure (RTL, viewport, PWA), SW version sync, security checks (eval, innerHTML), manifest validation |
+| `tests/appIntegrity.test.js` | 17 | HTML structure (RTL, viewport, PWA), SW version sync, package.json version alignment, security checks (eval, innerHTML), manifest validation |
 | `tests/serviceWorker.test.js` | 25 | SW cache configuration, URL lists, version sync, fetch strategy routing, file existence checks |
 | `tests/appLogic.test.js` | 91 | Quiz engine, FSRS spaced repetition, sanitization, AI integration, study plan logic |
 
@@ -441,7 +441,7 @@ GitHub Actions runs CI → on pass, GitHub Pages updates within ~60 seconds.
 | Study notes | 40 |
 | Hazzard chapters | 108 (in-app reader) |
 | Harrison chapters | 69 (in-app reader) |
-| Test suite | 408 tests across 9 files (vitest) |
+| Test suite | 409 tests across 9 files (vitest) |
 | CI workflows | 3 (ci.yml, integrity-guard.yml, weekly-audit.yml) |
 | Inline handlers | onclick=160, onchange=26, oninput=6 |
 | App version | v9.48 |

--- a/tests/appIntegrity.test.js
+++ b/tests/appIntegrity.test.js
@@ -87,17 +87,27 @@ describe("service worker version sync", () => {
 
   it("APP_VERSION in HTML aligns with sw.js CACHE", () => {
     const appVersionMatch = html.match(/APP_VERSION\s*=\s*['"]([^'"]+)['"]/);
-    const cacheMatch = swContent.match(/CACHE\s*=\s*['"]([^'"]+)['"]/);
+    const cacheMatch = swContent.match(/CACHE\s*=\s*'shlav-a-v([^']+)'/);
 
     expect(appVersionMatch, "APP_VERSION found").not.toBeNull();
     expect(cacheMatch, "CACHE version found").not.toBeNull();
 
     const appVersion = appVersionMatch[1];
-    const cacheVersion = cacheMatch[1];
-    // Cache format: "shlav-a-v9.14", APP_VERSION: "9.14"
-    // Just verify the major.minor aligns
-    expect(cacheVersion, `CACHE "${cacheVersion}" contains APP_VERSION "${appVersion}"`).toContain(
-      appVersion.split(".").slice(0, 2).join(".")
+    const swVersion = cacheMatch[1];
+    // Exact match: APP_VERSION "9.50" must equal sw.js CACHE suffix "9.50"
+    expect(swVersion, `sw.js CACHE version "${swVersion}" must exactly match APP_VERSION "${appVersion}"`).toBe(
+      appVersion
+    );
+  });
+
+  it("package.json version matches APP_VERSION", () => {
+    const pkg = JSON.parse(readFileSync(resolve(ROOT, "package.json"), "utf-8"));
+    const appVersionMatch = html.match(/APP_VERSION\s*=\s*['"]([^'"]+)['"]/);
+    expect(appVersionMatch, "APP_VERSION found").not.toBeNull();
+    const appVersion = appVersionMatch[1];
+    // package.json uses semver "9.50.0", APP_VERSION is "9.50"
+    expect(pkg.version, `package.json "${pkg.version}" must start with APP_VERSION "${appVersion}"`).toMatch(
+      new RegExp("^" + appVersion.replace(/\./g, "\\."))
     );
   });
 });

--- a/tests/serviceWorker.test.js
+++ b/tests/serviceWorker.test.js
@@ -172,7 +172,8 @@ describe("sw.js — version alignment with app", () => {
 
     const swVersion = cacheMatch[1];
     const appVersion = appVersionMatch[1];
-    expect(swVersion).toContain(appVersion.split(".").slice(0, 2).join("."));
+    // Exact match — no loose .toContain()
+    expect(swVersion, `sw.js CACHE "${swVersion}" must exactly match APP_VERSION "${appVersion}"`).toBe(appVersion);
   });
 
   it("HTML cache cleanup exempts the exact sw.js CACHE key", () => {


### PR DESCRIPTION
## Summary\n\n- **Tighten Vitest version sync tests** — changed loose `.toContain()` to exact `.toBe()` for `sw.js` ↔ `APP_VERSION` checks in both `appIntegrity.test.js` and `serviceWorker.test.js` (prevents false positives like `9.5` matching `9.50`)\n- **Add package.json version validation** — new test ensuring `package.json` version starts with `APP_VERSION` (this was previously unchecked and could silently drift)\n- **Extend CI version sync step** — the Python check now validates all 3 version sources: `shlav-a-mega.html` APP_VERSION, `sw.js` CACHE, and `package.json` version\n- **Update CLAUDE.md** — test counts updated (408 → 409, appIntegrity 16 → 17)\n\n## What was the problem?\n\nThe repo had two version sync gaps:\n1. Vitest tests used `.toContain()` with `major.minor` slicing — could pass with substring false positives\n2. `package.json` version was never validated against `APP_VERSION` in CI or tests\n\n## Source of truth\n\n`APP_VERSION` in `shlav-a-mega.html` is the single source of truth. `sw.js` CACHE and `package.json` version must match it.\n\n## Test plan\n\n- [x] All 409 tests pass (`npx vitest run`)\n- [x] CI version sync step validated locally\n- [ ] CI passes on this PR\n\nhttps://claude.ai/code/session_01YUxxkQsapvYdYqupJdHWB6