### PR TITLE
fix(ai): validate chapter number in quizMeOnChapter

### DIFF
--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -2748,6 +2748,10 @@ box.innerHTML=html;
 }
 
 async function quizMeOnChapter(chNum,chTitle){
+  // Validate chNum — reject non-positive or absurd values that would waste
+  // AI quota on invalid prompts (Hazzard 8e: 1–108, Harrison 22e: 1–500).
+  const n=Number(chNum);
+  if(!Number.isFinite(n)||n<1||n>500){console.warn('[quizMeOnChapter] invalid chapter number:',chNum);return;}
   // Show loading state in Library
   const el=document.getElementById('quiz-me-box');
   if(el){el.innerHTML='<div style="text-align:center;padding:20px;color:rgb(var(--fg2))">⏳ Generating questions from Ch '+sanitize(chNum)+'...</div>';}


### PR DESCRIPTION
## Summary

Deep-audit finding applied as a surgical fix.

`quizMeOnChapter(chNum, chTitle)` in `shlav-a-mega.html` accepted any `chNum` passed by UI onclick handlers (Hazzard Ch 1–108, Harrison Ch 1–459 in practice) and built an AI prompt around it. A bad value — console call, corrupted inline handler, or future UI refactor — would waste AI quota on invalid prompts and display garbage to the user.

Validate that `chNum` is a finite number in [1, 500] and early-return with a `console.warn` otherwise. The [1, 500] bound safely covers both Hazzard 8e and Harrison 22e ranges.

## Audit findings intentionally NOT included

- **`AI_SECRET='shlav-a-mega-2026'` in client source (line 5244)** and **Supabase anon key (line 1632)** — require backend/Supabase-console rotation.
- **Dead-code removal (`_pendingSR`, `migrateToIDB`)** — verification showed both are actively used; audit was wrong.
- **innerHTML/XSS hardening in charts and AI approval path** — current code sanitizes; larger refactor deferred.
- **CSP / SRI hash / A11y focus-trap improvements** — each is a focused PR on its own.
- **Questions.json split for faster load** — significant architectural change.

## Test plan

- [x] `npm test` — 678 tests across 21 files pass
- [ ] Manual smoke: click Hazzard chapter Quiz button, confirm AI generation still works; open DevTools, call `quizMeOnChapter('abc','x')`, confirm it early-returns with warning

https://claude.ai/code/session_018yS2e68SpoHJXC15ZJH8Hb