### PR TITLE
fix: update-banner dismiss button broken by block-scoped DISMISS_KEY

### DIFF
--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -4890,10 +4890,11 @@ b.style.cssText='position:fixed;top:0;left:0;right:0;z-index:99999;background:li
 b.innerHTML=`<div><b>🆕 עדכון זמין!</b> גרסה חדשה מוכנה</div>
 <div style="display:flex;gap:6px;flex-shrink:0">
 <button onclick="applyUpdate()" style="background:rgb(var(--card-bg));color:#0D7377;border:none;border-radius:8px;padding:6px 14px;font-size:11px;font-weight:700;cursor:pointer">🔄 עדכן עכשיו</button>
-<button onclick="localStorage.setItem(DISMISS_KEY,'1');this.closest('#update-banner').remove()" style="background:rgba(255,255,255,.2);color:#fff;border:none;border-radius:8px;padding:6px 10px;font-size:11px;cursor:pointer">✕</button>
+<button onclick="dismissUpdateBanner()" style="background:rgba(255,255,255,.2);color:#fff;border:none;border-radius:8px;padding:6px 10px;font-size:11px;cursor:pointer">✕</button>
 </div>`;
 document.body.prepend(b);
 }
+function dismissUpdateBanner(){localStorage.setItem(DISMISS_KEY,'1');var b=document.getElementById('update-banner');if(b)b.remove();}
 function applyUpdate(){
 localStorage.removeItem(DISMISS_KEY);
 if(navigator.serviceWorker&&navigator.serviceWorker.controller){


### PR DESCRIPTION
## Summary

- **Fix**: The update-banner dismiss button (`✕`) was non-functional — clicking it threw `ReferenceError: DISMISS_KEY is not defined`, so the banner could never be suppressed and reappeared on every page load.
- **Root cause**: `DISMISS_KEY` is a `const` declared inside the `if('serviceWorker' in navigator)` block (block-scoped). The inline `onclick` handler in `innerHTML` is compiled as a standalone function that cannot access block-scoped variables — only the global/lexical environment.
- **Fix**: Extract dismiss logic into a named `dismissUpdateBanner()` function inside the same block, giving it closure access to `DISMISS_KEY`. Function declarations in blocks are hoisted to global scope in sloppy mode (Annex B), making them callable from inline handlers — exactly like `applyUpdate()` already works.

## Diff scope

- 1 file changed: `shlav-a-mega.html`
- 2 insertions, 1 deletion
- No behavior change except the dismiss button now works correctly

## Test plan

- [x] JS brace balance verified (2116/2116)
- [x] All 426 tests pass (`npx vitest run`)
- [ ] Manual: open app → trigger SW update → verify banner appears → click ✕ → verify banner is removed and does not reappear on reload
- [ ] Manual: verify `localStorage` contains `shlav_update_dismissed_9.50` after dismissal
- [ ] Manual: click "עדכן עכשיו" → verify dismiss key is cleared and page reloads

https://claude.ai/code/session_01Cn5yPkr7Pt5ajhVcFbs9XD