### PR TITLE
security: migrate Supabase client from legacy JWT anon key to publishable key

### DIFF
--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -1960,7 +1960,7 @@ function fmtT(s){const h=Math.floor(s/3600),m=Math.floor((s%3600)/60),sc=s%60;re
 
 // ===== QUESTION IMAGE UPLOAD =====
 const SUPA_URL='https://krmlzwwelqvlfslwltol.supabase.co';
-const SUPA_ANON='eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImtybWx6d3dlbHF2bGZzbHdsdG9sIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzE5NjQxMDksImV4cCI6MjA4NzU0MDEwOX0.PFSuFgHA-WBnrgs4stmloxvOORSX0CiXDPsW2dinAAQ';
+const SUPA_ANON='sb_publishable_tUuqQQ8RKMvLDwTz5cKkOg_o_y-rHtw';
 async function uploadQImage(qIdx){
 const input=document.createElement('input');
 input.type='file';input.accept='image/*';input.capture='environment';

--- a/src/auth/githubAuth.js
+++ b/src/auth/githubAuth.js
@@ -10,7 +10,7 @@
 //   Then call: window.signInWithGitHub()
 
 const SUPA_URL = 'https://krmlzwwelqvlfslwltol.supabase.co';
-const SUPA_ANON = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImtybWx6d3dlbHF2bGZzbHdsdG9sIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzE5NjQxMDksImV4cCI6MjA4NzU0MDEwOX0.PFSuFgHA-WBnrgs4stmloxvOORSX0CiXDPsW2dinAAQ';
+const SUPA_ANON = 'sb_publishable_tUuqQQ8RKMvLDwTz5cKkOg_o_y-rHtw';
 
 let _supabase = null;
 


### PR DESCRIPTION
## Summary

Audit of the repo with the three diagnostic greps:

```
grep -rn "krmlzwwelqvlfslwltol" --include="*.js" --include="*.ts" --include="*.cjs" --include="*.mjs" --include="*.html" --include=".env*" .
grep -rn "sb_publishable_"      --include="*.js" --include="*.ts" --include="*.cjs" --include="*.mjs" --include="*.html" --include=".env*" .
grep -rn "eyJhbGciOi"            --include="*.js" --include="*.ts" --include="*.html" --include=".env*" .
```

**Before:**
- Project ref `krmlzwwelqvlfslwltol` — 5 hits (URLs / storage prefix / test fixture — all fine to keep).
- `sb_publishable_` — **0 hits** (publishable-key migration had not happened).
- Legacy JWT `eyJhbGciOi` — **2 hits** in `shlav-a-mega.html:1963` and `src/auth/githubAuth.js:13` (both `SUPA_ANON`).

**After:**
- Both `SUPA_ANON` constants now equal `sb_publishable_tUuqQQ8RKMvLDwTz5cKkOg_o_y-rHtw`.
- The legacy `eyJhbGciOi` JWT is no longer present anywhere in the tree.

## Why this is a drop-in

`SUPA_ANON` is consumed in ~10 fetch call sites as either the `apikey` header or `Authorization: Bearer <key>`. Supabase publishable keys are accepted in exactly those same slots, so no call-site, header, or test changes were required. Publishable keys are designed to be shipped in client code; access control continues to be enforced by RLS.

## Test plan

- [x] `npm test` — 693/693 passing, 23 test files, 2.18 s
- [x] Re-ran all three audit greps — legacy JWT grep returns empty; publishable-key grep returns the two expected hits
- [ ] Manual smoke on the live Pages build: image upload, leaderboard read/write, feedback submit, `samega_backups` cloud sync, GitHub OAuth sign-in


---
_Generated by [Claude Code](https://claude.ai/code/session_01LdpDazQdf9pREwymi8VS7f)_