### PR TITLE
refactor: extract SW update logic into src/sw-update.js

### DIFF
--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -318,6 +318,7 @@ upd();setInterval(upd,30000);
 <div class="tabs" id="tb" role="tablist" aria-label="Navigation tabs"></div>
 
 <script src="shared/fsrs.js"></script>
+<script src="src/sw-update.js"></script>
 <script>
 let QZ=[];
 
@@ -4859,14 +4860,8 @@ ${sec('Progress Tracking','📊','#f59e0b',
 document.body.appendChild(ov);
 }
 
-// PWA + Background Sync + Daily Notification
-if('serviceWorker' in navigator){
-// ===== UPDATE BANNER =====
 // ===== SYLLABUS CONFIG =====
 const SYLLABUS_VERSION='P005-2026';
-
-// ===== UPDATE DISMISSAL KEY =====
-const DISMISS_KEY='shlav_update_dismissed_'+APP_VERSION;
 
 // ===== WRONG ANSWER REPORTS → SUPABASE =====
 async function saveAnswerReport(qIdx, userReason, aiVerdict){
@@ -4880,45 +4875,9 @@ body:JSON.stringify({app:'geriatrics',question_idx:qIdx,question_text:(q.q||'').
 }catch(e){console.warn('Report save failed:',e.message);}
 }
 
-function showUpdateBanner(){
-if(localStorage.getItem(DISMISS_KEY))return;
-const existing=document.getElementById('update-banner');
-if(existing)return;
-const b=document.createElement('div');
-b.id='update-banner';
-b.style.cssText='position:fixed;top:0;left:0;right:0;z-index:99999;background:linear-gradient(135deg,#0D7377,#14919B);color:#fff;padding:12px 16px;font-size:12px;display:flex;align-items:center;gap:10px;justify-content:space-between;box-shadow:0 2px 12px rgba(0,0,0,.3)';
-b.innerHTML=`<div><b>🆕 עדכון זמין!</b> גרסה חדשה מוכנה</div>
-<div style="display:flex;gap:6px;flex-shrink:0">
-<button onclick="applyUpdate()" style="background:rgb(var(--card-bg));color:#0D7377;border:none;border-radius:8px;padding:6px 14px;font-size:11px;font-weight:700;cursor:pointer">🔄 עדכן עכשיו</button>
-<button onclick="dismissUpdateBanner()" style="background:rgba(255,255,255,.2);color:#fff;border:none;border-radius:8px;padding:6px 10px;font-size:11px;cursor:pointer">✕</button>
-</div>`;
-document.body.prepend(b);
-}
-function dismissUpdateBanner(){localStorage.setItem(DISMISS_KEY,'1');var b=document.getElementById('update-banner');if(b)b.remove();}
-function applyUpdate(){
-localStorage.removeItem(DISMISS_KEY);
-if(navigator.serviceWorker&&navigator.serviceWorker.controller){
-navigator.serviceWorker.getRegistrations().then(regs=>{
-regs.forEach(r=>{if(r.waiting)r.waiting.postMessage({type:'SKIP_WAITING'});});
-});
-}
-caches.keys().then(ks=>{ks.forEach(k=>caches.delete(k));});
-setTimeout(()=>window.location.reload(true),500);
-}
-
-// Clear old caches
-caches.keys().then(ks=>{
-const old=ks.filter(k=>k.startsWith('shlav-a-')&&k!=='shlav-a-v'+APP_VERSION);
-old.forEach(k=>{caches.delete(k);console.log('Deleted old cache:',k);});
-});
-navigator.serviceWorker.register('sw.js').then(reg=>{
-reg.update();
-// Detect waiting worker = update available
-if(reg.waiting){showUpdateBanner();}
-reg.addEventListener('updatefound',()=>{
-const nw=reg.installing;
-if(nw){nw.addEventListener('statechange',()=>{if(nw.state==='installed'&&navigator.serviceWorker.controller){showUpdateBanner();}});}
-});
+// PWA + Background Sync + Daily Notification (update logic in src/sw-update.js)
+initSWUpdate(APP_VERSION).then(function(reg){
+if(!reg)return;
 // Schedule daily notification at 07:00
 function scheduleDailyNotification(){
 const now=new Date();
@@ -4940,8 +4899,6 @@ Notification.requestPermission();
 }
 scheduleDailyNotification();
 }).catch(()=>{});
-}
-// queueBackgroundSync removed — was dead code (never called)
 
 _dataPromise.then(()=>{renderTabs();render();}).catch((e)=>{console.error('Boot failed:',e);document.body.innerHTML='<div style="padding:2em;text-align:center;color:#ef4444"><h2>Failed to load app data</h2><p>'+String(e)+'</p><button onclick="location.reload()">Retry</button></div>';});
 </script>

--- a/src/sw-update.js
+++ b/src/sw-update.js
@@ -1,0 +1,63 @@
+// src/sw-update.js — Service worker registration + update banner
+// Extracted from shlav-a-mega.html (Phase 2)
+// Globals exposed: initSWUpdate(), applyUpdate(), dismissUpdateBanner()
+
+var _swDismissKey;
+
+function showUpdateBanner(){
+if(localStorage.getItem(_swDismissKey))return;
+var existing=document.getElementById('update-banner');
+if(existing)return;
+var b=document.createElement('div');
+b.id='update-banner';
+b.style.cssText='position:fixed;top:0;left:0;right:0;z-index:99999;background:linear-gradient(135deg,#0D7377,#14919B);color:#fff;padding:12px 16px;font-size:12px;display:flex;align-items:center;gap:10px;justify-content:space-between;box-shadow:0 2px 12px rgba(0,0,0,.3)';
+b.innerHTML='<div><b>🆕 עדכון זמין!</b> גרסה חדשה מוכנה</div>'+
+'<div style="display:flex;gap:6px;flex-shrink:0">'+
+'<button onclick="applyUpdate()" style="background:rgb(var(--card-bg));color:#0D7377;border:none;border-radius:8px;padding:6px 14px;font-size:11px;font-weight:700;cursor:pointer">🔄 עדכן עכשיו</button>'+
+'<button onclick="dismissUpdateBanner()" style="background:rgba(255,255,255,.2);color:#fff;border:none;border-radius:8px;padding:6px 10px;font-size:11px;cursor:pointer">✕</button>'+
+'</div>';
+document.body.prepend(b);
+}
+
+function dismissUpdateBanner(){
+localStorage.setItem(_swDismissKey,'1');
+var b=document.getElementById('update-banner');
+if(b)b.remove();
+}
+
+function applyUpdate(){
+localStorage.removeItem(_swDismissKey);
+if(navigator.serviceWorker&&navigator.serviceWorker.controller){
+navigator.serviceWorker.getRegistrations().then(function(regs){
+regs.forEach(function(r){if(r.waiting)r.waiting.postMessage({type:'SKIP_WAITING'});});
+});
+}
+caches.keys().then(function(ks){ks.forEach(function(k){caches.delete(k);});});
+setTimeout(function(){window.location.reload(true);},500);
+}
+
+/**
+ * Register service worker, set up update detection, clean old caches.
+ * @param {string} appVersion - APP_VERSION from the main app
+ * @returns {Promise<ServiceWorkerRegistration|null>} registration (or null if SW unsupported)
+ */
+function initSWUpdate(appVersion){
+if(!('serviceWorker' in navigator))return Promise.resolve(null);
+_swDismissKey='shlav_update_dismissed_'+appVersion;
+
+// Clear old caches
+caches.keys().then(function(ks){
+var old=ks.filter(function(k){return k.startsWith('shlav-a-')&&k!=='shlav-a-v'+appVersion;});
+old.forEach(function(k){caches.delete(k);console.log('Deleted old cache:',k);});
+});
+
+return navigator.serviceWorker.register('sw.js').then(function(reg){
+reg.update();
+if(reg.waiting){showUpdateBanner();}
+reg.addEventListener('updatefound',function(){
+var nw=reg.installing;
+if(nw){nw.addEventListener('statechange',function(){if(nw.state==='installed'&&navigator.serviceWorker.controller){showUpdateBanner();}});}
+});
+return reg;
+});
+}

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 const CACHE='shlav-a-v9.50';
-const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js'];
+const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','src/sw-update.js'];
 const JSON_DATA_URLS=['data/questions.json','data/topics.json','data/notes.json','data/drugs.json','data/flashcards.json','harrison_chapters.json','data/hazzard_chapters.json','data/tabs.json'];
 const ALL_URLS=[...HTML_URLS,...JSON_DATA_URLS];
 

--- a/tests/serviceWorker.test.js
+++ b/tests/serviceWorker.test.js
@@ -215,11 +215,13 @@ describe("sw.js — version alignment with app", () => {
     expect(cacheKeyMatch, "CACHE key found in sw.js").not.toBeNull();
     const swCacheKey = cacheKeyMatch[1];
 
-    // The HTML cleanup code filters old caches: k !== '<current-cache-key>'
+    // The cache cleanup code filters old caches: k !== '<current-cache-key>'
     // This must match the sw.js CACHE exactly or the current cache gets deleted
-    // Cache cleanup now uses dynamic reference: k!=='shlav-a-v'+APP_VERSION
-    const dynamicCleanup = html.includes("k!=='shlav-a-v'+APP_VERSION");
-    const staticCleanup = html.match(/ks\.filter\(k=>k\.startsWith\('shlav-a-'\)&&k!=='([^']+)'\)/);
+    // Cache cleanup may live in HTML or in src/sw-update.js (extracted module)
+    const swUpdatePath = resolve(ROOT, "src", "sw-update.js");
+    const appSource = html + (existsSync(swUpdatePath) ? readFileSync(swUpdatePath, "utf-8") : "");
+    const dynamicCleanup = appSource.includes("k!=='shlav-a-v'+appVersion") || appSource.includes("k!=='shlav-a-v'+APP_VERSION");
+    const staticCleanup = appSource.match(/ks\.filter\((?:function\(k\)\{return |k=>)k\.startsWith\('shlav-a-'\)&&k!=='([^']+)'\)/);
     
     if (dynamicCleanup) {
       // Dynamic reference — always matches APP_VERSION, which matches sw.js CACHE


### PR DESCRIPTION
## Summary

- **Extract** service worker registration, update banner, dismiss/apply handlers, and cache cleanup from `shlav-a-mega.html` into `src/sw-update.js` (Phase 2 of audit)
- **Net effect**: -41 lines from HTML monolith, +63 lines in new focused module
- **No behavior change** — same update lifecycle, same banner UI, same cache cleanup

## Changes

| File | Change |
|------|--------|
| `src/sw-update.js` | New file: `initSWUpdate()`, `applyUpdate()`, `dismissUpdateBanner()`, `showUpdateBanner()` |
| `shlav-a-mega.html` | Remove update logic block, add `<script src>`, call `initSWUpdate(APP_VERSION)` |
| `sw.js` | Add `src/sw-update.js` to `HTML_URLS` for offline caching |
| `tests/serviceWorker.test.js` | Cache cleanup test now checks both HTML and extracted module |

## What stays in HTML

- `saveAnswerReport()` — depends on `QZ`, `SUPA_URL`, `SUPA_ANON`
- Notification scheduling — depends on `getDueQuestions()`, `reg.active`
- `SYLLABUS_VERSION` — app config, not update logic

## Test plan

- [x] JS syntax check passes (`node --check src/sw-update.js`)
- [x] Brace balance verified (2100/2100)
- [x] All 426 tests pass
- [ ] Manual: verify update banner shows on SW update and dismiss/apply work
- [ ] Manual: verify offline caching includes new script

https://claude.ai/code/session_01Cn5yPkr7Pt5ajhVcFbs9XD