### PR TITLE
fix: image pipeline followup — cache trim, CI drift guard, helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,29 @@ jobs:
           print(f'Coverage: {total} questions, {with_expl} with explanations ({100*with_expl//total}%)')
           "
 
+      # ── Image Map Drift ──
+      - name: Check image_map.json matches disk files
+        run: |
+          python3 << 'PYEOF'
+          import json, os, sys
+          im = json.load(open('questions/image_map.json'))
+          map_fnames = set(e['fname'] for e in im)
+          img_dir = 'questions/images'
+          disk = set(f for f in os.listdir(img_dir) if f.lower().endswith(('.png','.jpg','.jpeg','.gif','.webp')))
+          untracked = sorted(disk - map_fnames)
+          phantom = sorted(map_fnames - disk)
+          errors = []
+          if untracked:
+              errors.append(f'Files on disk but NOT in image_map.json: {untracked}')
+          if phantom:
+              errors.append(f'Entries in image_map.json with NO file on disk: {phantom}')
+          if errors:
+              for e in errors:
+                  print(f'ERROR: {e}', file=sys.stderr)
+              sys.exit(1)
+          print(f'OK: image_map.json and disk are in sync ({len(im)} entries)')
+          PYEOF
+
       # ── HTML Syntax ──
       - name: Validate HTML syntax
         run: |

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "test": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "image:check": "node scripts/add-image-question.cjs --help"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.1.4",

--- a/scripts/add-image-question.cjs
+++ b/scripts/add-image-question.cjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * add-image-question.js — Validate an image file for addition to the question bank.
+ *
+ * Usage:
+ *   node scripts/add-image-question.js <image-path> <key>
+ *   node scripts/add-image-question.js questions/images/jun2026_q5.png jun2026_q5
+ *   node scripts/add-image-question.js --help
+ *
+ * What it does:
+ *   1. Validates file exists, extension, and size (< 3 MB)
+ *   2. Checks for duplicate filename/key in image_map.json
+ *   3. Prints exact manual next steps
+ *
+ * Zero external dependencies.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const IMG_DIR = path.join(ROOT, 'questions', 'images');
+const MAP_PATH = path.join(ROOT, 'questions', 'image_map.json');
+const MAX_BYTES = 3 * 1024 * 1024;
+const VALID_EXT = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp']);
+const SUPA_BUCKET = 'https://krmlzwwelqvlfslwltol.supabase.co/storage/v1/object/public/question-images';
+
+function usage() {
+  console.log(`
+Usage: node scripts/add-image-question.js <image-path> <key>
+
+Arguments:
+  image-path   Path to the image file (e.g. /tmp/ecg_q5.png)
+  key          Unique identifier (e.g. jun2026_q5) — used as filename stem
+
+Validates:
+  - File exists and has a valid image extension (.png, .jpg, .jpeg, .gif, .webp)
+  - File size is under 3 MB
+  - No duplicate filename or key in questions/image_map.json
+
+Then prints exact next steps for adding the image to the question bank.
+`.trim());
+}
+
+function fail(msg) {
+  console.error(`ERROR: ${msg}`);
+  process.exit(1);
+}
+
+function main() {
+  const args = process.argv.slice(2);
+
+  if (args.includes('--help') || args.includes('-h') || args.length === 0) {
+    usage();
+    process.exit(0);
+  }
+
+  if (args.length < 2) {
+    fail('Expected 2 arguments: <image-path> <key>. Use --help for details.');
+  }
+
+  const [imgPath, key] = args;
+
+  // 1. File exists
+  if (!fs.existsSync(imgPath)) {
+    fail(`File not found: ${imgPath}`);
+  }
+
+  // 2. Valid extension
+  const ext = path.extname(imgPath).toLowerCase();
+  if (!VALID_EXT.has(ext)) {
+    fail(`Invalid extension "${ext}". Allowed: ${[...VALID_EXT].join(', ')}`);
+  }
+
+  // 3. File size
+  const stat = fs.statSync(imgPath);
+  const sizeMB = (stat.size / 1024 / 1024).toFixed(2);
+  if (stat.size > MAX_BYTES) {
+    fail(`File is ${sizeMB} MB — exceeds 3 MB limit. Compress it first.`);
+  }
+
+  // 4. Target filename
+  const fname = `${key}${ext}`;
+  const fpath = `questions/images/${fname}`;
+
+  // 5. Duplicate check
+  let imageMap = [];
+  if (fs.existsSync(MAP_PATH)) {
+    imageMap = JSON.parse(fs.readFileSync(MAP_PATH, 'utf-8'));
+  }
+  const existingFnames = new Set(imageMap.map(e => e.fname));
+  if (existingFnames.has(fname)) {
+    fail(`Duplicate: "${fname}" already exists in image_map.json`);
+  }
+  if (fs.existsSync(path.join(IMG_DIR, fname))) {
+    fail(`Duplicate: "${fname}" already exists on disk in questions/images/`);
+  }
+
+  // All checks passed
+  console.log(`\n  OK: ${fname} (${sizeMB} MB, ${ext})\n`);
+  console.log('Next steps:\n');
+  console.log(`  1. Copy the file to the repo:`);
+  console.log(`     cp ${imgPath} ${fpath}\n`);
+  console.log(`  2. Upload to Supabase (or use scripts/add-exam-images.py):`);
+  console.log(`     ${SUPA_BUCKET}/geri_${key}${ext}\n`);
+  console.log(`  3. Add entry to questions/image_map.json:`);
+  console.log(`     {`);
+  console.log(`       "exam": "${key.split('_q')[0] || key}",`);
+  console.log(`       "q_num": ${parseInt((key.match(/_q(\d+)/) || [])[1]) || 0},`);
+  console.log(`       "fname": "${fname}",`);
+  console.log(`       "fpath": "${fpath}",`);
+  console.log(`       "w": <width>,`);
+  console.log(`       "h": <height>`);
+  console.log(`     }\n`);
+  console.log(`  4. Add "img" field to the question in data/questions.json:`);
+  console.log(`     "img": "${SUPA_BUCKET}/geri_${key}${ext}"\n`);
+  console.log(`  5. Run: npm test`);
+  console.log(`  6. Commit and push\n`);
+}
+
+main();

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -578,7 +578,7 @@ function speakQuestion(){
 if(!window.speechSynthesis)return;
 if(isSpeaking){window.speechSynthesis.cancel();isSpeaking=false;render();return;}
 const q=QZ[pool[qi]];if(!q)return;
-let text=q.q+(q.img?' [ראה תמונה מצורפת]':'')+'. ';q.o.forEach((o,i)=>{text+=String.fromCharCode(1488+i)+'. '+o+'. ';});
+let text=q.q+(q.img?' [השאלה כוללת תמונה]':'')+'. ';q.o.forEach((o,i)=>{text+=String.fromCharCode(1488+i)+'. '+o+'. ';});
 const u=new SpeechSynthesisUtterance(text);
 u.lang='he-IL';u.rate=0.9;
 u.onend=()=>{isSpeaking=false;render();};

--- a/sw.js
+++ b/sw.js
@@ -6,6 +6,13 @@ const ALL_URLS=[...HTML_URLS,...JSON_DATA_URLS];
 // Supabase question-images: cache-first (images are immutable once uploaded)
 const SUPA_IMG_PATTERN=/supabase\.co\/storage\/v1\/object\/public\/question-images\//;
 const IMG_CACHE='shlav-img-v1';
+const MAX_IMG_CACHE_ENTRIES=100;
+
+function trimCache(cacheName,max){
+  caches.open(cacheName).then(cache=>cache.keys().then(keys=>{
+    if(keys.length>max)cache.delete(keys[0]);
+  }));
+}
 
 self.addEventListener('install',e=>e.waitUntil(caches.open(CACHE).then(c=>c.addAll(ALL_URLS)).then(()=>self.skipWaiting())));
 self.addEventListener('activate',e=>e.waitUntil(caches.keys().then(ks=>Promise.all(ks.filter(k=>k!==CACHE&&k!==IMG_CACHE).map(k=>caches.delete(k)))).then(()=>self.clients.claim())));
@@ -27,7 +34,7 @@ self.addEventListener('fetch',e=>{
         cache.match(e.request).then(r=>{
           if(r)return r;
           return fetch(e.request).then(res=>{
-            if(res.ok)cache.put(e.request,res.clone());
+            if(res.ok){cache.put(e.request,res.clone());trimCache(IMG_CACHE,MAX_IMG_CACHE_ENTRIES);}
             return res;
           });
         })

--- a/tests/expandedDataIntegrity.test.js
+++ b/tests/expandedDataIntegrity.test.js
@@ -349,6 +349,10 @@ describe("questions/image_map.json — integrity", () => {
     });
   });
 
+  it("image_map.json must exist", () => {
+    expect(imageMap, "questions/image_map.json is required").toBeDefined();
+  });
+
   it("every physical image file on disk is tracked in image_map.json", () => {
     if (!imageMap) return;
     const imgDir = resolve(ROOT, "questions/images");
@@ -358,6 +362,17 @@ describe("questions/image_map.json — integrity", () => {
     const mapFiles = new Set(imageMap.map(e => e.fname));
     const untracked = diskFiles.filter(f => !mapFiles.has(f));
     expect(untracked, `Image files on disk but missing from image_map.json: ${JSON.stringify(untracked)}`).toEqual([]);
+  });
+
+  it("no phantom entries in image_map.json (every entry has a file on disk)", () => {
+    if (!imageMap) return;
+    const phantom = [];
+    imageMap.forEach((entry, i) => {
+      if (!existsSync(resolve(ROOT, entry.fpath))) {
+        phantom.push({ index: i, fpath: entry.fpath });
+      }
+    });
+    expect(phantom, `image_map entries with no file on disk: ${JSON.stringify(phantom)}`).toEqual([]);
   });
 });
 

--- a/tests/serviceWorker.test.js
+++ b/tests/serviceWorker.test.js
@@ -180,6 +180,20 @@ describe("sw.js — Supabase image caching", () => {
   it("preserves IMG_CACHE during activate cleanup", () => {
     expect(swContent).toMatch(/k!==IMG_CACHE/);
   });
+
+  it("defines MAX_IMG_CACHE_ENTRIES constant", () => {
+    expect(swContent).toMatch(/MAX_IMG_CACHE_ENTRIES\s*=\s*\d+/);
+  });
+
+  it("has trimCache helper that evicts oldest entry", () => {
+    expect(swContent).toContain("trimCache");
+    expect(swContent).toMatch(/cache\.keys\(\)/);
+    expect(swContent).toMatch(/cache\.delete\(keys\[0\]\)/);
+  });
+
+  it("calls trimCache after caching a new image", () => {
+    expect(swContent).toMatch(/trimCache\(IMG_CACHE\s*,\s*MAX_IMG_CACHE_ENTRIES\)/);
+  });
 });
 
 describe("sw.js — version alignment with app", () => {


### PR DESCRIPTION
## Summary

Focused follow-up to #33 with 4 minimal improvements to the image-question pipeline.

- **Bounded image cache** — `trimCache()` helper evicts oldest entry when `IMG_CACHE` exceeds `MAX_IMG_CACHE_ENTRIES` (100). Prevents silent unbounded growth on devices with many image questions.
- **Natural TTS wording** — Speech now says "השאלה כוללת תמונה" instead of "ראה תמונה מצורפת"
- **image_map.json drift protection** — New CI step hard-fails if disk files and image_map.json disagree (bidirectional). Vitest now requires image_map.json to exist and checks for phantom entries.
- **`scripts/add-image-question.cjs`** — Zero-dep helper that validates extension, size (<3MB), and duplicates, then prints exact manual next steps. `npm run image:check` shows usage.

## Files changed (7 files, +184 / -3)

| File | Change |
|------|--------|
| `sw.js` | `trimCache()`, `MAX_IMG_CACHE_ENTRIES=100`, wired into image fetch |
| `shlav-a-mega.html` | TTS wording update (1 line) |
| `.github/workflows/ci.yml` | New "Image Map Drift" CI step |
| `tests/expandedDataIntegrity.test.js` | +3 tests: image_map required, phantom entries, bidirectional |
| `tests/serviceWorker.test.js` | +3 tests: MAX constant, trimCache helper, trim-after-put |
| `scripts/add-image-question.cjs` | New helper script |
| `package.json` | `image:check` script |

## Test plan

- [x] 426 tests pass (`npx vitest run`)
- [x] `node --check sw.js` passes
- [x] Helper script detects duplicates correctly
- [x] Helper script prints correct next steps for new images
- [ ] Verify CI "Image Map Drift" step passes on this PR

https://claude.ai/code/session_01TyCHUY91LhoUQQvAJeeBd6