### PR TITLE
refactor: convert shell-level inline handlers to data-action delegation

### DIFF
--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -307,7 +307,7 @@ upd();setInterval(upd,30000);
 <a href="#ct" class="skip-link">Skip to content</a>
 <div class="hdr" style="position:relative">
 <h1>Shlav A Mega <span style="font-size:10px;font-weight:500;color:#0D7377;vertical-align:middle">Geriatrics</span> <span id="headerVer" style="font-size:9px;font-weight:400;color:rgb(var(--fg2));vertical-align:middle"></span></h1>
-<button class="dm-btn" onclick="toggleStudyMode()" title="Night/Study Mode" aria-label="Toggle night mode" style="right:44px">🕯️</button><button class="dm-btn" onclick="toggleDark()" title="Dark Mode" aria-label="Toggle dark mode">🌓</button><button class="dm-btn" onclick="showHelp()" title="Help" aria-label="Help" style="right:82px;font-size:11px">❓</button>
+<button class="dm-btn" data-action="toggle-study" title="Night/Study Mode" aria-label="Toggle night mode" style="right:44px">🕯️</button><button class="dm-btn" data-action="toggle-dark" title="Dark Mode" aria-label="Toggle dark mode">🌓</button><button class="dm-btn" data-action="show-help" title="Help" aria-label="Help" style="right:82px;font-size:11px">❓</button>
 <p id="hdr-sub">Loading...</p>
 </div>
 
@@ -3984,7 +3984,7 @@ h+=`<div style="text-align:center;margin-top:20px;padding:12px;font-size:9px;col
 <div>Shlav A Mega v${APP_VERSION} · ${new Date().toLocaleDateString('en-GB',{day:'numeric',month:'short',year:'numeric'})} · build ${BUILD_HASH}</div>
 <div>Hazzard's 8e + Harrison's 22e · ${QZ.length} Questions</div>
 <div style="margin-top:8px;display:flex;gap:8px;justify-content:center;flex-wrap:wrap">
-<button onclick="applyUpdate()" style="font-size:10px;padding:5px 14px;background:#0D7377;color:#fff;border:none;border-radius:8px;cursor:pointer;font-weight:600">🔄 Force Update</button>
+<button data-action="apply-update" style="font-size:10px;padding:5px 14px;background:#0D7377;color:#fff;border:none;border-radius:8px;cursor:pointer;font-weight:600">🔄 Force Update</button>
 <a href="https://eiasash.github.io/InternalMedicine/" target="_blank" style="font-size:10px;padding:5px 14px;background:#4f46e5;color:#fff;border:none;border-radius:8px;text-decoration:none;font-weight:600;display:inline-block">🏥 Internal Medicine App →</a>
 </div>
 <div style="margin-top:6px">صدقة جارية الى من نحب</div></div>`;
@@ -4808,7 +4808,7 @@ const sec=(title,icon,color,items)=>`<div style="margin-bottom:14px">
 ov.innerHTML=`<div style="max-width:420px;margin:0 auto;background:rgb(var(--card-bg));border-radius:16px;padding:20px;color:rgb(var(--fg));font-size:11px;line-height:1.7">
 <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px">
 <div style="font-size:16px;font-weight:800">🩺 Shlav A Mega</div>
-<button onclick="this.closest('#help-overlay').remove()" style="background:none;border:none;font-size:20px;cursor:pointer;color:rgb(var(--fg3))" aria-label="Close help">✕</button>
+<button data-action="close-overlay" style="background:none;border:none;font-size:20px;cursor:pointer;color:rgb(var(--fg3))" aria-label="Close help">✕</button>
 </div>
 <div style="font-size:10px;color:rgb(var(--fg2));margin-bottom:16px">Israeli Geriatrics Board Exam Prep (שלב א׳ גריאטריה) · P005-2026 · Hazzard's 8e + Harrison's 22e · Works Offline</div>
 <div style="padding:10px;background:#ecfdf5;border:1px solid rgb(var(--green-brd));border-radius:10px;margin-bottom:14px">
@@ -4899,6 +4899,20 @@ Notification.requestPermission();
 }
 scheduleDailyNotification();
 }).catch(()=>{});
+
+// Delegated click handler for shell-level data-action buttons
+document.body.addEventListener('click',function(e){
+var btn=e.target.closest('[data-action]');
+if(!btn)return;
+switch(btn.dataset.action){
+case 'toggle-study':toggleStudyMode();break;
+case 'toggle-dark':toggleDark();break;
+case 'show-help':showHelp();break;
+case 'apply-update':applyUpdate();break;
+case 'dismiss-update':dismissUpdateBanner();break;
+case 'close-overlay':var ov=btn.closest('[id$="-overlay"]');if(ov)ov.remove();break;
+}
+});
 
 _dataPromise.then(()=>{renderTabs();render();}).catch((e)=>{console.error('Boot failed:',e);document.body.innerHTML='<div style="padding:2em;text-align:center;color:#ef4444"><h2>Failed to load app data</h2><p>'+String(e)+'</p><button onclick="location.reload()">Retry</button></div>';});
 </script>

--- a/src/sw-update.js
+++ b/src/sw-update.js
@@ -13,8 +13,8 @@ b.id='update-banner';
 b.style.cssText='position:fixed;top:0;left:0;right:0;z-index:99999;background:linear-gradient(135deg,#0D7377,#14919B);color:#fff;padding:12px 16px;font-size:12px;display:flex;align-items:center;gap:10px;justify-content:space-between;box-shadow:0 2px 12px rgba(0,0,0,.3)';
 b.innerHTML='<div><b>🆕 עדכון זמין!</b> גרסה חדשה מוכנה</div>'+
 '<div style="display:flex;gap:6px;flex-shrink:0">'+
-'<button onclick="applyUpdate()" style="background:rgb(var(--card-bg));color:#0D7377;border:none;border-radius:8px;padding:6px 14px;font-size:11px;font-weight:700;cursor:pointer">🔄 עדכן עכשיו</button>'+
-'<button onclick="dismissUpdateBanner()" style="background:rgba(255,255,255,.2);color:#fff;border:none;border-radius:8px;padding:6px 10px;font-size:11px;cursor:pointer">✕</button>'+
+'<button data-action="apply-update" style="background:rgb(var(--card-bg));color:#0D7377;border:none;border-radius:8px;padding:6px 14px;font-size:11px;font-weight:700;cursor:pointer">🔄 עדכן עכשיו</button>'+
+'<button data-action="dismiss-update" style="background:rgba(255,255,255,.2);color:#fff;border:none;border-radius:8px;padding:6px 10px;font-size:11px;cursor:pointer">✕</button>'+
 '</div>';
 document.body.prepend(b);
 }


### PR DESCRIPTION
## Summary

- **Convert 7 shell-level inline onclick handlers** to `data-action` attributes with a single delegated click listener on `document.body`
- Removes `onclick=` from: header buttons (3), help overlay close (1), update banner (2), settings force-update (1)
- ~153 content-level inline handlers deeper in the app are intentionally left untouched

## Actions handled by delegation

| `data-action` | Function called |
|---|---|
| `toggle-study` | `toggleStudyMode()` |
| `toggle-dark` | `toggleDark()` |
| `show-help` | `showHelp()` |
| `apply-update` | `applyUpdate()` |
| `dismiss-update` | `dismissUpdateBanner()` |
| `close-overlay` | Removes nearest `[id$="-overlay"]` ancestor |

## Test plan

- [x] JS syntax check passes
- [x] Brace balance verified (2102/2102)
- [x] All 426 tests pass
- [ ] Manual: verify header buttons (dark mode, study mode, help) work
- [ ] Manual: verify help overlay opens and closes via ✕ and backdrop click
- [ ] Manual: verify update banner apply/dismiss work
- [ ] Manual: verify Force Update in settings footer works

https://claude.ai/code/session_01Cn5yPkr7Pt5ajhVcFbs9XD