### PR TITLE
docs: strike false CI claims from AUTOMATION_BUNDLE.md

### DIFF
--- a/docs/AUTOMATION_BUNDLE.md
+++ b/docs/AUTOMATION_BUNDLE.md
@@ -23,22 +23,6 @@ Drop-in automation for `Eiasash/Geriatrics`. Reconciled with the repo's **actual
 | MCP additions | `.mcp.json.additions` | MCP config | existing `supabase` MCP (manual merge) |
 | CLAUDE.md additions | `CLAUDE.md.additions` | Docs (manual append) | existing CLAUDE.md |
 
-## Known issues with the existing repo (NOT fixed by this branch)
-
-### `.github/workflows/ci.yml` validates stale root-level JSON
-
-The CI workflow currently reads `questions.json` / `notes.json` / `drugs.json` / `flashcards.json` from the **repo root**, but CLAUDE.md and the application itself declare `data/*.json` as the single source of truth. The root-level files are stale (last touched 2026-04-08; `data/` versions last touched 2026-04-16). CI is effectively validating frozen copies.
-
-**Recommended fix** (separate PR): update `.github/workflows/ci.yml` to read from `data/*.json` and delete the root-level duplicates once all consumers are migrated. This bundle's `scripts/hooks/*.sh` and `/ship-it` already point at `data/*.json` — matching CLAUDE.md's declared canon.
-
-### Question-count threshold discrepancy
-
-CLAUDE.md says `>1400` questions must be present; the current `ci.yml` threshold is `>900`. Not this bundle's problem, but worth reconciling.
-
-### Dirty working tree on local main
-
-The repo's local `main` has ~280 commits ahead of `origin/main` and ~140 uncommitted modifications. **This branch was created fresh off `origin/main`** and does not touch that state. Those changes are your problem to push separately.
-
 ## Coexistence with existing automation
 
 Current repo already contains `.claude/`:


### PR DESCRIPTION
## Summary

Strikes a misleading "Known issues with the existing repo" section from `docs/AUTOMATION_BUNDLE.md` that was added in #47. On re-verification against `origin/main`, all three claims in that section are wrong:

1. **"ci.yml validates stale root-level JSON"** — FALSE. `.github/workflows/ci.yml`, `integrity-guard.yml`, and `weekly-audit.yml` all correctly read from `data/questions.json`, `data/notes.json`, `data/drugs.json`, `data/flashcards.json`, `data/topics.json`, `data/tabs.json`. See e.g. line 17 of ci.yml: `for f in data/questions.json data/notes.json ...`.

2. **"Question-count threshold >900 vs CLAUDE.md >1400"** — FALSE. ci.yml line 25 enforces `if [ "$COUNT" -le 1400 ]; then exit 1`. Matches CLAUDE.md.

3. **"Local main has ~280 commits ahead of origin/main"** — FALSE. Local main is in fact behind origin/main by ~281 commits; origin is the authoritative copy.

## Why this matters

Leaving those claims in the docs would (a) mislead future contributors into "fixing" non-problems and (b) damage trust in the rest of the bundle's documentation. The automation itself (hooks, subagents, skills, commands) is unaffected.

## Test plan

- [ ] CI passes (docs-only change; no workflow logic touched)
- [ ] Rendered `docs/AUTOMATION_BUNDLE.md` on main after merge no longer contains a "Known issues" section
- [ ] "Coexistence with existing automation" section follows directly after "What's included"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
