### PR TITLE
feat: time-to-answer signals per question

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "9.64.0",
+  "version": "9.65.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -778,6 +778,38 @@ function getDueQuestions(){
 const now=Date.now();
 return Object.entries(S.sr).filter(([k,v])=>v.next<=now).map(([k])=>parseInt(k)).slice(0,20);
 }
+// Time-to-answer signal helpers.
+// Median of S.sr[i].at across all questions in topic `ti` with recorded time.
+// Returns null if fewer than 3 samples — median isn't meaningful with less.
+function topicMedianTime(ti){
+  if(ti===undefined||ti===null||ti<0)return null;
+  const samples=[];
+  Object.entries(S.sr).forEach(([k,v])=>{
+    const q=QZ[k];if(!q||q.ti!==ti)return;
+    if(typeof v.at==='number'&&v.at>0)samples.push(v.at);
+  });
+  if(samples.length<3)return null;
+  samples.sort((a,b)=>a-b);
+  const mid=samples.length>>1;
+  return samples.length%2?samples[mid]:Math.round((samples[mid-1]+samples[mid])/2);
+}
+// Global median across all recorded answer times — used when topic median is unavailable.
+function globalMedianTime(){
+  const samples=[];
+  Object.entries(S.sr).forEach(([k,v])=>{
+    if(typeof v.at==='number'&&v.at>0)samples.push(v.at);
+  });
+  if(samples.length<3)return null;
+  samples.sort((a,b)=>a-b);
+  const mid=samples.length>>1;
+  return samples.length%2?samples[mid]:Math.round((samples[mid-1]+samples[mid])/2);
+}
+// Count of questions currently meeting the Slow filter criterion (avg >60s).
+function slowQuestionCount(){
+  let n=0;
+  Object.values(S.sr).forEach(v=>{if(typeof v.at==='number'&&v.at>60)n++;});
+  return n;
+}
 
 const HARRISON_PDF_MAP={"14":"harrison/Ch14_Pain_Pathophysiology_and_Management.pdf","15":"harrison/Ch15_Chest_Discomfort.pdf","16":"harrison/Ch16_Abdominal_Pain.pdf","17":"harrison/Ch17_Headache.pdf","18":"harrison/Ch18_Low_back_pain.pdf","20":"harrison/Ch20_Fever.pdf","22":"harrison/Ch22_Fever_of_Unknown_Origin.pdf","26":"harrison/Ch026_Neurologic_Causes_of_Weakness_and_Paralysis.pdf","30":"harrison/Ch30_Coma.pdf","39":"harrison/Ch39_Dyspnea.pdf","40":"harrison/Ch40_Cough.pdf","41":"harrison/Ch41_Hemoptysis.pdf","42":"harrison/Ch42_Hypoxia_and_Cyanosis.pdf","43":"harrison/Ch43_Edema.pdf","48":"harrison/Ch48_Nausea_Vomiting_and_Indigestion.pdf","49":"harrison/Ch49_Diarrhea_and_Constipation.pdf","50":"harrison/Ch50_Unintentional_Weight_Loss.pdf","51":"harrison/Ch51_Gastrointestinal_Bleeding.pdf","52":"harrison/Ch52_Jaundice.pdf","53":"harrison/Ch53_Abdominal_Swelling_and_Ascites.pdf","55":"harrison/Ch55_Azotemia_and_Urinary_Abnormalities.pdf","56":"harrison/Ch56_Fluid_and_Electrolyte_Disturbances.pdf","57":"harrison/Ch57_Hypercalcemia_and_Hypocalcemia.pdf","58":"harrison/Ch58_Acidosis_and_Alkalosis.pdf","66":"harrison/Ch66_Anemia_and_Polycythemia.pdf","67":"harrison/Ch67_Disorders_of_Granulocytes_and_Monocytes.pdf","69":"harrison/Ch69_Bleeding_and_Thrombosis.pdf","70":"harrison/Ch70_Enlargement_of_Lymph_Nodes_and_Spleen.pdf","79":"harrison/Ch79_Infections_in_Patients_with_Cancer.pdf","80":"harrison/Ch80_Oncologic_Emergencies.pdf","102":"harrison/Ch102_Iron_Deficiency_and_Other_Hypoproliferat.pdf","120":"harrison/Ch120_Disorders_of_Platelets_and_Vessel_Wall.pdf","121":"harrison/Ch121_Coagulation_Disorders.pdf","127":"harrison/Ch127_Approach_to_the_Acutely_Ill_Infected_Febrile_.pdf","133":"harrison/Ch133_Infective_Endocarditis.pdf","136":"harrison/Ch136_Osteomyelitis.pdf","142":"harrison/Ch142_Encephalitis.pdf","143":"harrison/Ch143_Acute_Meningitis.pdf","147":"harrison/Ch147_Infections_Acquired_in_Health_Care_Facilities.pdf","243":"harrison/Ch243_Approach_to_the_Patient_with_Possible_Cardiov.pdf","247":"harrison/Ch247_Electrocardiography.pdf","285":"harrison/Ch285_Non-ST-Segment_Elevation_Acute_Coronary_Syndr.pdf","286":"harrison/Ch286_ST-Segment_Elevation_Myocardial_Infarction.pdf","295":"harrison/Ch295_Approach_to_the_Patient_with_Disease_of_the_R.pdf","305":"harrison/Ch305_Disorders_of_the_Pleura.pdf","311":"harrison/Ch311_Approach_to_the_Patient_with_Critical_Illness.pdf","314":"harrison/Ch314_Approach_to_the_Patient_with_Shock.pdf","315":"harrison/Ch315_Sepsis_and_Septic_Shock.pdf","316":"harrison/Ch316_Cardiogenic_Shock_and_Pulmonary_Edema.pdf","317":"harrison/Ch317_Cardiovascular_Collapse,_Cardiac_Arrest,_and_.pdf","319":"harrison/Ch319_Approach_to_the_Patient_with_Renal_Disease_or.pdf","321":"harrison/Ch321_Acute_Kidney_Injury.pdf","322":"harrison/Ch322_Chronic_Kidney_Disease.pdf","332":"harrison/Ch332_Approach_to_the_Patient_with_Gastrointestinal.pdf","347":"harrison/Ch347_Approach_to_the_Patient_with_Liver_Disease.pdf","355":"harrison/Ch355_Cirrhosis_and_Its_Complications.pdf","375":"harrison/Ch375_The_Vasculitis_Syndromes.pdf","379":"harrison/Ch379_Sarcoidosis.pdf","382":"harrison/Ch382_Approach_to_Articular_and_Musculoskeletal_Dis.pdf","384":"harrison/Ch384_Gout_and_Other_Crystal-Associated_Arthropathi.pdf","387":"harrison/Ch387_Periarticular_Disorders_of_the_Extremities.pdf","388":"harrison/Ch388_Approach_to_the_Patient_with_Endocrine_Disord.pdf","433":"harrison/Ch433_Approach_to_the_Patient_with_Neurologic_Disea.pdf","436":"harrison/Ch436_Seizures_and_Epilepsy.pdf","437":"harrison/Ch437_Introduction_to_Cerebrovascular_Diseases.pdf","438":"harrison/Ch438_Ischemic_Stroke.pdf","439":"harrison/Ch439_Intracerebral_Hemorrhage.pdf","458":"harrison/Ch458_Guillain-Barr%23U00e9_Syndrome_and_Other_Immune.pdf","459":"harrison/Ch459_Myasthenia_Gravis_and_Other_Diseases_of_the_N.pdf"};
 // ===== TABS =====
@@ -830,6 +862,9 @@ let _sessionSaved=false;
 let _mockAnswered=0;
 let _examStartOk=0,_examStartNo=0;
 let qStartTime=Date.now();
+// Time-to-answer signal: seconds elapsed on the most recent `check()` call.
+// Captured in check() so it's stable for the reveal UI even after srScore resets qStartTime.
+let _lastElapsed=0;
 // ===== FEATURES: Confidence, Wrong-Reason, Difficulty =====
 let _confidence=null; // null,0(unsure),1(maybe),2(confident)
 let _pendingSR=null; // qIdx awaiting confidence rating after correct answer
@@ -1016,6 +1051,7 @@ function flipCard(){flipRevealed=true;render();}
 function onCallPick(correct){
   sel=correct?QZ[pool[qi]].c:((QZ[pool[qi]].c+1)%QZ[pool[qi]].o.length);
   checkMockIntercept();ans=true;
+  _lastElapsed=Math.max(0,Math.round((Date.now()-qStartTime)/1000));
   const q=QZ[pool[qi]];
   if(correct){S.qOk++;srScore(pool[qi],true);}
   else{S.qNo++;srScore(pool[qi],false);}
@@ -1087,6 +1123,9 @@ if(sel===null)return;
 checkMockIntercept();
 if(timedMode)clearInterval(timedInt);
 ans=true;
+// Capture elapsed BEFORE srScore runs (srScore resets qStartTime).
+// Used by the reveal UI to show "You took Xs" and topic-median comparison.
+_lastElapsed=Math.max(0,Math.round((Date.now()-qStartTime)/1000));
 const q=QZ[pool[qi]];
 // Feature 9: store confidence in SR data
 if(_confidence!==null){
@@ -1710,6 +1749,29 @@ return h;
 function _rqmExplain(){
 const q=QZ[pool[qi]];
 let h='';
+// Time-to-answer signal: show elapsed seconds + topic median comparison on reveal.
+// Only meaningful after an actual check() — skip on exam mode and flip-card paths (no explanation panel there).
+if(ans&&!examMode&&_lastElapsed>0){
+  const elapsed=_lastElapsed;
+  const tmed=q.ti>=0?topicMedianTime(q.ti):null;
+  const gmed=globalMedianTime();
+  const ref=tmed||gmed;
+  const refLabel=tmed?'topic median':(gmed?'your median':null);
+  const avgSelf=(S.sr[pool[qi]]&&S.sr[pool[qi]].at)||null;
+  // Color logic: green <= ref, yellow 1x-1.5x ref, red > 1.5x ref. Neutral if no ref.
+  let color='rgb(var(--fg2))',emoji='⏱',msg='';
+  if(ref){
+    if(elapsed<=ref){color='#16a34a';emoji='⚡';msg='faster than '+refLabel;}
+    else if(elapsed<=ref*1.5){color='#d97706';emoji='⏱';msg='about '+refLabel;}
+    else{color='#dc2626';emoji='🐢';msg='slower than '+refLabel;}
+  }
+  h+=`<div id="time-signal" class="time-signal" style="margin-top:10px;padding:8px 12px;background:rgb(var(--bg2));border:1px solid rgb(var(--brd));border-radius:10px;display:flex;gap:10px;align-items:center;flex-wrap:wrap;font-size:11px;color:rgb(var(--fg2))">`;
+  h+=`<span style="font-weight:700;color:${color}">${emoji} ${elapsed}s</span>`;
+  if(ref)h+=`<span style="color:rgb(var(--fg3))">· ${refLabel} ${ref}s</span>`;
+  if(msg)h+=`<span style="color:${color};font-size:10px">· ${msg}</span>`;
+  if(avgSelf&&avgSelf!==elapsed)h+=`<span style="color:rgb(var(--fg3));font-size:10px;margin-inline-start:auto">your avg ${avgSelf}s</span>`;
+  h+=`</div>`;
+}
 if(ans&&!examMode){
 const note=q.ti>=0&&NOTES[q.ti]?NOTES[q.ti]:null;
 if(note){
@@ -1832,7 +1894,8 @@ h+=`</div>`;
 // Non-year filters row (single-select)
 h+=`<div style="display:flex;gap:4px;flex-wrap:nowrap;overflow-x:auto;margin-bottom:10px;padding-bottom:4px;-webkit-overflow-scrolling:touch">`;
 const _trapCount=QZ.filter((_,i)=>isExamTrap(i)).length;
-const filts=[['Hazzard',`🤖 AI (${QZ.filter(q=>q.t==='Hazzard').length})`],['Hazzard-suppl',`📖 Suppl (${QZ.filter(q=>q.t==='Hazzard-suppl').length})`],['Harrison',`📘 Harrison (${QZ.filter(q=>q.t==='Harrison').length})`],['hard','🔥 Hard'],['slow','⏱️ Slow'],['weak','🎯 Weak'],['due','🔄 Due'],['traps',`🪤 Traps (${_trapCount})`],['nbs','🎯 Next Best Step']];
+const _slowCount=slowQuestionCount();
+const filts=[['Hazzard',`🤖 AI (${QZ.filter(q=>q.t==='Hazzard').length})`],['Hazzard-suppl',`📖 Suppl (${QZ.filter(q=>q.t==='Hazzard-suppl').length})`],['Harrison',`📘 Harrison (${QZ.filter(q=>q.t==='Harrison').length})`],['hard','🔥 Hard'],['slow',`⏱️ Slow${_slowCount>0?' ('+_slowCount+')':''}`],['weak','🎯 Weak'],['due','🔄 Due'],['traps',`🪤 Traps (${_trapCount})`],['nbs','🎯 Next Best Step']];
 if(dueN>0)filts.push(['due',`🔄 Due (${dueN})`]);
 filts.forEach(([f,l])=>{
 if(f==='nbs')h+=`<span class="pill ${filt==='nbs'?'on':''}" onclick="startNextBestStep()">${l}</span>`;
@@ -4635,8 +4698,9 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='9.64';
+const APP_VERSION='9.65';
 const CHANGELOG={
+'9.65': ['⏱ Time-to-answer signal: לוח ההסבר מציג עכשיו כמה שניות לקחת לשאלה הזו בהשוואה לחציון של הנושא (או לחציון האישי שלך כשאין מספיק נתונים לנושא). ירוק = מהיר, כתום = בממוצע, אדום = איטי מ-1.5x החציון.', 'פילטר "⏱️ Slow" מראה עכשיו את מספר השאלות בהן הממוצע שלך גבוה מ-60 שניות (slowQuestionCount) — קל יותר לדעת אם יש לך על מה לעבוד.', 'עזרי API חדשים: topicMedianTime(ti), globalMedianTime(), slowQuestionCount() — חשופים לבדיקות ולשכבות UI עתידיות.'],
 '9.64': ['📚 קישור דו-כיווני Hazzard/Harrison ברמת השאלה (לא רק ברמת הנושא כמו עד כה). כל שאלה ב-data/questions.json ממופה עכשיו לפרק Hazzard + פרק Harrison הטובים ביותר דרך `data/question_chapters.json` (3,406 שאלות תויגו ע"י scripts/tag_chapters.cjs — 40 נושאים × מפה ידנית + 30 overrides ספציפיים למחלות).', 'UI: אחרי תשובה שגויה מוצגים עכשיו שני כפתורי פרק (Hazzard ו-Harrison) במקום אחד; קיימים גם בקוראי הפרקים עם "Drill all N" שממלא pool ישירות מ-QCHAPS.', 'פילטרים חדשים: filt="haz-ch" ו-filt="har-ch" עם topicFilt=chNum — תרגול כל השאלות הממופות לפרק ספציפי.'],
 '9.63': ['UX: "Why did I get it wrong?" (📚 👓 ⚖️ 🤦) כבר לא חוסם את כפתור "הבאה" — הפך לאופציונלי. בסוויט הקודם הפכנו את "How sure are you" לאופציונלי; עכשיו גם שורת ה-why-wrong שלמטה אופציונלית.', 'טסט חדש: topicRefCoverage — מוודא שכל entry ב-TOPIC_REF מצביע לפרק שקיים ב-data/hazzard_chapters.json, ושכל onclick שקורא ל-openHazzardChapter מגיע דרך libSec=haz-pdf (מונע את הבאג של 9.62 שהגיע ל-libSec=harrison).', 'Pre-push hook חדש: `scripts/git-hooks/pre-push` מריץ את שני בודקי innerHTML לפני כל push. התקנה ב-`npm run hooks:install`.'],
 '9.62': ['UX: "How sure are you?" (😬 🤔 😎) כבר לא חוסם את כפתור בדוק — הפך לאופציונלי. אפשר עדיין ללחוץ על אחת האמוג\'ים, אבל לא חייבים.', 'תיקון: כפתור "Read: Hazzard Ch X — you\'re weak here" מנווט עכשיו ישירות לפרק הספציפי (נפתח Hazzard chapter viewer עם התוכן) במקום לפתוח את הסקציה הלא-נכונה (Harrison) של מדף הספרייה'],

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v9.64';
+const CACHE='shlav-a-v9.65';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','src/storage.js','src/sw-update.js'];
 const JSON_DATA_URLS=['data/questions.json','data/topics.json','data/notes.json','data/drugs.json','data/flashcards.json','harrison_chapters.json','data/hazzard_chapters.json','data/tabs.json','data/question_chapters.json'];
 const ALL_URLS=[...HTML_URLS,...JSON_DATA_URLS];

--- a/tests/timeSignals.test.js
+++ b/tests/timeSignals.test.js
@@ -1,0 +1,214 @@
+/**
+ * Guards the time-to-answer signal feature added in 9.65.
+ *
+ * The feature has three surfaces:
+ *   1. `_lastElapsed` is captured at `check()` time (before `srScore` resets qStartTime).
+ *   2. `_rqmExplain()` renders a `.time-signal` widget comparing elapsed vs topic median.
+ *   3. The ⏱️ Slow filter pill shows a count suffix via `slowQuestionCount()`.
+ *
+ * Strategy: source-level greps for wiring invariants + vm sandbox for the
+ * pure helpers (`topicMedianTime`, `globalMedianTime`, `slowQuestionCount`)
+ * extracted from the monolith, so we test the exact bytes that ship.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import vm from 'node:vm';
+
+const rootDir = resolve(import.meta.dirname, '..');
+const html = readFileSync(resolve(rootDir, 'shlav-a-mega.html'), 'utf-8');
+
+/**
+ * Pull `function <name>( ... ) { ... }` out of the monolith, brace-balanced.
+ */
+function extractFunction(src, name) {
+  const sig = `function ${name}(`;
+  const i = src.indexOf(sig);
+  if (i < 0) throw new Error(`${name} not found in shlav-a-mega.html`);
+  const openBrace = src.indexOf('{', i);
+  let depth = 0;
+  let end = -1;
+  for (let j = openBrace; j < src.length; j++) {
+    const c = src[j];
+    if (c === '{') depth++;
+    else if (c === '}') {
+      depth--;
+      if (depth === 0) { end = j; break; }
+    }
+  }
+  if (end < 0) throw new Error(`Could not balance braces for ${name}`);
+  return src.slice(i, end + 1);
+}
+
+describe('time-to-answer wiring (source-level guards)', () => {
+  it('declares `let _lastElapsed=0;` as a top-level binding', () => {
+    expect(html).toMatch(/let\s+_lastElapsed\s*=\s*0\s*;/);
+  });
+
+  it('captures _lastElapsed inside check() before srScore runs', () => {
+    const checkBody = extractFunction(html, 'check');
+    // Must assign _lastElapsed before any srScore() call inside check().
+    const elapsedIdx = checkBody.indexOf('_lastElapsed');
+    const srScoreIdx = checkBody.indexOf('srScore(');
+    expect(elapsedIdx, 'check() must set _lastElapsed').toBeGreaterThan(-1);
+    expect(srScoreIdx, 'check() must still call srScore').toBeGreaterThan(-1);
+    expect(elapsedIdx, '_lastElapsed must be captured BEFORE srScore runs').toBeLessThan(srScoreIdx);
+    // And uses the qStartTime diff (not a hardcoded zero).
+    expect(checkBody).toMatch(/_lastElapsed\s*=\s*Math\.max\(\s*0\s*,\s*Math\.round\(\s*\(\s*Date\.now\(\)\s*-\s*qStartTime\s*\)\s*\/\s*1000\s*\)\s*\)\s*;/);
+  });
+
+  it('captures _lastElapsed inside onCallPick (flip-card path)', () => {
+    const onCallBody = extractFunction(html, 'onCallPick');
+    expect(onCallBody).toMatch(/_lastElapsed\s*=\s*Math\.max/);
+  });
+
+  it('renders the time-signal widget only when ans&&!examMode&&_lastElapsed>0', () => {
+    // The guard condition must include all three — preventing a stale signal in exam mode
+    // and avoiding divide-by-zero-like "0s" flashes before the first check.
+    expect(html).toMatch(/if\s*\(\s*ans\s*&&\s*!\s*examMode\s*&&\s*_lastElapsed\s*>\s*0\s*\)/);
+  });
+
+  it('time-signal block uses the .time-signal id/class hook', () => {
+    // Needed so the widget is discoverable for future dashboards / CSS tweaks.
+    expect(html).toMatch(/id=["']time-signal["']/);
+    expect(html).toMatch(/class=["']time-signal["']/);
+  });
+
+  it('Slow filter pill interpolates slowQuestionCount()', () => {
+    // Must be called in the filts array so the pill shows a count suffix.
+    const slowPillLine = html
+      .split('\n')
+      .find(line => line.includes("['slow',") && line.includes('_slowCount'));
+    expect(slowPillLine, 'Slow pill must reference _slowCount').toBeTruthy();
+    expect(html).toMatch(/const\s+_slowCount\s*=\s*slowQuestionCount\(\)/);
+  });
+});
+
+describe('time-to-answer helpers (vm sandbox)', () => {
+  // Seed a minimal sandbox with QZ + S, then evaluate the three helpers.
+  const ctx = {
+    S: { sr: {} },
+    QZ: [],
+    topicMedianTime: null,
+    globalMedianTime: null,
+    slowQuestionCount: null,
+  };
+  vm.createContext(ctx);
+  vm.runInContext(
+    extractFunction(html, 'topicMedianTime') + ';' +
+    extractFunction(html, 'globalMedianTime') + ';' +
+    extractFunction(html, 'slowQuestionCount'),
+    ctx,
+  );
+
+  it('topicMedianTime returns null with fewer than 3 samples', () => {
+    ctx.QZ.length = 0;
+    ctx.S.sr = {};
+    ctx.QZ.push({ ti: 0 }, { ti: 0 });
+    ctx.S.sr['0'] = { at: 30 };
+    ctx.S.sr['1'] = { at: 50 };
+    expect(ctx.topicMedianTime(0)).toBeNull();
+  });
+
+  it('topicMedianTime computes median of odd-length samples', () => {
+    ctx.QZ.length = 0;
+    ctx.S.sr = {};
+    [10, 30, 90].forEach((at, i) => {
+      ctx.QZ.push({ ti: 5 });
+      ctx.S.sr[String(i)] = { at };
+    });
+    expect(ctx.topicMedianTime(5)).toBe(30);
+  });
+
+  it('topicMedianTime computes median of even-length samples (rounded)', () => {
+    ctx.QZ.length = 0;
+    ctx.S.sr = {};
+    [10, 20, 40, 60].forEach((at, i) => {
+      ctx.QZ.push({ ti: 7 });
+      ctx.S.sr[String(i)] = { at };
+    });
+    // median = (20+40)/2 = 30
+    expect(ctx.topicMedianTime(7)).toBe(30);
+  });
+
+  it('topicMedianTime ignores questions outside the topic', () => {
+    ctx.QZ.length = 0;
+    ctx.S.sr = {};
+    [10, 20, 30].forEach((at, i) => {
+      ctx.QZ.push({ ti: 1 });
+      ctx.S.sr[String(i)] = { at };
+    });
+    // 3 more in a different topic — should NOT leak in
+    [999, 888, 777].forEach((at, i) => {
+      const key = String(i + 3);
+      ctx.QZ.push({ ti: 2 });
+      ctx.S.sr[key] = { at };
+    });
+    expect(ctx.topicMedianTime(1)).toBe(20);
+    expect(ctx.topicMedianTime(2)).toBe(888);
+  });
+
+  it('topicMedianTime returns null for invalid ti values', () => {
+    expect(ctx.topicMedianTime(-1)).toBeNull();
+    expect(ctx.topicMedianTime(null)).toBeNull();
+    expect(ctx.topicMedianTime(undefined)).toBeNull();
+  });
+
+  it('topicMedianTime drops at<=0 (drive-by zeroes, unseeded entries)', () => {
+    ctx.QZ.length = 0;
+    ctx.S.sr = {};
+    [0, 0, 0, 40, 50, 60].forEach((at, i) => {
+      ctx.QZ.push({ ti: 3 });
+      ctx.S.sr[String(i)] = { at };
+    });
+    // Only the three positive samples count → median = 50
+    expect(ctx.topicMedianTime(3)).toBe(50);
+  });
+
+  it('globalMedianTime aggregates across all topics', () => {
+    ctx.QZ.length = 0;
+    ctx.S.sr = {};
+    // five samples across different topics
+    [10, 20, 30, 40, 50].forEach((at, i) => {
+      ctx.QZ.push({ ti: i });
+      ctx.S.sr[String(i)] = { at };
+    });
+    expect(ctx.globalMedianTime()).toBe(30);
+  });
+
+  it('globalMedianTime returns null with fewer than 3 samples', () => {
+    ctx.QZ.length = 0;
+    ctx.S.sr = {};
+    ctx.QZ.push({ ti: 0 }, { ti: 0 });
+    ctx.S.sr['0'] = { at: 30 };
+    ctx.S.sr['1'] = { at: 50 };
+    expect(ctx.globalMedianTime()).toBeNull();
+  });
+
+  it('slowQuestionCount counts only entries with at>60', () => {
+    ctx.QZ.length = 0;
+    ctx.S.sr = {
+      '0': { at: 30 },   // not slow
+      '1': { at: 60 },   // strictly >60 — threshold matches existing filter branch, so 60 is NOT slow
+      '2': { at: 61 },   // slow
+      '3': { at: 120 },  // slow
+      '4': { at: 0 },    // unseeded — skip
+      '5': {},           // no at field — skip
+    };
+    expect(ctx.slowQuestionCount()).toBe(2);
+  });
+});
+
+describe('version sync', () => {
+  it('sw.js CACHE matches APP_VERSION in the HTML', () => {
+    const sw = readFileSync(resolve(rootDir, 'sw.js'), 'utf-8');
+    const m = sw.match(/const\s+CACHE\s*=\s*['"]shlav-a-v([\d.]+)['"]/);
+    expect(m, 'sw.js must declare CACHE version').toBeTruthy();
+    const pkg = JSON.parse(readFileSync(resolve(rootDir, 'package.json'), 'utf-8'));
+    const appVer = html.match(/const\s+APP_VERSION\s*=\s*['"]([\d.]+)['"]/);
+    expect(appVer, 'HTML must declare APP_VERSION').toBeTruthy();
+    expect(m[1]).toBe(appVer[1]);
+    expect(pkg.version).toMatch(new RegExp('^' + appVer[1].replace(/\./g, '\\.') + '(\\.\\d+)?$'));
+  });
+});


### PR DESCRIPTION
## What changed

Every answer reveal now shows how long you took + how that compares to your topic median (or your global median when the topic has <3 samples). Instant feedback for exam-condition pacing without adding friction.

```
⚡ 28s · topic median 45s · faster than topic median        your avg 32s
⏱ 44s · topic median 45s · about topic median              your avg 38s
🐢 92s · topic median 45s · slower than topic median       your avg 71s
```

## Surface
- **Reveal widget** — rendered in `_rqmExplain` gated by `ans && !examMode && _lastElapsed > 0`. Color-coded: green ≤ median, amber ≤ 1.5×, red > 1.5×. Skipped in exam mode by design.
- **Slow filter pill** — now shows count `⏱️ Slow (N)` so you know whether the filter has anything in it without clicking.

## Implementation
- `_lastElapsed` captured in `check()` BEFORE `srScore()` runs, because `srScore()` resets `qStartTime` for the next question. Also captured in the on-call flip-card path (`onCallPick`).
- Three new pure helpers, all extractable for tests:
  - `topicMedianTime(ti)` — per-topic median of `S.sr[i].at`, requires ≥3 samples, drops `at<=0`.
  - `globalMedianTime()` — fallback when the topic is too thin.
  - `slowQuestionCount()` — count of entries with `at > 60` (matches the existing `filt==='slow'` branch strictness exactly).

## Version
- `shlav-a-v9.63` → `shlav-a-v9.65` (skipping 9.64 — that slot is claimed by PR #65 chapter-linking; using 9.65 avoids a collision regardless of merge order).
- `scripts/check-version-sync.py` validates `APP_VERSION` ↔ `sw.js CACHE` ↔ `package.json`.

## Tests — `tests/timeSignals.test.js` (16 tests)
Source-level guards (6):
- `_lastElapsed` top-level binding
- captured in `check()` BEFORE `srScore()` call
- captured in `onCallPick()`
- reveal widget gate condition
- `.time-signal` id/class hooks present
- Slow pill wired to `slowQuestionCount()`

vm-sandbox helper tests (9):
- `topicMedianTime`: null <3 samples, odd/even medians, topic scoping, invalid `ti`, drops `at<=0`
- `globalMedianTime`: cross-topic aggregate, null <3 samples
- `slowQuestionCount`: strict `>60` threshold (60 is NOT slow, matching filter branch)

Version-sync cross-check (1).

## Verify
```
OK: All versions aligned (v9.65)
OK: Brace balance (2404 pairs)
OK: No unsanitized innerHTML interpolation
OK: 6 innerHTML sites with interpolation, all pieces sanitized or annotated
Harrison hebrew baseline: 0 <= baseline 0

 Test Files  16 passed (16)
      Tests  595 passed (595)
```

## Why this matters
The `s.at` field has been tracked since forever (it drives the `⏱️ Slow` filter), but you never saw the number until you went looking for it in the footer. Now it's in your face on every reveal — so pacing feedback happens in the loop instead of post-hoc.

Closes #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)