### PR TITLE
chore: add Supabase MCP server config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "supabase": {
       "type": "http",
-      "url": "https://mcp.supabase.com/mcp?project_ref=drvocrtufqtifkgmijpg&features=docs%2Caccount%2Cdatabase%2Cdebugging%2Cdevelopment%2Cbranching%2Cfunctions%2Cstorage"
+      "url": "https://mcp.supabase.com/mcp?project_ref=krmlzwwelqvlfslwltol&features=docs%2Caccount%2Cdatabase%2Cdebugging%2Cdevelopment%2Cbranching%2Cfunctions%2Cstorage"
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "supabase": {
       "type": "http",
-      "url": "https://mcp.supabase.com/mcp?project_ref=drvocrtufqtifkgmijpg&features=storage%2Cbranching%2Cfunctions%2Cdevelopment%2Cdebugging%2Cdatabase%2Caccount%2Cdocs"
+      "url": "https://mcp.supabase.com/mcp?project_ref=drvocrtufqtifkgmijpg&features=docs%2Caccount%2Cdatabase%2Cdebugging%2Cdevelopment%2Cbranching%2Cfunctions%2Cstorage"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Updates `.mcp.json` to point the Supabase MCP HTTP server at the shared project `krmlzwwelqvlfslwltol` (previous ref `drvocrtufqtifkgmijpg` is obsolete).
- Features enabled: docs, account, database, debugging, development, branching, functions, storage.

## Data separation
Geriatrics and InternalMedicine now share one Supabase project. Data separation must be handled at the database layer — not via MCP config. Recommended approaches:
- Per-app Postgres schema (e.g. `geriatrics.*` vs `internalmedicine.*`), or
- Per-app table prefix, or
- Shared tables with an `app`/`tenant` column enforced by RLS policies.

This PR only updates the MCP endpoint; follow-up migrations are needed to actually split the data.

## Next steps
After merging, run `claude /mcp` in a regular terminal, select the `supabase` server, and complete authentication.

Optional: install Supabase agent skills with `npx skills add supabase/agent-skills`.