### PR TITLE
Split Geriatrics tables into `geriatrics` schema

### DIFF
--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -3011,7 +3011,7 @@ const payload={uid,answered:totalAnswered,correct:totalCorrect,streak,readiness,
 try{
   const res=await fetch(SUPA_URL+'/rest/v1/shlav_leaderboard',{
     method:'POST',
-    headers:{'Content-Type':'application/json','apikey':SUPA_ANON,'Authorization':'Bearer '+SUPA_ANON,'Prefer':'resolution=merge-duplicates'},
+    headers:{'Content-Type':'application/json','apikey':SUPA_ANON,'Authorization':'Bearer '+SUPA_ANON,'Content-Profile':'geriatrics','Prefer':'resolution=merge-duplicates'},
     body:JSON.stringify(payload)
   });
   if(!res.ok){console.warn('Leaderboard submit non-ok',res.status);return{submitted:false,status:res.status};}
@@ -3021,7 +3021,7 @@ try{
 async function fetchLeaderboard(){
 try{
   const res=await fetch(SUPA_URL+'/rest/v1/shlav_leaderboard?select=uid,answered,correct,streak,readiness,accuracy,ts&order=accuracy.desc.nullslast,answered.desc&limit=20',{
-    headers:{'apikey':SUPA_ANON}
+    headers:{'apikey':SUPA_ANON,'Accept-Profile':'geriatrics'}
   });
   return await res.json();
 }catch(e){console.warn('Leaderboard fetch failed',e);return[];}
@@ -5164,7 +5164,7 @@ try{localStorage.setItem('samega_fb_sent',JSON.stringify(fb));}catch(e){}
 try{
   await fetch(SUPA_URL+'/rest/v1/shlav_feedback',{
     method:'POST',
-    headers:{'Content-Type':'application/json','apikey':SUPA_ANON,'Authorization':'Bearer '+SUPA_ANON},
+    headers:{'Content-Type':'application/json','apikey':SUPA_ANON,'Authorization':'Bearer '+SUPA_ANON,'Content-Profile':'geriatrics'},
     body:JSON.stringify(entry)
   });
 }catch(e){console.warn('Feedback submit failed',e);}
@@ -5260,7 +5260,7 @@ async function cloudBackup(){
     const payload={id:_sbDeviceId(),data:_bundled,updated_at:new Date().toISOString()};
     const res=await fetch(SUPA_URL+'/rest/v1/samega_backups',{
       method:'POST',
-      headers:{'apikey':_SB_KEY,'Authorization':'Bearer '+_SB_KEY,'Content-Type':'application/json','Prefer':'resolution=merge-duplicates'},
+      headers:{'apikey':_SB_KEY,'Authorization':'Bearer '+_SB_KEY,'Content-Type':'application/json','Content-Profile':'geriatrics','Prefer':'resolution=merge-duplicates'},
       body:JSON.stringify(payload)
     });
     if(res.ok||res.status===409){
@@ -5268,7 +5268,7 @@ async function cloudBackup(){
       if(res.status===409){
         const patchRes=await fetch(SUPA_URL+'/rest/v1/samega_backups?id=eq.'+_sbDeviceId(),{
           method:'PATCH',
-          headers:{'apikey':_SB_KEY,'Authorization':'Bearer '+_SB_KEY,'Content-Type':'application/json'},
+          headers:{'apikey':_SB_KEY,'Authorization':'Bearer '+_SB_KEY,'Content-Type':'application/json','Content-Profile':'geriatrics'},
           body:JSON.stringify({data:_bundled,updated_at:new Date().toISOString()})
         });
         if(!patchRes.ok){const pe=await patchRes.text();toast('❌ Backup update failed: '+patchRes.status+'\n'+pe.slice(0,200,'info'));return;}
@@ -5289,7 +5289,7 @@ async function cloudRestore(){
   if(!id)return;
   try{
     const res=await fetch(SUPA_URL+'/rest/v1/samega_backups?id=eq.'+encodeURIComponent(id)+'&select=data,updated_at',{
-      headers:{'apikey':_SB_KEY,'Authorization':'Bearer '+_SB_KEY}
+      headers:{'apikey':_SB_KEY,'Authorization':'Bearer '+_SB_KEY,'Accept-Profile':'geriatrics'}
     });
     if(!res.ok){toast('❌ Restore failed: '+res.status,'info');return;}
     const rows=await res.json();
@@ -5767,7 +5767,7 @@ let fb;try{fb=JSON.parse(localStorage.getItem('shlav_feedback')||'[]');}catch(e)
 fb.push(payload);if(fb.length>50)fb.splice(0,fb.length-50);
 localStorage.setItem('shlav_feedback',JSON.stringify(fb));
 fetch(SUPA_URL+'/rest/v1/shlav_feedback',{
-method:'POST',headers:{'Content-Type':'application/json','apikey':SUPA_ANON,'Authorization':'Bearer '+SUPA_ANON,'Prefer':'return=minimal'},
+method:'POST',headers:{'Content-Type':'application/json','apikey':SUPA_ANON,'Authorization':'Bearer '+SUPA_ANON,'Content-Profile':'geriatrics','Prefer':'return=minimal'},
 body:JSON.stringify({message:msg,diagnostics:diag,app_version:APP_VERSION,type,context})
 }).catch(()=>{});
 if(type==='wrong_answer'&&qObj){

--- a/supabase-setup.sql
+++ b/supabase-setup.sql
@@ -1,40 +1,10 @@
--- Run this once in the Supabase SQL Editor:
--- https://supabase.com/dashboard/project/drvocrtufqtifkgmijpg/sql/new
-
-CREATE TABLE IF NOT EXISTS public.progress_state (
-  user_id TEXT PRIMARY KEY,
-  data JSONB NOT NULL DEFAULT '{}'::jsonb,
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-
-ALTER TABLE public.progress_state ENABLE ROW LEVEL SECURITY;
-
--- Drop the old overly-permissive policy if it exists
-DROP POLICY IF EXISTS "anon_all" ON public.progress_state;
-
--- Users can only read their own data (matched by user_id sent from client)
-CREATE POLICY "user_read_own" ON public.progress_state
-  FOR SELECT USING (
-    user_id = coalesce(current_setting('request.jwt.claims', true)::json->>'sub',
-              current_setting('request.headers', true)::json->>'x-user-id')
-  );
-
--- Users can only insert/update their own data
-CREATE POLICY "user_write_own" ON public.progress_state
-  FOR INSERT WITH CHECK (
-    user_id = coalesce(current_setting('request.jwt.claims', true)::json->>'sub',
-              current_setting('request.headers', true)::json->>'x-user-id')
-  );
-
-CREATE POLICY "user_update_own" ON public.progress_state
-  FOR UPDATE USING (
-    user_id = coalesce(current_setting('request.jwt.claims', true)::json->>'sub',
-              current_setting('request.headers', true)::json->>'x-user-id')
-  ) WITH CHECK (
-    user_id = coalesce(current_setting('request.jwt.claims', true)::json->>'sub',
-              current_setting('request.headers', true)::json->>'x-user-id')
-  );
-
--- Create an index on updated_at for efficient cleanup queries
-CREATE INDEX IF NOT EXISTS idx_progress_state_updated_at
-  ON public.progress_state (updated_at);
+-- This file is superseded by supabase/migrations/20260421120000_split_app_schema.sql
+-- (progress_state now lives in the `geriatrics` schema, not `public`).
+--
+-- To apply the current schema, run:
+--
+--   supabase db push
+--
+-- ...or paste supabase/migrations/20260421120000_split_app_schema.sql into the
+-- Supabase SQL Editor. Remember to add `geriatrics` to Project Settings ->
+-- API -> Exposed schemas after applying.

--- a/supabase/migrations/20260421120000_split_app_schema.sql
+++ b/supabase/migrations/20260421120000_split_app_schema.sql
@@ -1,0 +1,77 @@
+-- Split Geriatrics tables into their own schema.
+--
+-- Background: project krmlzwwelqvlfslwltol is shared with the InternalMedicine
+-- app. Per-app tables are moved out of `public` into app-specific schemas so
+-- the two apps cannot collide on table names and can be audited / backed up
+-- independently. Shared tables (answer_reports, question-images bucket,
+-- auth.*) stay where they are.
+--
+-- After applying this migration you MUST open the Supabase dashboard
+-- (Project Settings -> API -> Exposed schemas) and add `geriatrics` to the
+-- list. Without that, PostgREST returns 404 for requests that target the new
+-- schema via the Accept-Profile / Content-Profile headers.
+
+create schema if not exists geriatrics;
+
+grant usage on schema geriatrics to anon, authenticated, service_role;
+
+alter default privileges in schema geriatrics
+  grant select, insert, update, delete on tables to anon, authenticated;
+alter default privileges in schema geriatrics
+  grant usage, select on sequences to anon, authenticated;
+
+alter table if exists public.shlav_leaderboard set schema geriatrics;
+alter table if exists public.shlav_feedback    set schema geriatrics;
+alter table if exists public.samega_backups    set schema geriatrics;
+alter table if exists public.progress_state    set schema geriatrics;
+
+-- Ensure progress_state exists in the new schema even if it was never created
+-- in `public` first. DDL mirrors the retired supabase-setup.sql; RLS matches
+-- user_id against the Supabase JWT `sub` claim, falling back to the
+-- `x-user-id` header so pre-auth clients still work.
+create table if not exists geriatrics.progress_state (
+  user_id    text primary key,
+  data       jsonb       not null default '{}'::jsonb,
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_progress_state_updated_at
+  on geriatrics.progress_state (updated_at);
+
+alter table geriatrics.progress_state enable row level security;
+
+drop policy if exists user_read_own   on geriatrics.progress_state;
+drop policy if exists user_write_own  on geriatrics.progress_state;
+drop policy if exists user_update_own on geriatrics.progress_state;
+
+create policy user_read_own on geriatrics.progress_state
+  for select using (
+    user_id = coalesce(
+      current_setting('request.jwt.claims', true)::json->>'sub',
+      current_setting('request.headers',    true)::json->>'x-user-id'
+    )
+  );
+
+create policy user_write_own on geriatrics.progress_state
+  for insert with check (
+    user_id = coalesce(
+      current_setting('request.jwt.claims', true)::json->>'sub',
+      current_setting('request.headers',    true)::json->>'x-user-id'
+    )
+  );
+
+create policy user_update_own on geriatrics.progress_state
+  for update using (
+    user_id = coalesce(
+      current_setting('request.jwt.claims', true)::json->>'sub',
+      current_setting('request.headers',    true)::json->>'x-user-id'
+    )
+  ) with check (
+    user_id = coalesce(
+      current_setting('request.jwt.claims', true)::json->>'sub',
+      current_setting('request.headers',    true)::json->>'x-user-id'
+    )
+  );
+
+grant select, insert, update, delete on all tables    in schema geriatrics to anon, authenticated;
+grant usage,  select                on all sequences in schema geriatrics to anon, authenticated;


### PR DESCRIPTION
## Summary
Separates this app's Supabase data from InternalMedicine's in the shared project `krmlzwwelqvlfslwltol`.

- **Migration** `supabase/migrations/20260421120000_split_app_schema.sql` — creates `geriatrics` schema, grants anon/authenticated/service_role access, moves `shlav_leaderboard`, `shlav_feedback`, `samega_backups`, `progress_state` out of `public`. Also re-creates `progress_state` (idempotent) in the new schema with its RLS policies, so a fresh project that never had the old `public.progress_state` still ends up correct.
- **Client** `shlav-a-mega.html` — adds `Accept-Profile: geriatrics` (reads) and `Content-Profile: geriatrics` (writes) headers to every `shlav_*` / `samega_backups` fetch. All 7 call sites patched; `answer_reports` intentionally left alone (stays in `public`, discriminated by `app='geriatrics'`).
- **`supabase-setup.sql`** — reduced to a pointer at the migration file. The DDL it used to hold is now part of the migration.

## Deploy sequence (important — order matters)
1. Apply the migration: `supabase db push` (or paste the SQL into Supabase Studio).
2. In Supabase dashboard → **Project Settings → API → Exposed schemas**, add `geriatrics`. Without this PostgREST returns 404 for the new schema.
3. Merge & deploy this PR (code writes to `geriatrics` via the profile headers). If step 2 is skipped, leaderboard/backup/feedback will silently fail.

## Not in scope
- **RLS** for `shlav_*` / `samega_backups`: moved with existing grants; current anon-key behavior preserved. Only `progress_state` has RLS.
- **Hardcoded anon key** (line ~1566 of `shlav-a-mega.html`) is unchanged.
- **InternalMedicine** has its own matching PR for `pnimit_*` → `internal_medicine` schema.

## Test plan
- [ ] Apply migration against the Supabase project (staging if possible)
- [ ] Add `geriatrics` to Exposed schemas
- [ ] Deploy app, verify leaderboard load + submit (`GET`/`POST shlav_leaderboard`)
- [ ] Verify cloud backup + restore (`POST`/`PATCH`/`GET samega_backups`)
- [ ] Verify feedback submit (both sites: `submitFeedbackForm`-style + `submitReport` fire-and-forget)
- [ ] Verify "report wrong answer" still writes to `public.answer_reports`
- [ ] If any workflow uses `progress_state`, confirm it now reads/writes from `geriatrics.progress_state`