### PR TITLE
feat: add npm run verify for local pre-push confidence check

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "verify": "node --check src/sw-update.js && python3 scripts/check-version-sync.py && python3 scripts/check-brace-balance.py && python3 scripts/check-innerhtml.py && vitest run",
     "image:check": "node scripts/add-image-question.cjs --help"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Add `npm run verify` script that mirrors CI checks locally
- Single command to run before pushing: JS syntax, version sync, brace balance, innerHTML audit, full test suite

## Verification sequence

1. `node --check src/sw-update.js` — JS syntax
2. `python3 scripts/check-version-sync.py` — APP_VERSION alignment
3. `python3 scripts/check-brace-balance.py` — brace balance
4. `python3 scripts/check-innerhtml.py` — innerHTML audit
5. `vitest run` — 426 tests

## Test plan

- [x] `npm run verify` runs successfully, all checks pass
- [x] Chain fails fast on first error (&&)

https://claude.ai/code/session_01Cn5yPkr7Pt5ajhVcFbs9XD