### PR TITLE
feat: add cowork plugin for branch handoff workflow

### DIFF
--- a/plugins/cowork/.claude-plugin/plugin.json
+++ b/plugins/cowork/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "cowork",
+  "version": "0.1.0",
+  "description": "Cowork branch + session-handoff workflow for Geriatrics: questions.json, flashcards.json, notes.json, drugs.json. Formalizes the existing cowork/* branch convention (distractor-autopsy, flashcards-mode, tighten-hebrew-budgets, ...).",
+  "author": { "name": "eiasash" },
+  "keywords": ["cowork", "handoff", "geriatrics", "hazzard", "question-bank", "hebrew"]
+}

--- a/plugins/cowork/README.md
+++ b/plugins/cowork/README.md
@@ -1,0 +1,40 @@
+# cowork (Geriatrics)
+
+Claude Code plugin that formalizes the `cowork/<topic>` branch workflow already in use on this repo (`cowork/distractor-autopsy`, `cowork/flashcards-mode`, `cowork/tighten-hebrew-budgets`, …).
+
+One plugin = consistent start / handoff / resume / status / land commands + a distractor-autopsy reviewer agent + Hazzard-scoped topic-coverage reporting + a SessionStart hook that loads the current handoff automatically.
+
+## Install
+
+Symlink into the repo's `.claude/plugins/` (matches existing `.claude/` convention):
+
+```bash
+mkdir -p .claude/plugins
+ln -sfn "$PWD/plugins/cowork" .claude/plugins/cowork
+```
+
+## Commands
+
+| Command | Purpose |
+|---|---|
+| `/cowork:start <slug>` | Cut `cowork/<slug>` from main, scaffold `.cowork/<slug>.md` |
+| `/cowork:handoff` | Refresh handoff: question count, topic coverage delta, failing vitest suites, next step |
+| `/cowork:resume` | Read handoff, verify `npm test`, restate next action |
+| `/cowork:status` | Every cowork branch: ahead/behind, handoff age, question delta, any Hazzard-excluded-chapter regressions |
+| `/cowork:land` | Rebase, enforce question-schema, run vitest, draft squash message |
+| `/cowork:distractor-autopsy <qid>` | Deep review one MCQ's distractors before approving it |
+| `/cowork:topic-coverage` | Report question density per Hazzard allowed chapter; flag gaps and overweighted topics |
+| `/cowork:hebrew-sweep` | Check recently-touched Hebrew strings against hebrew-medical-glossary |
+
+## Agents
+
+- `distractor-autopsy` — second-opinion reviewer for MCQ quality (homogeneity, plausibility, absolute-term red flags, answer-key stability).
+- `schema-guard` — verifies any `data/questions.json` change respects the question-schema skill (fields, allowed enums, no GRS leak, no Hazzard-excluded chapter).
+
+## Hook
+
+`SessionStart` — if HEAD is `cowork/*`, prints the handoff file + last 5 commits.
+
+## Handoff file
+
+Lives at `.cowork/<slug>.md`, committed. See `skills/handoff-format/SKILL.md`.

--- a/plugins/cowork/agents/distractor-autopsy.md
+++ b/plugins/cowork/agents/distractor-autopsy.md
@@ -1,0 +1,30 @@
+---
+name: distractor-autopsy
+description: Deep-reviews a single MCQ for distractor quality before it lands in data/questions.json. Use when the user runs /cowork:distractor-autopsy or asks for a second opinion on a question. Does NOT author questions — only critiques.
+tools: Read, Grep, Glob, Bash
+---
+
+You are a board-exam item-writing reviewer. You have not seen the drafting session. Review the MCQ on its own merits.
+
+Report in under 350 words.
+
+## Rubric
+
+1. **Stem focus** — does it ask one thing? If the stem mentions two unrelated findings, call it out.
+2. **Answer-key stability** — rerun the clinical reasoning yourself from scratch. Do you land on the same correct answer the author marked? If not, explain which answer *you* pick and why.
+3. **Distractor homogeneity** — all 4 options should be the same class of thing (all drugs, all diagnoses, all dosages). Mixed classes make the correct answer trivially findable.
+4. **Plausibility** — each distractor must be a real differential a reasonable examinee might pick. Rate each 0–2: 0 = obviously wrong on sight, 1 = plausible, 2 = genuinely tempting. Flag any 0s.
+5. **Absolute-term red flags** — words like “always”, “never”, “all”, “none” in a distractor often correlate with wrong → flag.
+6. **Length bias** — is the correct answer noticeably longer/more qualified than the distractors? Flag.
+7. **Trade-name leak** — if a distractor names a drug by Israeli trade name but the correct answer uses generic, that's a tell. Flag.
+8. **Hazzard-excluded leak** — if the question's topic maps to an excluded Hazzard chapter (per `question-schema` skill), that's a hard blocker.
+9. **Cross-question recycling** — if a sibling question in the same topic uses an identical distractor for a different correct answer, the set leaks. Flag.
+
+## Output
+
+- **Verdict**: approve | revise | reject.
+- **Blockers**: numbered list (schema, key stability, excluded chapter).
+- **Revise**: numbered list (distractor tweaks, stem tightening).
+- **Per-distractor plausibility**: A / B / C / D with 0–2 score + one-line rationale.
+
+Do not rewrite the question. Do not call Edit/Write.

--- a/plugins/cowork/agents/schema-guard.md
+++ b/plugins/cowork/agents/schema-guard.md
@@ -1,0 +1,22 @@
+---
+name: schema-guard
+description: Verifies any change to data/questions.json, data/notes.json, data/drugs.json, data/flashcards.json against the question-schema skill. Use in /cowork:land before allowing merge.
+tools: Read, Grep, Bash
+---
+
+You are the schema gate. Block or allow — don't edit.
+
+1. Load the `question-schema` skill — it is authoritative.
+2. `git diff main...HEAD -- data/questions.json data/notes.json data/drugs.json data/flashcards.json`.
+3. For each added/changed entry, verify:
+   - Required fields present, allowed enum values only.
+   - `chapter` (if present) is in the Hazzard **allowed** list — not excluded.
+   - No GRS content leaked in (per skill).
+   - `topic` matches the auto-tagging map.
+   - IDs unique within file.
+4. Report under 200 words:
+   - **Blockers**: schema violations with entry id + field.
+   - **Warnings**: borderline (e.g. topic tag looks auto-guessed, not matching map exactly).
+   - **Verdict**: pass | fail.
+
+Never modify files. Never call Edit/Write.

--- a/plugins/cowork/commands/distractor-autopsy.md
+++ b/plugins/cowork/commands/distractor-autopsy.md
@@ -1,0 +1,16 @@
+---
+description: Deep review of a single MCQ's distractors before approval (echoes the cowork/distractor-autopsy branch workflow)
+argument-hint: <qid>  (id field from data/questions.json)
+---
+
+Invoke the `distractor-autopsy` agent with question id `$ARGUMENTS`.
+
+Before invoking, look up the question:
+
+```bash
+jq --arg id "$ARGUMENTS" '.[] | select(.id == $id)' data/questions.json
+```
+
+If the id does not exist, stop and list the last 10 ids as suggestions.
+
+Pass to the agent: the full question object + any sibling questions sharing the same `topic` (so it can check answer-key independence and distractor recycling across the set).

--- a/plugins/cowork/commands/handoff.md
+++ b/plugins/cowork/commands/handoff.md
@@ -1,0 +1,20 @@
+---
+description: Refresh the handoff file for the current cowork branch
+---
+
+Refresh `.cowork/<slug>.md` so the next session can resume cold.
+
+1. Branch must start with `cowork/`; else stop.
+2. Gather:
+   - `git status --porcelain`, `git diff --stat main...HEAD`, `git log --oneline main..HEAD`.
+   - Question delta: `jq 'length' data/questions.json` vs the value stored in the handoff's **Baseline** section.
+   - Flashcard delta: same for `data/flashcards.json`.
+   - `npm test --silent` per-suite PASS/FAIL.
+3. Update the handoff:
+   - **Status**: `in-progress` / `blocked: <reason>` / `ready-to-land`.
+   - **Done**: concrete bullets — `data/questions.json +12 (topic: frailty)`, `shlav-a-mega.html: quiz button RTL fix`. Vague bullets (“improved”, “cleaned”) are forbidden.
+   - **Next**: one concrete action with file path.
+   - **Tests**: one line per suite.
+   - **Notes for the next Claude**: non-obvious only — skipped test + reason, a distractor you deliberately left weak waiting for review, a Hebrew term waiting on glossary clarification.
+4. `git add .cowork/ && git commit -m "cowork: handoff"`. Do not push.
+5. Print the file.

--- a/plugins/cowork/commands/hebrew-sweep.md
+++ b/plugins/cowork/commands/hebrew-sweep.md
@@ -1,0 +1,9 @@
+---
+description: Check recently-touched Hebrew strings against hebrew-medical-glossary
+---
+
+1. `git diff main...HEAD -- '*.html' '*.json' '*.ts' '*.js'` — filter lines containing Hebrew (regex `[\u0590-\u05FF]`).
+2. Load the `hebrew-medical-glossary` skill.
+3. For each candidate string, classify: **Canonical** (matches glossary), **Variant** (a known non-canonical form the glossary lists), **Unknown** (flag for review), **Deviant** (wrong term per Clalit/Maccabi conventions — block).
+4. Report: counts by class, plus a numbered list of **Deviant** and **Unknown** strings with file:line.
+5. Do NOT auto-rewrite. The point is a reviewer's second opinion, not a silent fix.

--- a/plugins/cowork/commands/land.md
+++ b/plugins/cowork/commands/land.md
@@ -1,0 +1,11 @@
+---
+description: Land the current cowork branch onto main with schema enforcement
+---
+
+1. `git rev-parse --abbrev-ref HEAD` — must be `cowork/*`. Abort otherwise.
+2. `git fetch origin main && git rebase origin/main`. Conflicts → STOP, print them.
+3. **Schema guard** (delegate to the `schema-guard` agent): confirm any change to `data/questions.json`, `data/notes.json`, `data/drugs.json`, `data/flashcards.json` obeys the `question-schema` skill — required fields, allowed enum values, no Hazzard-excluded chapters, no GRS content, auto-tagging topic map consistent.
+4. Hebrew guard: for any Hebrew string diff in `shlav-a-mega.html` or data files, sample 5 strings and validate against `hebrew-medical-glossary`. Report deviations; do not auto-fix.
+5. `npm test --silent`, then any lint/build script in `package.json`. All must pass.
+6. Read `.cowork/<slug>.md`. Draft squash message: title `<type>(scope): <goal>`; body = **Done**; footer `Cowork-branch: cowork/<slug>`.
+7. Print the draft message + the git commands. Do NOT merge/push.

--- a/plugins/cowork/commands/resume.md
+++ b/plugins/cowork/commands/resume.md
@@ -1,0 +1,11 @@
+---
+description: Resume a cowork branch cold — read handoff, verify state, announce next step
+---
+
+1. `git rev-parse --abbrev-ref HEAD`. If not `cowork/*`, ask which to resume and checkout.
+2. Read `.cowork/<slug>.md`. Print **Goal**, **Next**, **Notes for the next Claude** verbatim.
+3. Verify no drift:
+   - `git log --oneline -5`, `git status --porcelain` (flag uncommitted surprises).
+   - `npm test --silent` — if a suite that was PASS is now FAIL, STOP, flag regression before anything else.
+   - Re-run `jq 'length' data/questions.json` — if it changed but handoff wasn't updated, flag drift.
+4. State in one sentence what you are about to do, mapped to the **Next** bullet.

--- a/plugins/cowork/commands/start.md
+++ b/plugins/cowork/commands/start.md
@@ -1,0 +1,15 @@
+---
+description: Cut a new cowork/<slug> branch and scaffold its handoff file
+argument-hint: <slug>  (kebab-case, matches existing convention e.g. flashcards-mode)
+---
+
+You are starting a new Geriatrics cowork session.
+
+1. `git rev-parse --abbrev-ref HEAD` — must be `main`, else stop and ask.
+2. `git fetch origin main && git checkout -b cowork/$ARGUMENTS origin/main`.
+3. Scaffold `.cowork/$ARGUMENTS.md` (template in `plugins/cowork/skills/handoff-format/SKILL.md`). Prefill:
+   - **Goal** — ask the user one sentence; do not guess.
+   - **Baseline** — `jq 'length' data/questions.json`, `jq 'length' data/flashcards.json`, topic-coverage snapshot (run `scripts/` if one exists; otherwise skip this bullet rather than inventing numbers).
+   - **Tests** — `npm test --silent 2>&1 | tail -20`, paste pass/fail.
+4. `git add .cowork/ && git commit -m "cowork: start $ARGUMENTS"`.
+5. Print the branch name and handoff path. Do not push.

--- a/plugins/cowork/commands/status.md
+++ b/plugins/cowork/commands/status.md
@@ -1,0 +1,13 @@
+---
+description: Summary of all cowork/* branches — ahead/behind, handoff age, data deltas
+---
+
+1. `git fetch origin --prune`.
+2. Enumerate `cowork/*` local + remote (dedupe).
+3. For each, in parallel:
+   - `git rev-list --left-right --count origin/main...<branch>` → ahead/behind.
+   - Read `.cowork/<slug>.md`: extract **Status**, **Last session** date.
+   - `git show <branch>:data/questions.json 2>/dev/null | jq 'length'` vs main → question delta.
+   - If the branch touches `data/questions.json`, grep the diff for any chapter in the Hazzard-excluded list (see question-schema skill). Any match → flag hard.
+4. Print markdown table: `branch | status | ahead/behind | qΔ | fcΔ | age | flags`.
+5. Recommend: smallest clean diff that is `ready-to-land`; flag any branch >14 days since last handoff.

--- a/plugins/cowork/commands/topic-coverage.md
+++ b/plugins/cowork/commands/topic-coverage.md
@@ -1,0 +1,13 @@
+---
+description: Question density per Hazzard allowed chapter; flag gaps and overweighting
+---
+
+1. Read `data/questions.json`.
+2. For each allowed Hazzard chapter (from `question-schema` skill):
+   - count questions tagged to that chapter.
+3. Print a table sorted ascending: `chapter | count | % of total`.
+4. Flag:
+   - **Gaps**: allowed chapter with < 3 questions.
+   - **Overweight**: any chapter > 15% of total.
+   - **Leak**: any question tagged to a Hazzard-*excluded* chapter (must be 0; if not, hard fail and list the question ids).
+5. End with a one-line recommendation: which gap to fill first in the current cowork branch.

--- a/plugins/cowork/hooks/hooks.json
+++ b/plugins/cowork/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); case \"$branch\" in cowork/*) slug=${branch#cowork/}; echo \"=== cowork session: $branch ===\"; if [ -f \".cowork/$slug.md\" ]; then cat \".cowork/$slug.md\"; else echo \"(no handoff file at .cowork/$slug.md — run /cowork:handoff)\"; fi; echo; echo \"--- last 5 commits ---\"; git log --oneline -5; ;; esac'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/cowork/skills/handoff-format/SKILL.md
+++ b/plugins/cowork/skills/handoff-format/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: handoff-format
+description: Canonical format for Geriatrics `.cowork/<slug>.md` handoff files. Load whenever writing or reading a handoff.
+---
+
+# cowork handoff format (Geriatrics)
+
+Handoff files live at `.cowork/<slug>.md`, one per active branch, committed.
+
+## Required sections
+
+### Header
+```
+# <slug>
+
+**Branch:** cowork/<slug>
+**Last session:** YYYY-MM-DD (model)
+**Status:** in-progress | blocked: <reason> | ready-to-land
+```
+
+### Goal
+One paragraph. Never edit after the first session — this is the anchor.
+
+### Baseline
+Snapshot from `/cowork:start`:
+- `data/questions.json` length at branch-off.
+- `data/flashcards.json` length at branch-off.
+- (optional) topic-coverage numbers at branch-off.
+
+### Done
+Concrete bullets with artifact + scope. Examples:
+- `data/questions.json` +12 (topic: frailty, ids: q0612–q0623).
+- `shlav-a-mega.html`: fixed RTL stray LTR mark in quiz-nav.
+- NOT allowed: “improved quiz”, “cleaned up”.
+
+### Next
+One or two concrete actions with file paths. Imperative. Examples:
+- `[ ] Add 4 questions for topic "delirium" to data/questions.json`.
+- NOT allowed: `[ ] Continue`, `[ ] Review`.
+
+### Tests
+One line per suite, current state:
+- `npm test -- quiz` : PASS
+- `npm run lint` : FAIL (3, pre-existing)
+
+### Notes for the next Claude
+Non-obvious only:
+- Skipped test + reason to re-enable.
+- A distractor left deliberately weak pending distractor-autopsy agent review.
+- Hebrew term waiting on glossary clarification.
+
+## Not allowed
+- Conversational summary — use commits.
+- Restating the diff — use `git diff`.
+- Follow-up ideas unrelated to this branch — open an issue instead.


### PR DESCRIPTION
## Description

Introduces the `cowork` Claude Code plugin, formalizing the existing `cowork/<topic>` branch workflow used throughout the Geriatrics repo (e.g., `cowork/distractor-autopsy`, `cowork/flashcards-mode`, `cowork/tighten-hebrew-budgets`).

The plugin provides:
- **Commands** for starting, resuming, handing off, and landing cowork branches with structured handoff files (`.cowork/<slug>.md`)
- **Agents** for deep MCQ distractor review and schema validation before merge
- **Hooks** that auto-load the current handoff on session start
- **Canonical handoff format** with required sections (Goal, Baseline, Done, Next, Tests, Notes)
- **Quality gates** including question-schema enforcement, Hazzard chapter exclusion checks, and Hebrew glossary validation

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📚 Documentation update

## Contents

### Plugin Structure
- `plugin.json` — plugin metadata
- `skills/handoff-format/SKILL.md` — canonical format for `.cowork/<slug>.md` files
- `commands/` — 8 commands: `start`, `resume`, `handoff`, `status`, `land`, `distractor-autopsy`, `topic-coverage`, `hebrew-sweep`
- `agents/` — 2 agents: `distractor-autopsy` (MCQ reviewer), `schema-guard` (data validation)
- `hooks/hooks.json` — SessionStart hook to auto-load handoff on cowork branches
- `README.md` — plugin overview and installation instructions

### Key Features
1. **Structured handoff** — enforces concrete, artifact-focused documentation (no vague summaries)
2. **Schema enforcement** — blocks merge if questions violate `question-schema` or touch Hazzard-excluded chapters
3. **MCQ quality review** — distractor-autopsy agent checks stem focus, answer-key stability, distractor homogeneity, plausibility, and red flags
4. **Coverage reporting** — topic-coverage command flags gaps (<3 questions) and overweighting (>15%)
5. **Hebrew validation** — hebrew-sweep checks recently-touched strings against glossary
6. **Status dashboard** — cowork:status shows all branches with ahead/behind, age, data deltas, and flags

## Testing
- No automated tests added (plugin is configuration + documentation; runtime behavior depends on Claude Code runtime)
- Plugin follows existing `.claude/plugins/` convention and is ready for symlink installation

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation complete (README, SKILL.md, command/agent descriptions)
- [x] No secrets or API keys exposed
- [x] Consistent with existing cowork/* branch naming and workflow

## Additional Notes
Installation: `ln -sfn "$PWD/plugins/cowork" .claude/plugins/cowork`

This formalizes a workflow already in use; the plugin adds consistency, automation, and guardrails without breaking existing practices.

https://claude.ai/code/session_015ZKmUZvbKfbSWqxrom9NMS