### PR TITLE
UX: make confidence emoji optional + fix 'Read: Hazzard Ch X' nav

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "9.61.0",
+  "version": "9.62.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -1606,7 +1606,7 @@ h+=`<div style="margin-bottom:8px;font-size:10px;color:rgb(var(--fg2));font-weig
 </div>`;
 }
 const _confLabel=_confidence===0?'😬':_confidence===1?'🤔':_confidence===2?'😎':'';
-h+=`<button class="btn btn-p" onclick="check()"${sel===null||(!examMode&&_confidence===null)?' disabled':''} aria-label="Check answer">${_confLabel} בדוק</button>`;if(!examMode)h+=`<button class="btn" onclick="showAnswerHardFail()" style="background:rgb(var(--yellow-bg));color:rgb(var(--yellow-fg));font-size:11px;padding:6px 14px;margin-left:6px;border:1px solid rgb(var(--yellow-brd))" aria-label="Show answer">👁 לא יודע</button>`;}
+h+=`<button class="btn btn-p" onclick="check()"${sel===null?' disabled':''} aria-label="Check answer">${_confLabel} בדוק</button>`;if(!examMode)h+=`<button class="btn" onclick="showAnswerHardFail()" style="background:rgb(var(--yellow-bg));color:rgb(var(--yellow-fg));font-size:11px;padding:6px 14px;margin-left:6px;border:1px solid rgb(var(--yellow-brd))" aria-label="Show answer">👁 לא יודע</button>`;}
 else{
 // Feature 1: Why-wrong classification (required after wrong, non-exam)
 if(!examMode&&sel!==q.c&&!_wrongReason){
@@ -1622,7 +1622,7 @@ h+=`<div id="why-wrong-box" style="display:inline-flex;align-items:center;gap:4p
 if(!examMode&&sel!==q.c&&q.ti>=0){
 const _chRef=TOPIC_REF[q.ti];
 if(_chRef&&_chRef.s==='haz'){
-h+=`<button class="btn" onclick="tab='lib';libSec='harrison';render()" style="font-size:10px;padding:5px 12px;background:rgb(var(--blue-bg));color:rgb(var(--blue-fg));border:1px solid rgb(var(--blue-brd));margin-bottom:6px;width:100%">📖 Read: ${_chRef.l} — you're weak here</button>`;
+h+=`<button class="btn" onclick="tab='lib';libSec='haz-pdf';openHazzardChapter(${sanitize(String(_chRef.ch))})" style="font-size:10px;padding:5px 12px;background:rgb(var(--blue-bg));color:rgb(var(--blue-fg));border:1px solid rgb(var(--blue-brd));margin-bottom:6px;width:100%">📖 Read: ${sanitize(_chRef.l)} — you're weak here</button>`;
 }
 }
 // Difficulty + Next on same row
@@ -4594,8 +4594,9 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='9.61';
+const APP_VERSION='9.62';
 const CHANGELOG={
+'9.62': ['UX: "How sure are you?" (😬 🤔 😎) כבר לא חוסם את כפתור בדוק — הפך לאופציונלי. אפשר עדיין ללחוץ על אחת האמוג\'ים, אבל לא חייבים.', 'תיקון: כפתור "Read: Hazzard Ch X — you\'re weak here" מנווט עכשיו ישירות לפרק הספציפי (נפתח Hazzard chapter viewer עם התוכן) במקום לפתוח את הסקציה הלא-נכונה (Harrison) של מדף הספרייה'],
 '9.61': ['📝 85 הסברים חדשים נכתבו לשאלות עם שדה e ריק (Claude Sonnet 4.5, פורמט סטנדרטי: התשובה הנכונה / למה נכונה / למה אחרות שגויות / נקודת מפתח לקשיש)', 'סטנדרטיזציית תגיות מבחן לפורמט קנוני YYYY-Mon: יוני 21→2021-Jun, יוני 23→2023-Jun, יוני 25→2025-Jun, מאי 24→2024-May, ספט 24→2024-Sep, 2023-ב→2023-Sep', '2025-א (65 שאלות ייחודיות) סווג: 41 וינייטות→2025-Jun, 24 תיאוריה→Hazzard-suppl; 24 דופליקטים ישירים עם יוני 25 הוסרו', 'מיגרציית localStorage אוטומטית עם סנטינל __tagMigrationV1 — לא מאבדים נתוני משתמש קיימים', 'פילטר רב-בחירה לשנות מבחן (UI הופץ מ-Pnimit) — ניתן לסמן כמה שנים יחד, ספירה לכל שנה, שורה נפרדת ממקורות תוכן', 'בדיקות רגרסיה חדשות (regressionGuards.test.js, 42 בדיקות) — תופסות mojibake, duplicates, שבר שאלות, תגיות לא מזוהות, סנכרון גרסת SW', 'סה"כ שאלות: 3,406 (מ-3,430 — 24 דופליקטים הוסרו)'],
 '9.60': ['🚨 11 שאלות של יוני 23 (בסיס) תוקנו — c שגוי לפי מפתח התשובות הרשמי המעודכן של הר"י', 'שיעור שגיאות: 11/137 = 8% (טוב משמעותית מ-מאי 24 שהיה 61%) — מעיד שהייבוא של יוני 23 תקין ביסודו אבל עם שגיאות נקודתיות', 'תיקונים: Q12 הרפס זוסטר פנים "מעקב"→"ACYCLOVIR 800", Q24 DM+אלצהיימר A1C 11% "אינסולין קצר"→"אינסולין ארוך", Q36 BPH אי-שליטה "ציסטוסקופיה"→"UA+קולטורה", Q56 Lancet 2020 "חבלת ראש"→"ירידה בשמיעה", Q70 ADA 2022 "הפסקת סטטינים"→"APIDRA→SITAGLIPTIN"', 'עוד: Q81 MMSE discrepancy "שונות בין בודקים"→"LBD fluctuations", Q112 FUO "ביופסיית כבד"→"ביופסיית עורק טמפורלי", Q122 hypoxia "hypoventilation"→"V/Q mismatch", Q131 LFTs cholestatic "סרולוגיה hep"→"US כבד/מרה", Q145 metabolic alkalosis "כליה"→"FUROSEMIDE", Q147 Li+Na 155 "nDI"→"ירידה בשתיה"', '🔍 ממצא משני: idx 1393 מכיל Q105+Q106 מאוחדות (באג ייבוא) — לא תוקן, דורש פירוק ידני. Q106 חסרה מהריפו.', '10 מ-150 שאלות הבסיס חסרות (רובן תמונה-תלויות): Q5, Q67, Q101, Q109, Q125, Q139, Q148 ועוד'],
 '9.59': ['🚨 82 שאלות של מאי 24 (בסיס) תוקנו — c שגוי ב-132/150 שאלות שתויגו שגוי כ-"ספט 24"', 'מקור: PDF רשמי של מפתח התשובות המעודכן של הר"י (פרסום 138, מאי 2024) — 10 שינויים מהמפתח המקורי', 'אבחנה: 81 שאלות עם תשובה שלא תואמת לא את המפתח המקורי ולא המעודכן — באג נתונים אמיתי, לא drift של מפתח', 'דוגמאות: Q1 DPP "יעילות שווה"→"שינוי אורחות חיים עדיף", Q9 עצירות "BISACODYL"→"PEG", Q40 שפעת/RSV "OSELTAMIVIR"→"פחות אשפוזים ב-RSV"', 'כל תיקון תועד ב-e עם מעבר האותיות (למשל "א → ב") ומקור רשמי', 'שגיאות ברות זיהוי: Q100 outdated (מפתח עודכן מ-ג ל-ד), 81 אחרות פשוט שגויות במקור'],

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v9.61';
+const CACHE='shlav-a-v9.62';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','src/storage.js','src/sw-update.js'];
 const JSON_DATA_URLS=['data/questions.json','data/topics.json','data/notes.json','data/drugs.json','data/flashcards.json','harrison_chapters.json','data/hazzard_chapters.json','data/tabs.json'];
 const ALL_URLS=[...HTML_URLS,...JSON_DATA_URLS];


### PR DESCRIPTION
## Summary

Two quiz UX fixes based on direct feedback — mirror of the InternalMedicine PR, plus an extra Geriatrics-specific bug in the chapter nav.

### 1. Confidence emoji picker is now optional

The "How sure are you?" row (😬 🤔 😎) was a hard gate — the בדוק button was `disabled` until you picked one. Now it's optional.

**Change:** dropped `(!examMode && _confidence === null)` from the check-answer `disabled` condition.

### 2. "Read: Hazzard Ch X — you're weak here" now actually opens the chapter

The button was **doubly broken**:

- It set `libSec='harrison'` — wrong section entirely. The `TOPIC_REF` entries have `s:'haz'` meaning **Hazzard**, not Harrison. Clicking the button threw you into the wrong textbook.
- Even if the section had been right, it never called `openHazzardChapter(ch)` — so you'd still have landed on an index, not the chapter content.

**Change:** set `libSec='haz-pdf'` and call `openHazzardChapter(${_chRef.ch})`. Both `_chRef.ch` and `_chRef.l` are now `sanitize()`-wrapped so the new per-piece innerHTML checker stays green.

## Version

9.61 → 9.62 (APP_VERSION + sw.js CACHE + package.json).

## Test plan

- [x] `npm run verify` green (14/14 test files, 574/574 tests)
- [ ] Manual: answer → click בדוק without picking confidence → should proceed
- [ ] Manual: get Q wrong on a topic with a Hazzard mapping (e.g. Depression → Ch 62) → click "📖 Read: Hazzard Ch 62" → should open the Hazzard chapter viewer for Ch 62, not the Harrison index

🤖 Generated with [Claude Code](https://claude.com/claude-code)
