### PR TITLE
hardening: ratchet Hebrew budgets + fix real boot-error XSS + harden innerHTML guard

### DIFF
--- a/scripts/check-innerhtml.py
+++ b/scripts/check-innerhtml.py
@@ -1,18 +1,83 @@
 #!/usr/bin/env python3
-"""Audit innerHTML for unsanitized interpolation in shlav-a-mega.html."""
+"""Audit innerHTML for unsanitized interpolation in shlav-a-mega.html.
+
+Rules:
+  * FAIL (exit 1) on any `.innerHTML = <expr>` where <expr> contains `+` or
+    `${...}` interpolation AND does not call `sanitize(` anywhere in the
+    assignment expression (which may span multiple lines up to the next `;`).
+  * Allow explicit opt-out via `// safe-innerhtml: <reason>` on the opening
+    line of the assignment. The reason is required so every exemption is
+    auditable by `grep`.
+
+Previously this emitted a WARNING and always exited 0, so real findings were
+invisible. Now a new violation blocks `npm run verify`.
+"""
+import re
 import sys
 
-html = open('shlav-a-mega.html').read()
-lines = html.split('\n')
-warnings = []
-for i, line in enumerate(lines, 1):
-    if '.innerHTML=' in line or '.innerHTML =' in line:
-        after_eq = line.split('innerHTML')[1]
-        if ('+' in after_eq or '${' in after_eq) and 'sanitize(' not in after_eq:
-            warnings.append(f'  Line {i}: {line.strip()[:100]}')
-if warnings:
-    print(f'WARNING: {len(warnings)} innerHTML assignments with unsanitized interpolation:')
-    for w in warnings:
-        print(w)
-else:
-    print('OK: No unsanitized innerHTML interpolation detected')
+SRC = 'shlav-a-mega.html'
+OPEN_RE = re.compile(r'\.innerHTML\s*=')
+SAFE_MARK = 'safe-innerhtml:'
+
+
+def scan(text: str):
+    lines = text.split('\n')
+    violations = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        m = OPEN_RE.search(line)
+        if not m:
+            i += 1
+            continue
+        # Skip method calls like .innerHTML=='foo' (comparison) or function refs
+        # by requiring a bare `=` not immediately followed by `=`.
+        if line[m.end():m.end() + 1] == '=':
+            i += 1
+            continue
+        start_line = i
+        # Collect the assignment expression until a terminating `;`.
+        # The naive approach: greedy read until we see a `;` at top level or
+        # end-of-statement. We don't attempt full JS parsing; we accept the
+        # expression as the concatenation of all lines until the first `;`
+        # that appears outside a string literal on the same or later lines.
+        buf = line[m.end():]
+        j = i
+        while ';' not in buf and j + 1 < n:
+            j += 1
+            buf += '\n' + lines[j]
+        # Trim at the first ; (close enough for this check)
+        expr = buf.split(';', 1)[0]
+        # Opt-out annotation on any line in the span OR on the line directly
+        # preceding the assignment (natural comment-above-statement placement).
+        lookback_start = max(0, start_line - 1)
+        annotated = any(SAFE_MARK in lines[k] for k in range(lookback_start, j + 1))
+        has_interp = '+' in expr or '${' in expr
+        has_sanitize = 'sanitize(' in expr
+        if has_interp and not has_sanitize and not annotated:
+            violations.append((start_line + 1, line.strip()[:100]))
+        i = j + 1
+    return violations
+
+
+def main():
+    try:
+        text = open(SRC, encoding='utf-8').read()
+    except FileNotFoundError:
+        print(f'ERROR: {SRC} not found', file=sys.stderr)
+        return 2
+    violations = scan(text)
+    if violations:
+        print(f'FAIL: {len(violations)} innerHTML assignments with unsanitized interpolation:')
+        for line_no, preview in violations:
+            print(f'  Line {line_no}: {preview}')
+        print('  Fix: wrap dynamic input in sanitize(), or add')
+        print('       `// safe-innerhtml: <reason>` if the input is provably static / internal.')
+        return 1
+    print('OK: No unsanitized innerHTML interpolation')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -788,6 +788,7 @@ let libSec='haz-pdf';
 let harChOpen=null,_harData=null,_harLoading=false;
 let hazChOpen=null,_hazData=null,_hazLoading=false;
 function renderTabs(){
+// safe-innerhtml: TABS is a hardcoded array of tab definitions (id/label/icon); no user input
 document.getElementById('tb').innerHTML=TABS.map(t=>
 `<button class="${t.id===tab?'on':''}" onclick="go('${t.id}')" aria-label="${t.l}" style="transition:all .15s ease"><span class="ic">${t.ic}</span>${t.l}</button>`
 ).join('');
@@ -1122,7 +1123,7 @@ function _updateWrongUI(){
   const el=document.getElementById('why-wrong-box');
   if(el){
     const labels={'no_knowledge':'📚 Didn\'t know','misread':'👓 Misread','between_2':'⚖️ Between 2','silly':'🤦 Silly mistake'};
-    el.innerHTML='<div style="font-size:10px;color:#059669;font-weight:600">✅ '+labels[_wrongReason]+'</div>';
+    el.innerHTML='<div style="font-size:10px;color:#059669;font-weight:600">✅ '+labels[_wrongReason]+'</div>'; // safe-innerhtml: labels is a static dict of 4 hardcoded emoji strings
   }
   // Unblock the next button
   const nb=document.getElementById('next-btn');
@@ -4506,7 +4507,7 @@ case'learn':
   if(learnSub==='study')_body=renderStudy();
   else if(learnSub==='flash')_body=renderFlash();
   else if(learnSub==='drugs')_body=renderDrugs();
-  el.innerHTML=_subBar+_body;}break;
+  el.innerHTML=_subBar+_body;}break; // safe-innerhtml: _subBar is static HTML; _body from internal render*() functions (no user input)
 case'study':tab='learn';learnSub='study';el.innerHTML='';render();break;
 case'flash':tab='learn';learnSub='flash';el.innerHTML='';render();break;
 case'drugs':tab='learn';learnSub='drugs';el.innerHTML='';render();break;
@@ -4528,7 +4529,7 @@ case'more':
   else if(moreSub==='search')_mBody=renderSearch();
   else if(moreSub==='chat')_mBody=renderChat();
   else if(moreSub==='feedback')_mBody=renderFeedback();
-  el.innerHTML=_moreBar+_mBody;}break;
+  el.innerHTML=_moreBar+_mBody;}break; // safe-innerhtml: _moreBar is static HTML; _mBody from internal render*() functions (no user input)
 case'search':tab='more';moreSub='search';el.innerHTML='';render();break;
 case'chat':tab='more';moreSub='chat';el.innerHTML='';render();break;
 case'book':case'syl':tab='lib';el.innerHTML=renderLibrary();break;
@@ -4988,7 +4989,7 @@ case 'close-overlay':var ov=btn.closest('[id$="-overlay"]');if(ov)ov.remove();br
 }
 });
 
-_dataPromise.then(()=>{renderTabs();render();}).catch((e)=>{console.error('Boot failed:',e);document.body.innerHTML='<div style="padding:2em;text-align:center;color:#ef4444"><h2>Failed to load app data</h2><p>'+String(e)+'</p><button onclick="location.reload()">Retry</button></div>';});
+_dataPromise.then(()=>{renderTabs();render();}).catch((e)=>{console.error('Boot failed:',e);document.body.innerHTML='<div style="padding:2em;text-align:center;color:#ef4444"><h2>Failed to load app data</h2><p>'+sanitize(String(e&&e.message||e))+'</p><button onclick="location.reload()">Retry</button></div>';});
 </script>
 </body>
 </html>

--- a/tests/contentQuality.test.js
+++ b/tests/contentQuality.test.js
@@ -67,32 +67,33 @@ describe('questions.json — encoding integrity (strict)', () => {
   });
 });
 
-describe('questions.json — formatting quality (budgeted at current baseline)', () => {
-  // FIXME: this budget should drop toward 0 as RTL-extraction artifacts get
-  // cleaned up. Current violations are mostly `?מ` / `?איזו` at the start of
-  // Hebrew stems — punctuation on the wrong side after PDF text extraction.
-  const QMARK_HEBREW_BUDGET = 128;
+describe('questions.json — formatting quality (ratchet at current baseline)', () => {
+  // Exact ratchet: test fails on ANY change (up or down). Cleanup PRs must
+  // bump this number as part of the diff — silent drift in either direction
+  // is the failure mode we're trying to prevent.
+  const QMARK_HEBREW_BASELINE = 126;
 
-  it(`no more than ${QMARK_HEBREW_BUDGET} "?\u05d0-\u05ea" occurrences (wrong-side punct from RTL mangling)`, () => {
+  it(`"?\u05d0-\u05ea" occurrences: exact ${QMARK_HEBREW_BASELINE}`, () => {
     const bad = [];
     questions.forEach((q, i) => {
       const text = [q.q, ...(q.o || [])].join(' | ');
       if (/\?[\u0590-\u05FF]/.test(text)) bad.push({ i, tag: q.t, preview: (q.q || '').slice(0, 60) });
     });
-    if (bad.length > QMARK_HEBREW_BUDGET) {
-      console.error(`?[Hebrew] count rose from baseline ${QMARK_HEBREW_BUDGET} to ${bad.length}. First 3: ${JSON.stringify(bad.slice(0, 3))}`);
+    const delta = bad.length - QMARK_HEBREW_BASELINE;
+    if (delta !== 0) {
+      const dir = delta > 0 ? 'rose' : 'dropped';
+      console.error(`?[Hebrew] count ${dir} from ${QMARK_HEBREW_BASELINE} to ${bad.length} (delta ${delta > 0 ? '+' : ''}${delta}). Update QMARK_HEBREW_BASELINE. First 3: ${JSON.stringify(bad.slice(0, 3))}`);
     }
-    expect(bad.length).toBeLessThanOrEqual(QMARK_HEBREW_BUDGET);
+    expect(bad.length).toBe(QMARK_HEBREW_BASELINE);
   });
 });
 
-describe('questions.json — duplicates (budgeted at current baseline)', () => {
-  // FIXME: this budget should drop toward 0 as known duplicates get removed.
-  // Current dupes include Q124/3381, Q191/3385, Q3382/3388, etc. — likely
-  // from a past merge that didn't dedupe before appending.
-  const DUP_BUDGET = 8;
+describe('questions.json — duplicates (ratchet at current baseline)', () => {
+  // Exact ratchet. Current dupes include Q124/3381, Q191/3385, Q3382/3388.
+  // When a dedupe PR lands, test fails → update DUP_BASELINE to new count.
+  const DUP_BASELINE = 8;
 
-  it(`no more than ${DUP_BUDGET} duplicates by first 100 chars of stem`, () => {
+  it(`duplicates by first 100 chars of stem: exact ${DUP_BASELINE}`, () => {
     const seen = new Map();
     const dupes = [];
     questions.forEach((q, i) => {
@@ -101,10 +102,12 @@ describe('questions.json — duplicates (budgeted at current baseline)', () => {
       if (seen.has(key)) dupes.push({ first: seen.get(key), second: i, preview: key.slice(0, 50) });
       else seen.set(key, i);
     });
-    if (dupes.length > DUP_BUDGET) {
-      console.error(`Duplicate count rose from baseline ${DUP_BUDGET} to ${dupes.length}. First 3: ${JSON.stringify(dupes.slice(0, 3))}`);
+    const delta = dupes.length - DUP_BASELINE;
+    if (delta !== 0) {
+      const dir = delta > 0 ? 'rose' : 'dropped';
+      console.error(`Duplicate count ${dir} from ${DUP_BASELINE} to ${dupes.length} (delta ${delta > 0 ? '+' : ''}${delta}). Update DUP_BASELINE. First 3: ${JSON.stringify(dupes.slice(0, 3))}`);
     }
-    expect(dupes.length).toBeLessThanOrEqual(DUP_BUDGET);
+    expect(dupes.length).toBe(DUP_BASELINE);
   });
 });
 

--- a/tests/regressionGuards.test.js
+++ b/tests/regressionGuards.test.js
@@ -82,10 +82,12 @@ describe('questions.json — formatting quality', () => {
   const PAST_EXAM_TAGS = ['2020', '2021', '2021-Jun', '2022', '2023-Jun', '2023-Sep', '2024-May', '2024-Sep', '2025-Jun'];
   beforeAll(() => { questions = loadJSON('data/questions.json'); });
 
-  // Catches "בן58" → should be "בן 58". Geriatrics has a large legacy backlog
-  // of 580+ pre-existing cases — budget loosened to 600 so CI flags regressions
-  // without forcing a full cleanup pass.
-  test('Hebrew-digit missing-space count does not regress (<=600)', () => {
+  // Catches "בן58" → should be "בן 58". Geriatrics has a legacy backlog
+  // in past-exam PDFs — exact ratchet at current count so cleanup PRs are
+  // visible (test fails → bump the number → proof of progress). Previous
+  // `<=600` hid silent drift in either direction.
+  const HEBREW_DIGIT_BASELINE = 575;
+  test(`Hebrew-digit missing-space (past-exam): exact ${HEBREW_DIGIT_BASELINE}`, () => {
     const bad = [];
     questions.forEach((q, i) => {
       if (!PAST_EXAM_TAGS.includes(q.t)) return;
@@ -94,15 +96,19 @@ describe('questions.json — formatting quality', () => {
         bad.push({ i, tag: q.t });
       }
     });
-    if (bad.length > 600) {
-      console.error(`Hebrew+digit (no space) in ${bad.length} Qs (budget 600):`, bad.slice(0, 3));
+    const delta = bad.length - HEBREW_DIGIT_BASELINE;
+    if (delta !== 0) {
+      const dir = delta > 0 ? 'rose' : 'dropped';
+      console.error(`Hebrew+digit count ${dir} from ${HEBREW_DIGIT_BASELINE} to ${bad.length} (delta ${delta > 0 ? '+' : ''}${delta}). Update HEBREW_DIGIT_BASELINE.`);
     }
-    expect(bad.length).toBeLessThanOrEqual(600);
+    expect(bad.length).toBe(HEBREW_DIGIT_BASELINE);
   });
 
   // Catches `?גבוהה` (question mark on wrong side after RTL mangling).
-  // Loosened budget for Geriatrics legacy corpus.
-  test('wrong-side ?[Hebrew] count does not regress (<=150)', () => {
+  // Exact ratchet at current count. When cleanup happens, test fails,
+  // update the baseline number in the same PR.
+  const QMARK_HEBREW_BASELINE = 126;
+  test(`wrong-side ?[Hebrew] (past-exam): exact ${QMARK_HEBREW_BASELINE}`, () => {
     const bad = [];
     questions.forEach((q, i) => {
       if (!PAST_EXAM_TAGS.includes(q.t)) return;
@@ -111,10 +117,12 @@ describe('questions.json — formatting quality', () => {
         bad.push({ i, tag: q.t });
       }
     });
-    if (bad.length > 150) {
-      console.error(`?[Hebrew] in ${bad.length} Qs:`, bad.slice(0, 3));
+    const delta = bad.length - QMARK_HEBREW_BASELINE;
+    if (delta !== 0) {
+      const dir = delta > 0 ? 'rose' : 'dropped';
+      console.error(`?[Hebrew] count ${dir} from ${QMARK_HEBREW_BASELINE} to ${bad.length} (delta ${delta > 0 ? '+' : ''}${delta}). Update QMARK_HEBREW_BASELINE.`);
     }
-    expect(bad.length).toBeLessThanOrEqual(150);
+    expect(bad.length).toBe(QMARK_HEBREW_BASELINE);
   });
 
   // Catches content bleed: stem contains DIGIT-DOT followed by question-opener word.


### PR DESCRIPTION
## Summary

Four tightenings on top of #55:

1. **`regressionGuards` past-exam budgets** from `<=600` / `<=150` to exact `575` / `126` at current count. Exact-match forces cleanup PRs to bump the baseline visibly; silent drift in either direction was the failure mode we're preventing.
2. **`contentQuality` budgets** from `<=128` / `<=8` to exact `126` / `8`. (The whole-corpus `?[Hebrew]` count happens to match the past-exam-only count now that Hazzard-suppl is clean.)
3. **Real XSS fix in boot error handler** — `shlav-a-mega.html` line 4991 dumped `String(e)` of caught errors straight into `document.body.innerHTML`. A malicious server-side error message could have executed script in the boot fallback. Wrapped with `sanitize(String(e&&e.message||e))`.
4. **`check-innerhtml.py` hardened** — multi-line aware (tracks the full assignment expression up to the next `;`), respects `// safe-innerhtml: <reason>` annotation in the span or on the line directly preceding, and now FAILS exit 1 instead of printing a warning and exiting 0. The old per-line scan missed the `renderTabs()` case on line 791 — now caught and annotated.

Annotated 4 safe-by-design sites (renderTabs over static TABS, the hardcoded `labels` dict, `_subBar+_body`, `_moreBar+_mBody`) so any NEW innerHTML+interpolation site without an explicit reason blocks the build.

## Test plan

- [x] `npm test` — 14 files / 574 tests
- [x] `npm run verify` — brace-balance + innerHTML + strict Hebrew + tests all green, no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)