### PR TITLE
tests: un-park tagMigration/aiAutopsyXss, fix 2 Hazzard-suppl Hebrew bugs, lock baseline

### DIFF
--- a/docs/harrison-hebrew-baseline.csv
+++ b/docs/harrison-hebrew-baseline.csv
@@ -1,0 +1,3 @@
+idx,tag,field,offset,snippet
+1175,Hazzard-suppl,o[0],32,רופתי המומלץ בשחרורו?א.הוספת טיפול ב-APIXA
+3368,Hazzard-suppl,o[3],33,ויקיצה איטית 25. ל ?מי מהמטופלים הבאים מת

--- a/docs/harrison-hebrew-baseline.csv
+++ b/docs/harrison-hebrew-baseline.csv
@@ -1,3 +1,2 @@
 idx,tag,field,offset,snippet
-1175,Hazzard-suppl,o[0],32,רופתי המומלץ בשחרורו?א.הוספת טיפול ב-APIXA
-3368,Hazzard-suppl,o[3],33,ויקיצה איטית 25. ל ?מי מהמטופלים הבאים מת
+

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "verify": "node --check src/sw-update.js && python3 scripts/check-version-sync.py && python3 scripts/check-brace-balance.py && python3 scripts/check-innerhtml.py && vitest run",
+    "verify": "node --check src/sw-update.js && python3 scripts/check-version-sync.py && python3 scripts/check-brace-balance.py && python3 scripts/check-innerhtml.py && HARRISON_HEBREW_BASELINE=0 node scripts/harrison-hebrew-baseline.cjs --strict && vitest run",
     "image:check": "node scripts/add-image-question.cjs --help"
   },
   "devDependencies": {

--- a/scripts/harrison-hebrew-baseline.cjs
+++ b/scripts/harrison-hebrew-baseline.cjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Harrison/Hazzard Hebrew ?[Hebrew] baseline scan (Geriatrics).
+ *
+ * Context: regressionGuards.test.js only runs the wrong-side punctuation
+ * check against PAST_EXAM_TAGS. Hazzard / Harrison / Hazzard-suppl /
+ * Exam-tagged questions (AI-generated, large pool) skip that gate, so
+ * any `?[Hebrew]` artifact is invisible to CI.
+ *
+ * Enumerates every occurrence of `?` immediately preceding a Hebrew
+ * letter (U+0590–U+05FF) in non-past-exam questions, writes a CSV
+ * baseline to docs/harrison-hebrew-baseline.csv, and prints summary
+ * counts per tag.
+ *
+ * Usage:  node scripts/harrison-hebrew-baseline.cjs
+ *         node scripts/harrison-hebrew-baseline.cjs --strict
+ *         HARRISON_HEBREW_BASELINE=10 node scripts/... --strict
+ *
+ * Output: docs/harrison-hebrew-baseline.csv
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const Q_PATH = path.join(ROOT, 'data', 'questions.json');
+const OUT_PATH = path.join(ROOT, 'docs', 'harrison-hebrew-baseline.csv');
+
+// Mirrors Geriatrics regressionGuards.test.js PAST_EXAM_TAGS.
+const PAST_EXAM_TAGS = new Set([
+  '2020', '2021', '2021-Jun', '2022', '2023-Jun', '2023-Sep',
+  '2024-May', '2024-Sep', '2025-Jun',
+]);
+
+const BAD_PUNCT_RE = /\?[\u0590-\u05FF]/g;
+
+function scan() {
+  const questions = JSON.parse(fs.readFileSync(Q_PATH, 'utf-8'));
+  const rows = [];
+  const byTag = new Map();
+  questions.forEach((q, i) => {
+    if (PAST_EXAM_TAGS.has(q.t)) return;
+    const fields = [['q', q.q], ...(q.o || []).map((o, k) => [`o[${k}]`, o])];
+    for (const [field, text] of fields) {
+      if (!text) continue;
+      const matches = [...String(text).matchAll(BAD_PUNCT_RE)];
+      if (!matches.length) continue;
+      byTag.set(q.t, (byTag.get(q.t) || 0) + matches.length);
+      matches.forEach(m => {
+        const at = m.index;
+        const ctx = String(text).slice(Math.max(0, at - 20), at + 22);
+        rows.push({
+          idx: i,
+          tag: q.t || '',
+          field,
+          offset: at,
+          snippet: ctx.replace(/\s+/g, ' ').trim(),
+        });
+      });
+    }
+  });
+  return { rows, byTag, total: questions.length };
+}
+
+function writeCsv(rows) {
+  const header = 'idx,tag,field,offset,snippet\n';
+  const escape = (s) => {
+    const v = String(s == null ? '' : s);
+    return /[",\n]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v;
+  };
+  const body = rows
+    .map(r => [r.idx, r.tag, r.field, r.offset, r.snippet].map(escape).join(','))
+    .join('\n');
+  fs.mkdirSync(path.dirname(OUT_PATH), { recursive: true });
+  fs.writeFileSync(OUT_PATH, header + body + '\n', 'utf-8');
+}
+
+function main() {
+  const { rows, byTag, total } = scan();
+  writeCsv(rows);
+  console.log(`scanned ${total} questions`);
+  console.log(`wrote ${rows.length} ?[Hebrew] rows → ${path.relative(ROOT, OUT_PATH)}`);
+  if (byTag.size === 0) {
+    console.log('no ?[Hebrew] violations in non-past-exam tags');
+  } else {
+    console.log('by tag:');
+    for (const [tag, n] of [...byTag.entries()].sort((a, b) => b[1] - a[1])) {
+      console.log(`  ${(tag || '(untagged)').padEnd(18)} ${n}`);
+    }
+  }
+
+  if (process.argv.includes('--strict')) {
+    const envVar = process.env.HARRISON_HEBREW_BASELINE;
+    const budget = envVar ? Number(envVar) : rows.length;
+    if (!Number.isFinite(budget)) {
+      console.error('--strict requires HARRISON_HEBREW_BASELINE env as integer');
+      process.exit(2);
+    }
+    if (rows.length > budget) {
+      console.error(`FAIL: ${rows.length} violations > baseline ${budget}`);
+      process.exit(1);
+    }
+    console.log(`OK: ${rows.length} <= baseline ${budget}`);
+  }
+}
+
+main();

--- a/tests/aiAutopsyXss.test.js
+++ b/tests/aiAutopsyXss.test.js
@@ -1,0 +1,162 @@
+/**
+ * XSS property test for the aiAutopsy post-sanitize formatting chain in
+ * shlav-a-mega.html (monolithic).
+ *
+ * Pipeline: callAI() → sanitize() → replace chain → innerHTML.
+ *
+ * The replace chain injects raw <b>/<span>/<br> on top of already-escaped
+ * text. Invariant: any `<`/`>`/"/' originating from the AI output must
+ * still be escaped after formatting. The only literal tags allowed are
+ * the formatter's own.
+ *
+ * Because Geriatrics has no module extraction, this test pulls the REAL
+ * `sanitize` + the `safeTxt.replace(...)` chain out of the HTML via
+ * regex and re-runs them — so if someone edits either in the source,
+ * these tests cover the exact new behaviour.
+ *
+ * Mirrors InternalMedicine/tests/aiAutopsyXss.test.js.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import vm from 'node:vm';
+
+const html = readFileSync(
+  resolve(import.meta.dirname, '..', 'shlav-a-mega.html'),
+  'utf-8'
+);
+
+// Pull the ACTUAL source of both sanitize() and the replace chain out of
+// shlav-a-mega.html and assemble them into a testable harness.
+function buildHarness() {
+  // sanitize()
+  const sanMatch = html.match(/function sanitize\(s\)\{[^}]+\}/);
+  if (!sanMatch) throw new Error('sanitize() not found in shlav-a-mega.html');
+
+  // The replace chain (exact formatter used by aiAutopsy).
+  // Capture from `safeTxt.replace(` through the final `.replace(/\n/g,'<br>');`
+  const chainMatch = html.match(
+    /const formatted=safeTxt\.replace\([\s\S]*?\.replace\(\/\\n\/g,'<br>'\);/
+  );
+  if (!chainMatch) throw new Error('formatAutopsy replace chain not found');
+
+  const src = `
+    ${sanMatch[0]}
+    function formatAutopsy(safeTxt){
+      ${chainMatch[0]}
+      return formatted;
+    }
+    function pipe(raw){ return formatAutopsy(sanitize(raw)); }
+  `;
+  const ctx = {};
+  vm.createContext(ctx);
+  vm.runInContext(src, ctx);
+  return ctx; // exposes sanitize, formatAutopsy, pipe
+}
+
+const { sanitize, formatAutopsy, pipe } = buildHarness();
+
+describe('shlav-a-mega.html — aiAutopsy formatter tag inventory', () => {
+  it('wraps ✗ in <b style="color:#dc2626">', () => {
+    expect(formatAutopsy('✗ foo')).toContain('<b style="color:#dc2626">✗</b>');
+  });
+
+  it('wraps "Wrong because:" in a red span', () => {
+    expect(formatAutopsy('Wrong because: x')).toContain(
+      '<span style="color:#b91c1c">Wrong because:</span>'
+    );
+  });
+
+  it('wraps "Would be correct if:" in a green span', () => {
+    expect(formatAutopsy('Would be correct if: y')).toContain(
+      '<span style="color:#059669">Would be correct if:</span>'
+    );
+  });
+
+  it('converts \\n to <br>', () => {
+    expect(formatAutopsy('a\nb')).toBe('a<br>b');
+  });
+});
+
+describe('shlav-a-mega.html — aiAutopsy XSS invariants', () => {
+  it('sanitize escapes <, >, &, ", \' (pre-format guarantee)', () => {
+    expect(sanitize(`<script>"'&`)).toBe('&lt;script&gt;&quot;&#39;&amp;'.replace(
+      '&amp;',
+      '&amp;'
+    ));
+    // Canonical order: & first, then the rest.
+    expect(sanitize('&<>"\'')).toBe('&amp;&lt;&gt;&quot;&#39;');
+  });
+
+  it('neutralises raw <script> tags in AI output', () => {
+    const out = pipe('<script>alert(1)</script>');
+    expect(out).not.toMatch(/<script/i);
+    expect(out).toContain('&lt;script&gt;');
+  });
+
+  it('neutralises <img onerror=> inside autopsy bullet', () => {
+    const out = pipe('✗ <img src=x onerror=alert(1)> — Wrong because: bad');
+    const literalLt = out.match(/</g) || [];
+    // Only the formatter's own tags contribute literal `<`: <b>, </b>, <span>, </span>.
+    expect(literalLt.length).toBe(4);
+    expect(out).toContain('&lt;img');
+    expect(out).not.toMatch(/<img/);
+  });
+
+  it('javascript: href is made inert (brackets escaped)', () => {
+    const out = pipe('✗ <a href="javascript:alert(1)">link</a>');
+    expect(out).not.toMatch(/<a\s/);
+    expect(out).toContain('&lt;a');
+    expect(out).toContain('&quot;javascript:alert(1)&quot;');
+  });
+
+  it('attribute-context breakout via "> fails — quotes and brackets escaped', () => {
+    const out = pipe('"><svg onload=1>');
+    expect(out).not.toContain('"><');
+    expect(out).not.toMatch(/<svg/);
+    expect(out).toContain('&quot;');
+    expect(out).toContain('&lt;svg');
+  });
+
+  it('preserves Hebrew / Unicode content', () => {
+    const out = pipe('✗ חולה — Wrong because: תסמונת');
+    expect(out).toContain('חולה');
+    expect(out).toContain('תסמונת');
+  });
+
+  it('property: no attacker payload builds a live tag across a fixture battery', () => {
+    const fixtures = [
+      '<script>',
+      '"><script>a()</script>',
+      '<img src=x onerror=alert(1)>',
+      '<svg/onload=alert(1)>',
+      '"onmouseover="alert(1)',
+      '\'"><iframe src=//evil>',
+      '<a href=javascript:alert(1)>x</a>',
+      '<style>body{background:url(javascript:alert(1))}</style>',
+      '✗ Wrong because: <b onclick=x>y</b>',
+      '<details open ontoggle=alert(1)>',
+    ];
+    for (const f of fixtures) {
+      const out = pipe(f);
+      const stripped = out
+        .replace(/<b style="color:#dc2626">✗<\/b>/g, '')
+        .replace(/<span style="color:#b91c1c">Wrong because:<\/span>/g, '')
+        .replace(/<span style="color:#059669">Would be correct if:<\/span>/g, '')
+        .replace(/<br>/g, '');
+      expect(stripped, `fixture: ${f}`).not.toMatch(/<[a-zA-Z/!?]/);
+      expect(stripped, `fixture: ${f}`).not.toMatch(/[a-zA-Z"'/]>/);
+      const rawDouble = stripped.match(/"/g) || [];
+      const rawSingle = stripped.match(/'/g) || [];
+      expect(rawDouble.length, `fixture: ${f} (raw ")`).toBe(0);
+      expect(rawSingle.length, `fixture: ${f} (raw ')`).toBe(0);
+    }
+  });
+
+  it('sanitize-then-format contract check — formatter tags survive unescaped', () => {
+    const out = pipe('✗ foo');
+    expect(out).toMatch(/<b style="color:#dc2626">/);
+    expect(out).not.toMatch(/&lt;b style=/);
+  });
+});

--- a/tests/tagMigration.test.js
+++ b/tests/tagMigration.test.js
@@ -1,0 +1,184 @@
+/**
+ * Tests for the exam-year tag migration IIFE in shlav-a-mega.html.
+ *
+ * Geriatrics is monolithic — the migration lives inline, so we extract the
+ * actual source by regex and run it in a vm sandbox with a mock
+ * localStorage. That way the test covers the SAME bytes that ship, and the
+ * regressionGuards.test.js source-pattern check remains a second line of
+ * defence.
+ *
+ * Invariants:
+ *   1. MAP rewrites are applied across all whitelisted storage keys.
+ *   2. DROP ('2025-א') is removed from arrays and object values — split by
+ *      classification, cannot auto-migrate.
+ *   3. Sentinel `__tagMigrationV1` is set on plain-object state, NOT arrays.
+ *   4. Already-sentinel'd state is left untouched.
+ *   5. Corrupt JSON per key is swallowed per-key (other keys still migrate).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import vm from 'node:vm';
+
+const rootDir = resolve(import.meta.dirname, '..');
+const html = readFileSync(resolve(rootDir, 'shlav-a-mega.html'), 'utf-8');
+
+/**
+ * Extract the exact IIFE from shlav-a-mega.html so the test runs real
+ * source, not a copy. Fail loudly if the block can't be located — a
+ * rename or restructure should force the extractor to be updated
+ * alongside the feature.
+ */
+function extractMigrationSource() {
+  const start = html.indexOf('(function migrateExamYearTags(){');
+  if (start < 0) throw new Error('migrateExamYearTags IIFE not found in shlav-a-mega.html');
+  // Match until the closing `})();` — there is exactly one closing
+  // pattern after the start marker inside the IIFE.
+  const tail = html.slice(start);
+  const end = tail.indexOf('})();');
+  if (end < 0) throw new Error('migrateExamYearTags IIFE close not found');
+  return tail.slice(0, end + 5); // include the `})();`
+}
+
+function makeLocalStorageShim(initial = {}) {
+  const store = new Map(Object.entries(initial));
+  return {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => store.set(k, String(v)),
+    removeItem: (k) => store.delete(k),
+    clear: () => store.clear(),
+    _raw: store,
+  };
+}
+
+/**
+ * Run the extracted IIFE once against a mock localStorage.
+ * LS is 'samega' — the same constant used in shlav-a-mega.html for the
+ * primary state key.
+ */
+function runMigration(initialStore) {
+  const src = extractMigrationSource();
+  const ls = makeLocalStorageShim(initialStore);
+  const ctx = { localStorage: ls, LS: 'samega' };
+  vm.createContext(ctx);
+  vm.runInContext(src, ctx);
+  return ls;
+}
+
+describe('shlav-a-mega.html — migrateExamYearTags IIFE', () => {
+  describe('MAP rewrites', () => {
+    it('rewrites Hebrew year labels to canonical YYYY-Mon', () => {
+      const ls = runMigration({
+        samega: JSON.stringify({
+          selectedYears: ['יוני 21', 'יוני 23', 'יוני 25', 'מאי 24', 'ספט 24', '2023-ב', '2025'],
+        }),
+      });
+      const after = JSON.parse(ls.getItem('samega'));
+      expect(after.selectedYears).toEqual([
+        '2021-Jun', '2023-Jun', '2025-Jun', '2024-May', '2024-Sep', '2023-Sep', '2025-Jun',
+      ]);
+    });
+
+    it('leaves already-canonical labels alone', () => {
+      const ls = runMigration({
+        samega: JSON.stringify({ selectedYears: ['2021-Jun', '2025-Jun', 'unknown-tag'] }),
+      });
+      const after = JSON.parse(ls.getItem('samega'));
+      expect(after.selectedYears).toEqual(['2021-Jun', '2025-Jun', 'unknown-tag']);
+    });
+
+    it('walks into nested objects/arrays', () => {
+      const ls = runMigration({
+        samega: JSON.stringify({
+          filters: { exam: { pick: 'מאי 24' } },
+          tags: { q1: 'יוני 25' },
+          list: [['יוני 21']],
+        }),
+      });
+      const after = JSON.parse(ls.getItem('samega'));
+      expect(after.filters.exam.pick).toBe('2024-May');
+      expect(after.tags.q1).toBe('2025-Jun');
+      expect(after.list[0]).toEqual(['2021-Jun']);
+    });
+  });
+
+  describe('DROP semantics (2025-א)', () => {
+    it('removes 2025-א from arrays (cannot auto-migrate — split by classification)', () => {
+      const ls = runMigration({
+        samega: JSON.stringify({ selectedYears: ['יוני 21', '2025-א', '2025-Jun'] }),
+      });
+      const after = JSON.parse(ls.getItem('samega'));
+      expect(after.selectedYears).toEqual(['2021-Jun', '2025-Jun']);
+      expect(after.selectedYears).not.toContain('2025-א');
+    });
+
+    it('deletes keys whose value is 2025-א from nested objects', () => {
+      const ls = runMigration({
+        samega: JSON.stringify({ picker: { current: '2025-א', prev: 'יוני 21' } }),
+      });
+      const after = JSON.parse(ls.getItem('samega'));
+      expect(after.picker.prev).toBe('2021-Jun');
+      expect('current' in after.picker).toBe(false);
+    });
+  });
+
+  describe('idempotency sentinel', () => {
+    it('sets __tagMigrationV1 on plain-object top-level state', () => {
+      const ls = runMigration({ samega: JSON.stringify({ selectedYears: ['יוני 21'] }) });
+      const after = JSON.parse(ls.getItem('samega'));
+      expect(after.__tagMigrationV1).toBe(true);
+    });
+
+    it('does NOT rewrite a sentinel-marked state on a second pass', () => {
+      const payload = { selectedYears: ['יוני 21'], __tagMigrationV1: true };
+      const ls = runMigration({ samega: JSON.stringify(payload) });
+      const after = JSON.parse(ls.getItem('samega'));
+      // Untouched because the sentinel short-circuits the walk.
+      expect(after.selectedYears).toEqual(['יוני 21']);
+    });
+
+    it('runs end-to-end idempotently across two invocations', () => {
+      const src = extractMigrationSource();
+      const ls = makeLocalStorageShim({ samega: JSON.stringify({ selectedYears: ['יוני 25'] }) });
+      const ctx = { localStorage: ls, LS: 'samega' };
+      vm.createContext(ctx);
+      vm.runInContext(src, ctx);
+      const snapshot = ls.getItem('samega');
+      vm.runInContext(src, ctx);
+      expect(ls.getItem('samega')).toBe(snapshot);
+    });
+  });
+
+  describe('multi-key migration', () => {
+    it('migrates each whitelisted LS key independently', () => {
+      const ls = runMigration({
+        samega: JSON.stringify({ a: 'יוני 21' }),
+        samega_mock_hist: JSON.stringify({ tag: 'מאי 24' }),
+        samega_sessions: JSON.stringify({ tag: 'יוני 25' }),
+        samega_custom_qs: JSON.stringify({ tag: 'ספט 24' }),
+        samega_pending_qs: JSON.stringify({ tag: '2023-ב' }),
+      });
+      expect(JSON.parse(ls.getItem('samega')).a).toBe('2021-Jun');
+      expect(JSON.parse(ls.getItem('samega_mock_hist')).tag).toBe('2024-May');
+      expect(JSON.parse(ls.getItem('samega_sessions')).tag).toBe('2025-Jun');
+      expect(JSON.parse(ls.getItem('samega_custom_qs')).tag).toBe('2024-Sep');
+      expect(JSON.parse(ls.getItem('samega_pending_qs')).tag).toBe('2023-Sep');
+    });
+
+    it('swallows corrupt JSON on one key without aborting others', () => {
+      const ls = runMigration({
+        samega: '{not-json',
+        samega_sessions: JSON.stringify({ tag: 'יוני 21' }),
+      });
+      // Corrupt key untouched.
+      expect(ls.getItem('samega')).toBe('{not-json');
+      // Healthy key still migrated.
+      expect(JSON.parse(ls.getItem('samega_sessions')).tag).toBe('2021-Jun');
+    });
+
+    it('ignores keys that are absent', () => {
+      expect(() => runMigration({})).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Un-parked `tagMigration.test.js`** via regex-extract + `vm.createContext` harness. Pulls the actual `migrateExamYearTags` IIFE out of `shlav-a-mega.html` and runs it against a mock localStorage. Covers the Hebrew MAP (`יוני 21` → `2021-Jun` etc), `2025-א` DROP semantics, sentinel idempotency, multi-key migration, and per-key corrupt-JSON isolation. If the regex ever fails to locate the IIFE, the test fails loudly.
- **Un-parked `aiAutopsyXss.test.js`** via the same extract-and-eval pattern for `sanitize()` + the autopsy replace chain.
- **Harrison / Hazzard `?[Hebrew]` baseline scan** (`scripts/harrison-hebrew-baseline.cjs`). Found 2 real PDF-extraction bleed bugs in `Hazzard-suppl` — both fixed:
  - **Q1175 o[0]**: question-stem tail + Hebrew option marker had leaked into the option text. Split the stem back to `q` (restoring the truncated `חוסמי ביט` → `חוסמי ביטא`) and kept `o[0]` clean as `הוספת טיפול ב-APIXABAN 2.5mg פעמיים ביום`.
  - **Q3368 o[3]**: an unrelated Q25 about rollators had been concatenated onto the real distractor. Stripped to just `הירדמות מהירה ויקיצה איטית`.
- **Wired `HARRISON_HEBREW_BASELINE=0 --strict`** into `npm run verify`. Non-past-exam tags (Hazzard, Harrison, Hazzard-suppl, Exam — ~3000 Qs) were skipped by the existing wrong-side-punctuation guard. Count now 0; strict mode blocks regressions.

## Test plan

- [x] `npm test` — 14 files / 574 tests passing (was 12/551)
- [x] `npm run verify` — brace-balance + version-sync + strict scan + tests all pass
- [ ] Local `git pull` → `npm test` → merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)