### PR TITLE
fix: harden image question pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,11 +27,11 @@ Data is loaded at runtime from `data/*.json` files. The service worker (`sw.js`)
 
 | Layer | Keys / Table | Purpose |
 |-------|-------------|---------|
-| `localStorage` | `samega`, `samega_ex`, `samega_apikey` | User preferences, exam state, API key |
+| `localStorage` | `samega`, `samega_ex`, `samega_apikey`, `shlav_q_images` | User preferences, exam state, API key, user-attached question images |
 | `IndexedDB` | (internal) | Study progress, spaced repetition state |
 | Supabase PostgreSQL | `progress_state` (RLS) | Optional cloud sync across devices |
 
-**Important**: localStorage keys `samega`, `samega_ex`, `samega_apikey` must not be renamed — they are stored in users' browsers.
+**Important**: localStorage keys `samega`, `samega_ex`, `samega_apikey`, `shlav_q_images` must not be renamed — they are stored in users' browsers.
 
 ---
 
@@ -402,7 +402,7 @@ Optional cloud sync via Supabase. The schema is in `supabase-setup.sql`.
 - The file is intentionally a single monolith — do not split it
 - CSS is at the top, JS is at the bottom before `</body>`
 - TOPICS array in JS must stay in sync with the 40-topic list (indices 0–39)
-- All localStorage operations must use the established keys (`samega`, `samega_ex`, `samega_apikey`)
+- All localStorage operations must use the established keys (`samega`, `samega_ex`, `samega_apikey`, `shlav_q_images`)
 - `explainWithAI()` must handle errors gracefully and cache results in localStorage
 - Data loads lazily from `data/*.json` — do not inline large data back into HTML
 - `data/` is the single source of truth for all JSON data — no root-level copies

--- a/questions/image_map.json
+++ b/questions/image_map.json
@@ -1,5 +1,69 @@
 [
   {
+    "exam": "2024_al",
+    "q_num": 4,
+    "fname": "2024_al_q4.png",
+    "fpath": "questions/images/2024_al_q4.png",
+    "w": 343,
+    "h": 379
+  },
+  {
+    "exam": "2024_al",
+    "q_num": 8,
+    "fname": "2024_al_q8.png",
+    "fpath": "questions/images/2024_al_q8.png",
+    "w": 893,
+    "h": 467
+  },
+  {
+    "exam": "2024_al",
+    "q_num": 35,
+    "fname": "2024_al_q35.png",
+    "fpath": "questions/images/2024_al_q35.png",
+    "w": 618,
+    "h": 598
+  },
+  {
+    "exam": "2024_al",
+    "q_num": 69,
+    "fname": "2024_al_q69.png",
+    "fpath": "questions/images/2024_al_q69.png",
+    "w": 879,
+    "h": 508
+  },
+  {
+    "exam": "2024_al2",
+    "q_num": 102,
+    "fname": "2024_al2_q102.png",
+    "fpath": "questions/images/2024_al2_q102.png",
+    "w": 783,
+    "h": 538
+  },
+  {
+    "exam": "2024_al2",
+    "q_num": 110,
+    "fname": "2024_al2_q110.png",
+    "fpath": "questions/images/2024_al2_q110.png",
+    "w": 1037,
+    "h": 574
+  },
+  {
+    "exam": "2024_al2",
+    "q_num": 115,
+    "fname": "2024_al2_q115.png",
+    "fpath": "questions/images/2024_al2_q115.png",
+    "w": 1010,
+    "h": 257
+  },
+  {
+    "exam": "2024_al2",
+    "q_num": 144,
+    "fname": "2024_al2_q144.png",
+    "fpath": "questions/images/2024_al2_q144.png",
+    "w": 1378,
+    "h": 720
+  },
+  {
     "exam": "jun2022",
     "q_num": 4,
     "fname": "jun2022_q4.png",
@@ -73,6 +137,22 @@
   },
   {
     "exam": "jun2025",
+    "q_num": 20,
+    "fname": "jun2025_q20.png",
+    "fpath": "questions/images/jun2025_q20.png",
+    "w": 873,
+    "h": 920
+  },
+  {
+    "exam": "jun2025",
+    "q_num": 45,
+    "fname": "jun2025_q45.png",
+    "fpath": "questions/images/jun2025_q45.png",
+    "w": 420,
+    "h": 430
+  },
+  {
+    "exam": "jun2025",
     "q_num": 47,
     "fname": "jun2025_q47.png",
     "fpath": "questions/images/jun2025_q47.png",
@@ -110,5 +190,45 @@
     "fpath": "questions/images/jun2025_q136.png",
     "w": 1500,
     "h": 1000
+  },
+  {
+    "exam": "sep2024",
+    "q_num": 8,
+    "fname": "sep2024_q8.png",
+    "fpath": "questions/images/sep2024_q8.png",
+    "w": 1000,
+    "h": 760
+  },
+  {
+    "exam": "sep2024",
+    "q_num": 31,
+    "fname": "sep2024_q31.png",
+    "fpath": "questions/images/sep2024_q31.png",
+    "w": 800,
+    "h": 532
+  },
+  {
+    "exam": "sep2024",
+    "q_num": 53,
+    "fname": "sep2024_q53.png",
+    "fpath": "questions/images/sep2024_q53.png",
+    "w": 305,
+    "h": 224
+  },
+  {
+    "exam": "sep2024",
+    "q_num": 69,
+    "fname": "sep2024_q69.png",
+    "fpath": "questions/images/sep2024_q69.png",
+    "w": 412,
+    "h": 574
+  },
+  {
+    "exam": "sep2024",
+    "q_num": 93,
+    "fname": "sep2024_q93.png",
+    "fpath": "questions/images/sep2024_q93.png",
+    "w": 568,
+    "h": 567
   }
 ]

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -117,6 +117,8 @@ body.dark .streak-badge{background:#451a03;border-color:rgb(var(--yellow-fg))}
 .share-btn{font-size:13px;padding:2px 6px;opacity:.5;cursor:pointer;border:none;background:none}
 .share-btn:hover{opacity:1}
 .empty{text-align:center;padding:32px 16px;color:rgb(var(--fg3));font-size:12px;line-height:1.7}
+.img-overlay{position:fixed;inset:0;z-index:9999;background:rgba(0,0,0,.85);display:flex;align-items:center;justify-content:center;cursor:pointer;-webkit-backdrop-filter:blur(4px);backdrop-filter:blur(4px)}
+.img-overlay img{max-width:95vw;max-height:90vh;border-radius:8px;box-shadow:0 4px 24px rgba(0,0,0,.5);object-fit:contain}
 
 body.dark{background:#0f172a;color:#e2e8f0;
 --bg:15 23 42;--bg2:30 41 59;--bg3:30 41 59;--fg:226 232 240;--fg2:148 163 184;--fg3:100 116 139;
@@ -576,7 +578,7 @@ function speakQuestion(){
 if(!window.speechSynthesis)return;
 if(isSpeaking){window.speechSynthesis.cancel();isSpeaking=false;render();return;}
 const q=QZ[pool[qi]];if(!q)return;
-let text=q.q+(q.img?' [Image: '+q.img+']':'')+'. ';q.o.forEach((o,i)=>{text+=String.fromCharCode(1488+i)+'. '+o+'. ';});
+let text=q.q+(q.img?' [ראה תמונה מצורפת]':'')+'. ';q.o.forEach((o,i)=>{text+=String.fromCharCode(1488+i)+'. '+o+'. ';});
 const u=new SpeechSynthesisUtterance(text);
 u.lang='he-IL';u.rate=0.9;
 u.onend=()=>{isSpeaking=false;render();};

--- a/sw.js
+++ b/sw.js
@@ -3,19 +3,40 @@ const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js'];
 const JSON_DATA_URLS=['data/questions.json','data/topics.json','data/notes.json','data/drugs.json','data/flashcards.json','harrison_chapters.json','data/hazzard_chapters.json','data/tabs.json'];
 const ALL_URLS=[...HTML_URLS,...JSON_DATA_URLS];
 
+// Supabase question-images: cache-first (images are immutable once uploaded)
+const SUPA_IMG_PATTERN=/supabase\.co\/storage\/v1\/object\/public\/question-images\//;
+const IMG_CACHE='shlav-img-v1';
+
 self.addEventListener('install',e=>e.waitUntil(caches.open(CACHE).then(c=>c.addAll(ALL_URLS)).then(()=>self.skipWaiting())));
-self.addEventListener('activate',e=>e.waitUntil(caches.keys().then(ks=>Promise.all(ks.filter(k=>k!==CACHE).map(k=>caches.delete(k)))).then(()=>self.clients.claim())));
+self.addEventListener('activate',e=>e.waitUntil(caches.keys().then(ks=>Promise.all(ks.filter(k=>k!==CACHE&&k!==IMG_CACHE).map(k=>caches.delete(k)))).then(()=>self.clients.claim())));
 
 // Cache strategy dispatcher
 function shouldUseCacheFirst(url){
   return JSON_DATA_URLS.some(pattern=>url.endsWith(pattern));
 }
 
-// Fetch strategies: navigate→HTML fallback, data→network-first, assets→cache-first
+// Fetch strategies: navigate→HTML fallback, data→network-first, assets→cache-first, Supabase images→cache-first
 self.addEventListener('fetch',e=>{
   // Skip non-GET (Supabase POSTs, Claude proxy, etc)
   if(e.request.method!=='GET')return;
-  // Skip cross-origin requests
+
+  // Supabase question images: cache-first (cross-origin, immutable)
+  if(SUPA_IMG_PATTERN.test(e.request.url)){
+    e.respondWith(
+      caches.open(IMG_CACHE).then(cache=>
+        cache.match(e.request).then(r=>{
+          if(r)return r;
+          return fetch(e.request).then(res=>{
+            if(res.ok)cache.put(e.request,res.clone());
+            return res;
+          });
+        })
+      )
+    );
+    return;
+  }
+
+  // Skip other cross-origin requests
   if(!e.request.url.startsWith(self.location.origin))return;
 
   const url=new URL(e.request.url).pathname;

--- a/tests/expandedDataIntegrity.test.js
+++ b/tests/expandedDataIntegrity.test.js
@@ -348,6 +348,116 @@ describe("questions/image_map.json — integrity", () => {
       }
     });
   });
+
+  it("every physical image file on disk is tracked in image_map.json", () => {
+    if (!imageMap) return;
+    const imgDir = resolve(ROOT, "questions/images");
+    if (!existsSync(imgDir)) return;
+    const { readdirSync } = require("fs");
+    const diskFiles = readdirSync(imgDir).filter(f => /\.(png|jpe?g|gif|webp)$/i.test(f));
+    const mapFiles = new Set(imageMap.map(e => e.fname));
+    const untracked = diskFiles.filter(f => !mapFiles.has(f));
+    expect(untracked, `Image files on disk but missing from image_map.json: ${JSON.stringify(untracked)}`).toEqual([]);
+  });
+});
+
+// ─── Question image (img field) validation ─────────────────────────────────
+
+describe("questions.json — image field (img) validation", () => {
+  const SUPA_IMG_PREFIX = "https://krmlzwwelqvlfslwltol.supabase.co/storage/v1/object/public/question-images/";
+
+  it("img field, when present, is a valid Supabase URL string", () => {
+    const invalid = [];
+    questions.forEach((q, i) => {
+      if (q.img === undefined || q.img === null) return;
+      if (typeof q.img !== "string" || !q.img.startsWith("https://")) {
+        invalid.push({ index: i, img: String(q.img).slice(0, 60) });
+      }
+    });
+    expect(invalid, `Questions with non-URL img field: ${JSON.stringify(invalid)}`).toEqual([]);
+  });
+
+  it("all img URLs use the expected Supabase bucket prefix", () => {
+    const wrong = [];
+    questions.forEach((q, i) => {
+      if (!q.img) return;
+      if (!q.img.startsWith(SUPA_IMG_PREFIX)) {
+        wrong.push({ index: i, img: q.img.slice(0, 80) });
+      }
+    });
+    expect(wrong, `Image URLs not matching Supabase bucket: ${JSON.stringify(wrong)}`).toEqual([]);
+  });
+
+  it("img URLs have a valid image file extension", () => {
+    const bad = [];
+    questions.forEach((q, i) => {
+      if (!q.img) return;
+      if (!/\.(png|jpe?g|gif|webp|svg)(\?.*)?$/i.test(q.img)) {
+        bad.push({ index: i, img: q.img.slice(-30) });
+      }
+    });
+    expect(bad, `Image URLs without valid extension: ${JSON.stringify(bad)}`).toEqual([]);
+  });
+
+  it("img URLs contain no whitespace or control characters", () => {
+    const bad = [];
+    questions.forEach((q, i) => {
+      if (!q.img) return;
+      if (/[\s\x00-\x1f]/.test(q.img)) {
+        bad.push({ index: i, img: q.img.slice(0, 60) });
+      }
+    });
+    expect(bad, `Image URLs with whitespace/control chars: ${JSON.stringify(bad)}`).toEqual([]);
+  });
+
+  it("no duplicate img URLs across different questions", () => {
+    const seen = new Map();
+    const dupes = [];
+    questions.forEach((q, i) => {
+      if (!q.img) return;
+      if (seen.has(q.img)) {
+        dupes.push({ indices: [seen.get(q.img), i], img: q.img.split("/").pop() });
+      } else {
+        seen.set(q.img, i);
+      }
+    });
+    // Some duplicates may be intentional (same image for variant questions), so warn at threshold
+    expect(dupes.length, `${dupes.length} duplicate img URLs found`).toBeLessThan(questions.length * 0.02);
+  });
+
+  it("oi field, when present, is an array matching options length", () => {
+    const bad = [];
+    questions.forEach((q, i) => {
+      if (!q.oi) return;
+      if (!Array.isArray(q.oi)) {
+        bad.push({ index: i, reason: "oi is not an array" });
+      } else if (q.oi.length !== q.o.length) {
+        bad.push({ index: i, oiLen: q.oi.length, oLen: q.o.length });
+      }
+    });
+    expect(bad, `Questions with malformed oi field: ${JSON.stringify(bad)}`).toEqual([]);
+  });
+});
+
+// ─── Image file size checks ────────────────────────────────────────────────
+
+describe("questions/images — file size limits", () => {
+  it("no image file exceeds 3 MB", () => {
+    const imgDir = resolve(ROOT, "questions/images");
+    if (!existsSync(imgDir)) return;
+    const { readdirSync, statSync } = require("fs");
+    const MAX_BYTES = 3 * 1024 * 1024;
+    const oversized = [];
+    readdirSync(imgDir)
+      .filter(f => /\.(png|jpe?g|gif|webp)$/i.test(f))
+      .forEach(f => {
+        const size = statSync(resolve(imgDir, f)).size;
+        if (size > MAX_BYTES) {
+          oversized.push({ file: f, sizeMB: (size / 1024 / 1024).toFixed(1) });
+        }
+      });
+    expect(oversized, `Images exceeding 3 MB: ${JSON.stringify(oversized)}`).toEqual([]);
+  });
 });
 
 // ─── OSCE — null entry validation ──────────────────────────────────────────

--- a/tests/serviceWorker.test.js
+++ b/tests/serviceWorker.test.js
@@ -162,6 +162,26 @@ describe("sw.js — push notifications", () => {
   });
 });
 
+describe("sw.js — Supabase image caching", () => {
+  it("defines SUPA_IMG_PATTERN for question images", () => {
+    expect(swContent).toMatch(/SUPA_IMG_PATTERN/);
+    expect(swContent).toContain("question-images");
+  });
+
+  it("defines a separate IMG_CACHE key", () => {
+    expect(swContent).toMatch(/IMG_CACHE\s*=\s*'shlav-img-v\d+'/);
+  });
+
+  it("uses cache-first strategy for Supabase image URLs", () => {
+    expect(swContent).toMatch(/SUPA_IMG_PATTERN\.test\(e\.request\.url\)/);
+    expect(swContent).toMatch(/caches\.open\(IMG_CACHE\)/);
+  });
+
+  it("preserves IMG_CACHE during activate cleanup", () => {
+    expect(swContent).toMatch(/k!==IMG_CACHE/);
+  });
+});
+
 describe("sw.js — version alignment with app", () => {
   it("sw.js CACHE version matches APP_VERSION in HTML", () => {
     const cacheMatch = swContent.match(/CACHE\s*=\s*'shlav-a-v([\d.]+)'/);


### PR DESCRIPTION
## Summary

- **Add `.img-overlay` CSS** — the zoom overlay (`viewImg`) was completely unstyled; now has fixed fullscreen backdrop with blur, centered image, and proper z-index
- **Cache Supabase images in service worker** — new `IMG_CACHE` with cache-first strategy for `question-images` bucket URLs. Images were previously fetched fresh every visit with zero offline support
- **Fix `speakQuestion` TTS** — says "ראה תמונה מצורפת" instead of reading the raw Supabase URL aloud
- **Add 12 new tests** — `img` URL validation (format, prefix, extension, whitespace, duplicates), `oi` field shape, image file size limit (3 MB), image_map disk tracking, SW image cache config
- **Align `image_map.json`** — expanded from 14 to 29 entries to match all physical files on disk
- **Document `shlav_q_images` localStorage key** in CLAUDE.md storage table

## Test plan

- [x] All 421 tests pass (`npx vitest run`)
- [x] `sw.js` passes `node --check`
- [ ] Verify image zoom overlay renders with dark backdrop on click
- [ ] Verify images load from SW cache on second visit (DevTools → Application → Cache Storage → `shlav-img-v1`)
- [ ] Verify TTS reads "ראה תמונה מצורפת" for image questions instead of URL

https://claude.ai/code/session_01TyCHUY91LhoUQQvAJeeBd6