### PR TITLE
test: add regression guard for JSON-extract regex health

### DIFF
--- a/tests/jsonExtractRegex.test.js
+++ b/tests/jsonExtractRegex.test.js
@@ -1,0 +1,33 @@
+/**
+ * Guard: shlav-a-mega.html must use `/\{[\s\S]*\}/` for AI JSON extraction.
+ *
+ * The sibling Pnimit + Mishpacha repos were hit by a state-rename find/replace
+ * that turned `\s\S` into `\s\G.S` in src/ai/explain.js, silently breaking
+ * the teach-back grader. Geriatrics currently uses the correct form in two
+ * places (teach-back + bulk-generation); this test locks that in.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const html = readFileSync(resolve(process.cwd(), 'shlav-a-mega.html'), 'utf-8');
+
+describe('JSON-extract regex health (shlav-a-mega.html)', () => {
+  it('contains the correct [\\s\\S] class at every use site', () => {
+    const correct = (html.match(/\[\\s\\S\]/g) || []).length;
+    expect(correct).toBeGreaterThanOrEqual(2);
+  });
+
+  it('never contains the corrupted [\\s\\G.S] class', () => {
+    // `\G` is not a meaningful JS regex token inside `[]`; if this pattern
+    // appears it means a G-prefix find/replace touched the regex text.
+    expect(html).not.toMatch(/\[\\s\\G\.S\]/);
+  });
+
+  it('never logs "Report G.save failed" (should be "Report save failed")', () => {
+    // Same find/replace class that corrupted the regex also hit string
+    // literals. Keep the log message canonical.
+    expect(html).not.toMatch(/Report G\.save failed/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `tests/jsonExtractRegex.test.js` — a defensive scan over `shlav-a-mega.html` that locks the two `[\s\S]` JSON-extract sites (teach-back grader + bulk question generator) and blocks two sibling-repo corruption patterns from ever landing here:
  - `[\s\G.S]` — the corrupted character class that silently broke the Pnimit + Mishpacha teach-back graders (fixed on their own branches).
  - `"Report G.save failed"` — a collaterally-corrupted log string from the same find/replace.

No source changes — Geriatrics is already correct; this test simply prevents the sibling bugs from catching up.

Test count: **690 → 693 passing**.

## Test plan
- [x] `npm test` passes locally (23 files, 693 tests)
- [ ] CI green on this branch

https://claude.ai/code/session_017QtMy5ExH9J2LrkTDetNUv