### PR TITLE
chore: enforce LF line endings for shell scripts (follow-up to #47)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,3 +19,7 @@ hazzard_chapters.json binary
 *.md text eol=lf
 *.yml text eol=lf
 *.yaml text eol=lf
+
+# Shell scripts — must be LF for portability (Claude Code hooks + git hooks)
+*.sh text eol=lf
+scripts/git-hooks/pre-commit text eol=lf


### PR DESCRIPTION
## Summary

Follow-up to #47. Adds 2 lines to `.gitattributes` to force LF line endings on shell scripts so Windows contributors don't silently rewrite them to CRLF on checkout — which breaks bash execution on Linux CI runners.

```
*.sh text eol=lf
scripts/git-hooks/pre-commit text eol=lf
```

## Why

The bundle from #47 shipped 9 `.sh` files + `scripts/git-hooks/pre-commit`. The existing `.gitattributes` covered `.html/.css/.js/.json/.md/.yml/.yaml` but not `.sh` — so when those files hit the repo from a Windows machine, Git warned `LF will be replaced by CRLF` and did the conversion on next touch. Left unfixed, this would shape-shift every time a mixed-OS team touched the scripts.

## Cleanup note

Supersedes the standalone `.gitattributes.automation` template file included in #47, which can be deleted in a follow-up housekeeping commit.

## Test plan

- [ ] CI passes (additive rules only; no existing workflow reads `.gitattributes`)
- [ ] `git check-attr eol scripts/hooks/pre-edit-safety.sh` returns `eol: lf`
- [ ] On a fresh Windows clone, the 9 shell scripts stay LF

🤖 Generated with [Claude Code](https://claude.com/claude-code)
