### PR TITLE
UX follow-up: why-wrong optional + TOPIC_REF test + pre-push hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "geriatrics",
-  "version": "9.62.0",
+  "version": "9.63.0",
   "private": true,
   "type": "module",
   "scripts": {
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "hooks:install": "git config core.hooksPath scripts/git-hooks && echo '✓ pre-commit + pre-push hooks active'",
     "verify": "node --check src/sw-update.js && python3 scripts/check-version-sync.py && python3 scripts/check-brace-balance.py && python3 scripts/check-innerhtml.py && python3 scripts/check-innerhtml-pieces.py && HARRISON_HEBREW_BASELINE=0 node scripts/harrison-hebrew-baseline.cjs --strict && vitest run",
     "image:check": "node scripts/add-image-question.cjs --help"
   },

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Pre-push hook: run both innerHTML safety checkers before allowing push.
+#
+# Install (one-time):
+#   cp scripts/git-hooks/pre-push .git/hooks/pre-push && chmod +x .git/hooks/pre-push
+# Or globally:
+#   git config core.hooksPath scripts/git-hooks
+#
+# Runs:
+#   1. check-innerhtml.py          — catches unsafe `.innerHTML = ` template literals
+#   2. check-innerhtml-pieces.py   — catches partial-sanitize (e.g. `${sanitize(a)} ${b}`)
+#
+# These are the same checks `npm run verify` runs, but gated at the push
+# boundary so a rushed `git push` can't ship a regression.
+
+set -e
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+FAIL=0
+
+if ! python3 scripts/check-innerhtml.py; then
+  echo ""
+  echo "❌ pre-push: check-innerhtml.py found unsafe innerHTML assignment."
+  FAIL=1
+fi
+
+if ! python3 scripts/check-innerhtml-pieces.py; then
+  echo ""
+  echo "❌ pre-push: check-innerhtml-pieces.py found partial-sanitize gap."
+  FAIL=1
+fi
+
+if [ "$FAIL" = "1" ]; then
+  echo ""
+  echo "Fix the flagged site(s), or bypass with 'git push --no-verify' (not recommended)."
+  exit 1
+fi
+
+exit 0

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -1625,8 +1625,7 @@ if(_chRef&&_chRef.s==='haz'){
 h+=`<button class="btn" onclick="tab='lib';libSec='haz-pdf';openHazzardChapter(${sanitize(String(_chRef.ch))})" style="font-size:10px;padding:5px 12px;background:rgb(var(--blue-bg));color:rgb(var(--blue-fg));border:1px solid rgb(var(--blue-brd));margin-bottom:6px;width:100%">📖 Read: ${sanitize(_chRef.l)} — you're weak here</button>`;
 }
 }
-// Difficulty + Next on same row
-const _blocked=!examMode&&sel!==q.c&&!_wrongReason;
+// Difficulty + Next on same row — why-wrong picker is a nudge, not a gate
 h+=`<div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap">`;
 if(!examMode){
 h+=`<div style="display:flex;gap:3px;align-items:center">
@@ -1635,7 +1634,7 @@ h+=`<div style="display:flex;gap:3px;align-items:center">
 <button class="btn" style="font-size:9px;padding:3px 7px;${_diffRating==='hard'?'background:rgb(var(--red-bg));color:rgb(var(--red-fg))':'background:rgb(var(--bg2));color:rgb(var(--fg3))'}" onclick="_diffRating='hard';_storeDiff(pool[qi],'hard')">Hard</button>
 </div>`;
 }
-h+=`<button id="next-btn" class="btn btn-d" onclick="next()"${_blocked?' disabled':''} style="margin-left:auto;${_blocked?'opacity:0.5':''}" aria-label="${examMode&&qi+1>=150?'Finish exam':'Next question'}">${examMode&&qi+1>=150?'סיים':'הבאה ←'}</button>`;
+h+=`<button id="next-btn" class="btn btn-d" onclick="next()" style="margin-left:auto" aria-label="${examMode&&qi+1>=150?'Finish exam':'Next question'}">${examMode&&qi+1>=150?'סיים':'הבאה ←'}</button>`;
 if(!examMode&&ans){
 h+=`<button onclick="document.getElementById('report-wrong-expand').style.display=document.getElementById('report-wrong-expand').style.display==='none'?'block':'none'" style="font-size:8px;padding:2px 6px;background:none;color:rgb(var(--fg3));cursor:pointer;border:none" title="Report wrong answer key">⚠️</button>`;
 }
@@ -4594,8 +4593,9 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='9.62';
+const APP_VERSION='9.63';
 const CHANGELOG={
+'9.63': ['UX: "Why did I get it wrong?" (📚 👓 ⚖️ 🤦) כבר לא חוסם את כפתור "הבאה" — הפך לאופציונלי. בסוויט הקודם הפכנו את "How sure are you" לאופציונלי; עכשיו גם שורת ה-why-wrong שלמטה אופציונלית.', 'טסט חדש: topicRefCoverage — מוודא שכל entry ב-TOPIC_REF מצביע לפרק שקיים ב-data/hazzard_chapters.json, ושכל onclick שקורא ל-openHazzardChapter מגיע דרך libSec=haz-pdf (מונע את הבאג של 9.62 שהגיע ל-libSec=harrison).', 'Pre-push hook חדש: `scripts/git-hooks/pre-push` מריץ את שני בודקי innerHTML לפני כל push. התקנה ב-`npm run hooks:install`.'],
 '9.62': ['UX: "How sure are you?" (😬 🤔 😎) כבר לא חוסם את כפתור בדוק — הפך לאופציונלי. אפשר עדיין ללחוץ על אחת האמוג\'ים, אבל לא חייבים.', 'תיקון: כפתור "Read: Hazzard Ch X — you\'re weak here" מנווט עכשיו ישירות לפרק הספציפי (נפתח Hazzard chapter viewer עם התוכן) במקום לפתוח את הסקציה הלא-נכונה (Harrison) של מדף הספרייה'],
 '9.61': ['📝 85 הסברים חדשים נכתבו לשאלות עם שדה e ריק (Claude Sonnet 4.5, פורמט סטנדרטי: התשובה הנכונה / למה נכונה / למה אחרות שגויות / נקודת מפתח לקשיש)', 'סטנדרטיזציית תגיות מבחן לפורמט קנוני YYYY-Mon: יוני 21→2021-Jun, יוני 23→2023-Jun, יוני 25→2025-Jun, מאי 24→2024-May, ספט 24→2024-Sep, 2023-ב→2023-Sep', '2025-א (65 שאלות ייחודיות) סווג: 41 וינייטות→2025-Jun, 24 תיאוריה→Hazzard-suppl; 24 דופליקטים ישירים עם יוני 25 הוסרו', 'מיגרציית localStorage אוטומטית עם סנטינל __tagMigrationV1 — לא מאבדים נתוני משתמש קיימים', 'פילטר רב-בחירה לשנות מבחן (UI הופץ מ-Pnimit) — ניתן לסמן כמה שנים יחד, ספירה לכל שנה, שורה נפרדת ממקורות תוכן', 'בדיקות רגרסיה חדשות (regressionGuards.test.js, 42 בדיקות) — תופסות mojibake, duplicates, שבר שאלות, תגיות לא מזוהות, סנכרון גרסת SW', 'סה"כ שאלות: 3,406 (מ-3,430 — 24 דופליקטים הוסרו)'],
 '9.60': ['🚨 11 שאלות של יוני 23 (בסיס) תוקנו — c שגוי לפי מפתח התשובות הרשמי המעודכן של הר"י', 'שיעור שגיאות: 11/137 = 8% (טוב משמעותית מ-מאי 24 שהיה 61%) — מעיד שהייבוא של יוני 23 תקין ביסודו אבל עם שגיאות נקודתיות', 'תיקונים: Q12 הרפס זוסטר פנים "מעקב"→"ACYCLOVIR 800", Q24 DM+אלצהיימר A1C 11% "אינסולין קצר"→"אינסולין ארוך", Q36 BPH אי-שליטה "ציסטוסקופיה"→"UA+קולטורה", Q56 Lancet 2020 "חבלת ראש"→"ירידה בשמיעה", Q70 ADA 2022 "הפסקת סטטינים"→"APIDRA→SITAGLIPTIN"', 'עוד: Q81 MMSE discrepancy "שונות בין בודקים"→"LBD fluctuations", Q112 FUO "ביופסיית כבד"→"ביופסיית עורק טמפורלי", Q122 hypoxia "hypoventilation"→"V/Q mismatch", Q131 LFTs cholestatic "סרולוגיה hep"→"US כבד/מרה", Q145 metabolic alkalosis "כליה"→"FUROSEMIDE", Q147 Li+Na 155 "nDI"→"ירידה בשתיה"', '🔍 ממצא משני: idx 1393 מכיל Q105+Q106 מאוחדות (באג ייבוא) — לא תוקן, דורש פירוק ידני. Q106 חסרה מהריפו.', '10 מ-150 שאלות הבסיס חסרות (רובן תמונה-תלויות): Q5, Q67, Q101, Q109, Q125, Q139, Q148 ועוד'],

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v9.62';
+const CACHE='shlav-a-v9.63';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','src/storage.js','src/sw-update.js'];
 const JSON_DATA_URLS=['data/questions.json','data/topics.json','data/notes.json','data/drugs.json','data/flashcards.json','harrison_chapters.json','data/hazzard_chapters.json','data/tabs.json'];
 const ALL_URLS=[...HTML_URLS,...JSON_DATA_URLS];

--- a/tests/topicRefCoverage.test.js
+++ b/tests/topicRefCoverage.test.js
@@ -1,0 +1,119 @@
+/**
+ * Guards TOPIC_REF → hazzard_chapters.json coverage.
+ *
+ * Every TOPIC_REF entry with s:'haz' has a .ch that powers the
+ * "📖 Read: Hazzard Ch X — you're weak here" button in the quiz view
+ * (calling openHazzardChapter). If .ch doesn't exist as a key in
+ * data/hazzard_chapters.json the button silently lands on empty content.
+ *
+ * The section-mismatch bug shipped in 9.61 (libSec='harrison' for 'haz'
+ * refs) is prevented by a source-level grep in regressionGuards.test.js;
+ * this test is the second layer — proving the chapters themselves exist.
+ *
+ * Geriatrics is monolithic, so we extract TOPIC_REF by regex and eval it
+ * in a vm sandbox to cover the exact bytes that ship.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import vm from 'node:vm';
+
+const rootDir = resolve(import.meta.dirname, '..');
+const html = readFileSync(resolve(rootDir, 'shlav-a-mega.html'), 'utf-8');
+const chapters = JSON.parse(
+  readFileSync(resolve(rootDir, 'data/hazzard_chapters.json'), 'utf-8'),
+);
+
+/**
+ * Extract `const TOPIC_REF = { ... };` block from the HTML monolith.
+ * Balance-aware so comments and nested braces don't throw it off.
+ */
+function extractTopicRef(src) {
+  const marker = 'const TOPIC_REF=';
+  const i = src.indexOf(marker);
+  if (i < 0) throw new Error('TOPIC_REF declaration not found in shlav-a-mega.html');
+  const openBrace = src.indexOf('{', i);
+  let depth = 0;
+  let end = -1;
+  for (let j = openBrace; j < src.length; j++) {
+    const c = src[j];
+    if (c === '{') depth++;
+    else if (c === '}') {
+      depth--;
+      if (depth === 0) { end = j; break; }
+    }
+  }
+  if (end < 0) throw new Error('Could not balance TOPIC_REF braces');
+  return src.slice(openBrace, end + 1);
+}
+
+const literal = extractTopicRef(html);
+const ctx = { TOPIC_REF: null };
+vm.createContext(ctx);
+vm.runInContext(`TOPIC_REF = ${literal};`, ctx);
+const TOPIC_REF = ctx.TOPIC_REF;
+
+describe('TOPIC_REF → Hazzard chapter coverage', () => {
+  it('extracted at least one entry (regex sanity check)', () => {
+    expect(Object.keys(TOPIC_REF).length).toBeGreaterThan(0);
+  });
+
+  it('every Hazzard ref (.s==="haz") resolves to a chapter in hazzard_chapters.json', () => {
+    const misses = [];
+    for (const [ti, ref] of Object.entries(TOPIC_REF)) {
+      if (!ref || ref.s !== 'haz') continue;
+      if (!chapters[String(ref.ch)]) {
+        misses.push({ ti, ch: ref.ch, label: ref.l });
+      }
+    }
+    expect(
+      misses,
+      `TOPIC_REF entries pointing at nonexistent chapters: ${JSON.stringify(misses, null, 2)}`,
+    ).toEqual([]);
+  });
+
+  it('every Hazzard ref has a positive integer .ch and a label', () => {
+    for (const [ti, ref] of Object.entries(TOPIC_REF)) {
+      if (!ref || ref.s !== 'haz') continue;
+      expect(Number.isInteger(ref.ch), `TOPIC_REF[${ti}].ch is not an integer`).toBe(true);
+      expect(ref.ch, `TOPIC_REF[${ti}].ch must be positive`).toBeGreaterThan(0);
+      expect(typeof ref.l, `TOPIC_REF[${ti}].l must be a string`).toBe('string');
+      expect(ref.l.length, `TOPIC_REF[${ti}].l must be non-empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it('TOPIC_REF only uses the whitelisted source keys {haz, notes}', () => {
+    const allowedSources = new Set(['haz', 'notes']);
+    for (const [ti, ref] of Object.entries(TOPIC_REF)) {
+      if (!ref) continue;
+      expect(
+        allowedSources.has(ref.s),
+        `TOPIC_REF[${ti}].s="${ref.s}" — expected 'haz' or 'notes'`,
+      ).toBe(true);
+    }
+  });
+
+  it('the quiz-view read-chapter button wires to libSec=haz-pdf (not the wrong section)', () => {
+    // Regression guard for 9.61 bug where button set libSec='harrison' for Hazzard refs.
+    const readButtonMatches = html.match(
+      /onclick="[^"]*📖[^"]*"|onclick="tab='lib';libSec='[^']+';openHazzardChapter/g,
+    );
+    // Find any button that calls openHazzardChapter — it MUST route through libSec='haz-pdf'
+    const badRoutes = [];
+    const regex = /onclick="([^"]*openHazzardChapter[^"]*)"/g;
+    let m;
+    while ((m = regex.exec(html)) !== null) {
+      const onclick = m[1];
+      // If onclick sets libSec to anything other than haz-pdf, flag it.
+      const libSecSet = onclick.match(/libSec='([^']+)'/);
+      if (libSecSet && libSecSet[1] !== 'haz-pdf') {
+        badRoutes.push({ onclick, wrongSec: libSecSet[1] });
+      }
+    }
+    expect(
+      badRoutes,
+      `openHazzardChapter calls routed through wrong libSec: ${JSON.stringify(badRoutes, null, 2)}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Mirror of the InternalMedicine follow-up.

### 1. Why-wrong picker is now a nudge, not a gate
The 📚👓⚖️🤦 row below the wrong-answer feedback was blocking the **Next** button. Same fix as 9.62 confidence picker — now optional.

### 2. TOPIC_REF coverage test (`tests/topicRefCoverage.test.js`)
Guards **two** invariants, the second of which is a direct regression guard against the 9.62 bug that shipped:
- **(a)** Every `s:'haz'` ref resolves to a chapter key in `data/hazzard_chapters.json`.
- **(b)** Every `onclick` calling `openHazzardChapter` routes through `libSec='haz-pdf'`. The 9.62 bug was `libSec='harrison'` baked into Hazzard refs — button opened the wrong library section entirely. This test would have caught it.

Geriatrics is monolithic, so the test regex-extracts `TOPIC_REF` and `vm.runInContext`s it — runs against the exact bytes that ship.

### 3. Pre-push hook (`scripts/git-hooks/pre-push`)
Runs both innerHTML checkers before allowing push. Install:
```
npm run hooks:install
```

## Version
9.62 → 9.63 (APP_VERSION + sw.js CACHE + package.json synced).

## Test plan
- [x] `npm run verify` green (15 test files → up from 14; 579 tests → up from 574)
- [x] Pre-push hook smoke-test: `bash scripts/git-hooks/pre-push` → green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
