### PR TITLE
refactor: centralize repeated CI validation into shared scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,52 +171,11 @@ jobs:
 
       # ── Service Worker + package.json Version Sync ──
       - name: Check all version sources are aligned
-        run: |
-          python3 << 'PYEOF'
-          import json, re, sys
-          html = open('shlav-a-mega.html').read()
-          sw = open('sw.js').read()
-          pkg = json.load(open('package.json'))
-          m_app = re.search(r"APP_VERSION\s*=\s*['\"]([^'\"]+)['\"]", html)
-          m_sw = re.search(r"CACHE\s*=\s*['\"]shlav-a-v([^'\"]+)['\"]", sw)
-          if not m_app:
-              print('ERROR: APP_VERSION not found in shlav-a-mega.html', file=sys.stderr)
-              sys.exit(1)
-          if not m_sw:
-              print('ERROR: CACHE version not found in sw.js', file=sys.stderr)
-              sys.exit(1)
-          app_v = m_app.group(1)
-          sw_v = m_sw.group(1)
-          pkg_v = pkg.get('version', '')
-          if app_v != sw_v:
-              print(f'ERROR: Version mismatch — app={app_v}, sw.js={sw_v}', file=sys.stderr)
-              sys.exit(1)
-          if not pkg_v.startswith(app_v):
-              print(f'ERROR: package.json version "{pkg_v}" does not start with APP_VERSION "{app_v}"', file=sys.stderr)
-              sys.exit(1)
-          print(f'OK: All versions aligned (v{app_v}) — sw.js={sw_v}, package.json={pkg_v}')
-          PYEOF
+        run: python3 scripts/check-version-sync.py
 
       # ── innerHTML Sanitization Audit ──
       - name: Audit innerHTML for unsanitized interpolation
-        run: |
-          python3 << 'PYEOF'
-          import re, sys
-          html = open('shlav-a-mega.html').read()
-          lines = html.split('\n')
-          warnings = []
-          for i, line in enumerate(lines, 1):
-              if '.innerHTML=' in line or '.innerHTML =' in line:
-                  after_eq = line.split('innerHTML')[1]
-                  if ('+' in after_eq or '${' in after_eq) and 'sanitize(' not in after_eq:
-                      warnings.append(f'  Line {i}: {line.strip()[:100]}')
-          if warnings:
-              print(f'WARNING: {len(warnings)} innerHTML assignments with unsanitized interpolation:')
-              for w in warnings:
-                  print(w)
-          else:
-              print('OK: No unsanitized innerHTML interpolation detected')
-          PYEOF
+        run: python3 scripts/check-innerhtml.py
 
       # ── Topic Coverage ──
       - name: Check topic coverage (min 5 questions per topic)
@@ -301,18 +260,7 @@ jobs:
 
       # ── JS Brace Balance ──
       - name: Check JS brace balance
-        run: |
-          python3 -c "
-          import sys
-          c = open('shlav-a-mega.html').read()
-          opens = c.count('{')
-          closes = c.count('}')
-          diff = opens - closes
-          if diff != 0:
-              print(f'ERROR: Brace imbalance — {{ ={opens}, }} ={closes}, diff={diff}', file=sys.stderr)
-              sys.exit(1)
-          print(f'OK: Brace balance ({opens} pairs)')
-          "
+        run: python3 scripts/check-brace-balance.py
 
       # ── Vitest Test Suite ──
       - name: Install test dependencies

--- a/.github/workflows/integrity-guard.yml
+++ b/.github/workflows/integrity-guard.yml
@@ -49,7 +49,12 @@ jobs:
         run: |
           python3 << 'PYEOF'
           import re, sys
+          import glob
           html = open('shlav-a-mega.html').read()
+          # Also search extracted JS modules (src/*.js, shared/*.js)
+          all_code = html
+          for js_file in sorted(glob.glob('src/*.js') + glob.glob('shared/*.js')):
+              all_code += '\n' + open(js_file).read()
           CRITICAL_FUNCTIONS = [
               # Boot path — without these the app is dead
               'loadDataArrays',
@@ -71,10 +76,10 @@ jobs:
               'renderTrack',
               'trackDailyActivity',
               'takeWeeklySnapshot',
-              # Version/update
+              # Version/update (in src/sw-update.js)
               'showUpdateBanner',
               'applyUpdate',
-              'queueBackgroundSync',
+              'initSWUpdate',
               # AI features
               'callAI',
               # Tab rendering (all 5 tabs + sub-tabs)
@@ -99,9 +104,9 @@ jobs:
           ]
           missing = []
           for fn in CRITICAL_FUNCTIONS:
-              # Match function declarations: function X(, async function X(, const X = 
+              # Match function declarations: function X(, async function X(, const X =
               pattern = rf'(?:(?:async\s+)?function\s+{fn}\s*\(|(?:const|let|var)\s+{fn}\s*=)'
-              if not re.search(pattern, html):
+              if not re.search(pattern, all_code):
                   missing.append(fn)
           if missing:
               print(f'FATAL: {len(missing)} critical functions are MISSING:', file=sys.stderr)

--- a/.github/workflows/weekly-audit.yml
+++ b/.github/workflows/weekly-audit.yml
@@ -99,19 +99,7 @@ jobs:
 
       # ── Version Sync ──
       - name: Check APP_VERSION matches SW cache
-        run: |
-          python3 << 'PYEOF'
-          import re, sys
-          html = open('shlav-a-mega.html').read()
-          sw = open('sw.js').read()
-          m_app = re.search(r"APP_VERSION='([^']+)'", html)
-          m_sw = re.search(r"CACHE='shlav-a-v([^']+)'", sw)
-          if not m_app or not m_sw:
-              print('ERROR: Version constants not found'); sys.exit(1)
-          if m_app.group(1) != m_sw.group(1):
-              print(f'MISMATCH: app={m_app.group(1)}, sw={m_sw.group(1)}'); sys.exit(1)
-          print(f'OK: Versions match (v{m_app.group(1)})')
-          PYEOF
+        run: python3 scripts/check-version-sync.py
 
       # ── Security ──
       - name: Check no eval() calls
@@ -141,35 +129,10 @@ jobs:
           "
 
       - name: Audit innerHTML sanitization
-        run: |
-          python3 << 'PYEOF'
-          import sys
-          html = open('shlav-a-mega.html').read()
-          lines = html.split('\n')
-          warnings = []
-          for i, line in enumerate(lines, 1):
-              if '.innerHTML=' in line or '.innerHTML =' in line:
-                  after_eq = line.split('innerHTML')[1]
-                  if ('+' in after_eq or '${' in after_eq) and 'sanitize(' not in after_eq:
-                      warnings.append(f'  Line {i}: {line.strip()[:100]}')
-          if warnings:
-              print(f'WARNING: {len(warnings)} unsanitized innerHTML:')
-              for w in warnings[:10]:
-                  print(w)
-          else:
-              print('OK: All dynamic innerHTML uses sanitize()')
-          PYEOF
+        run: python3 scripts/check-innerhtml.py
 
       - name: Check JS brace balance
-        run: |
-          python3 -c "
-          import sys
-          c = open('shlav-a-mega.html').read()
-          diff = c.count('{') - c.count('}')
-          if diff != 0:
-              print(f'ERROR: Brace imbalance (diff={diff})'); sys.exit(1)
-          print(f'OK: Braces balanced')
-          "
+        run: python3 scripts/check-brace-balance.py
 
       # ── JS Syntax Check ──
       - name: Check JS syntax with acorn

--- a/scripts/check-brace-balance.py
+++ b/scripts/check-brace-balance.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""Check JS brace balance in shlav-a-mega.html."""
+import sys
+
+c = open('shlav-a-mega.html').read()
+opens = c.count('{')
+closes = c.count('}')
+diff = opens - closes
+if diff != 0:
+    print(f'ERROR: Brace imbalance — {{ ={opens}, }} ={closes}, diff={diff}', file=sys.stderr)
+    sys.exit(1)
+print(f'OK: Brace balance ({opens} pairs)')

--- a/scripts/check-innerhtml.py
+++ b/scripts/check-innerhtml.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Audit innerHTML for unsanitized interpolation in shlav-a-mega.html."""
+import sys
+
+html = open('shlav-a-mega.html').read()
+lines = html.split('\n')
+warnings = []
+for i, line in enumerate(lines, 1):
+    if '.innerHTML=' in line or '.innerHTML =' in line:
+        after_eq = line.split('innerHTML')[1]
+        if ('+' in after_eq or '${' in after_eq) and 'sanitize(' not in after_eq:
+            warnings.append(f'  Line {i}: {line.strip()[:100]}')
+if warnings:
+    print(f'WARNING: {len(warnings)} innerHTML assignments with unsanitized interpolation:')
+    for w in warnings:
+        print(w)
+else:
+    print('OK: No unsanitized innerHTML interpolation detected')

--- a/scripts/check-version-sync.py
+++ b/scripts/check-version-sync.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Check APP_VERSION, sw.js CACHE, and package.json version are aligned."""
+import json, re, sys
+
+html = open('shlav-a-mega.html').read()
+sw = open('sw.js').read()
+pkg = json.load(open('package.json'))
+
+m_app = re.search(r"APP_VERSION\s*=\s*['\"]([^'\"]+)['\"]", html)
+m_sw = re.search(r"CACHE\s*=\s*['\"]shlav-a-v([^'\"]+)['\"]", sw)
+
+if not m_app:
+    print('ERROR: APP_VERSION not found in shlav-a-mega.html', file=sys.stderr)
+    sys.exit(1)
+if not m_sw:
+    print('ERROR: CACHE version not found in sw.js', file=sys.stderr)
+    sys.exit(1)
+
+app_v = m_app.group(1)
+sw_v = m_sw.group(1)
+pkg_v = pkg.get('version', '')
+
+if app_v != sw_v:
+    print(f'ERROR: Version mismatch — app={app_v}, sw.js={sw_v}', file=sys.stderr)
+    sys.exit(1)
+if not pkg_v.startswith(app_v):
+    print(f'ERROR: package.json version "{pkg_v}" does not start with APP_VERSION "{app_v}"', file=sys.stderr)
+    sys.exit(1)
+
+print(f'OK: All versions aligned (v{app_v}) — sw.js={sw_v}, package.json={pkg_v}')


### PR DESCRIPTION
## Summary

- **Extract 3 duplicated checks** from ci.yml + weekly-audit.yml into shared scripts (-99 lines from workflows)
- **Fix integrity-guard.yml GATE 2** bug: critical function search now includes `src/*.js` (showUpdateBanner/applyUpdate moved in Phase 2), and replaces stale `queueBackgroundSync` with `initSWUpdate`

## Shared scripts created

| Script | Purpose | Used by |
|---|---|---|
| `scripts/check-version-sync.py` | APP_VERSION + sw.js + package.json alignment | ci.yml, weekly-audit.yml |
| `scripts/check-innerhtml.py` | innerHTML sanitization audit | ci.yml, weekly-audit.yml |
| `scripts/check-brace-balance.py` | JS brace balance check | ci.yml, weekly-audit.yml |

## integrity-guard.yml GATE 2 fix

- Now searches `src/*.js` and `shared/*.js` alongside the HTML for critical functions
- Replaced `queueBackgroundSync` (removed dead code) with `initSWUpdate` (new Phase 2 function)

## Test plan

- [x] All 3 shared scripts run successfully locally
- [x] All 426 vitest tests pass
- [ ] CI workflows validate on this PR

https://claude.ai/code/session_01Cn5yPkr7Pt5ajhVcFbs9XD