### PR TITLE
security: add defensive CSP directives

### DIFF
--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -6,7 +6,7 @@
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="mobile-web-app-capable" content="yes">
 <meta name="theme-color" content="#0f172a">
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data: blob: https://*.supabase.co https://ima-contentfiles.s3.amazonaws.com https://ima-files.s3.amazonaws.com; connect-src 'self' https://*.supabase.co https://api.anthropic.com https://toranot.netlify.app;">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data: blob: https://*.supabase.co https://ima-contentfiles.s3.amazonaws.com https://ima-files.s3.amazonaws.com; connect-src 'self' https://*.supabase.co https://api.anthropic.com https://toranot.netlify.app; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self';">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🩺</text></svg>">
 <link rel="manifest" href="manifest.json">
 <title>Shlav A Mega — Board Prep</title>


### PR DESCRIPTION
## Summary

- **Add 4 defensive CSP directives** that the app does not violate — pure hardening, no breakage risk
- `'unsafe-inline'` intentionally preserved in `script-src` and `style-src` (see below)

## Directives added

| Directive | Effect |
|---|---|
| `object-src 'none'` | Blocks plugin content (Flash, Java applets) |
| `base-uri 'self'` | Prevents `<base>` tag injection attacks |
| `frame-ancestors 'none'` | Prevents clickjacking (no iframe embedding) |
| `form-action 'self'` | Restricts form submissions to same origin |

## What still blocks stricter CSP

`'unsafe-inline'` cannot be removed from `script-src` due to:
- 2 inline `<script>` blocks
- 151 `onclick=`, 26 `onchange=`, 6 `oninput=` inline handlers

Removing these would require migrating all ~183 handlers — not safe in one pass.

## Test plan

- [x] All 426 tests pass
- [x] Verified app has no `<form>`, `<object>`, `<embed>`, `<iframe>`, or `<base>` tags
- [ ] Manual: verify app loads without CSP console errors

https://claude.ai/code/session_01Cn5yPkr7Pt5ajhVcFbs9XD