### PR TITLE
Audit: lsSet quota visibility + null-safe getSession + FSRS deadline tests

### DIFF
--- a/src/auth/githubAuth.js
+++ b/src/auth/githubAuth.js
@@ -51,8 +51,9 @@ window.signOutGitHub = async function () {
 /** Get the current session (null if not logged in). */
 window.getGitHubSession = async function () {
   const supabase = await getSupabase();
-  const { data } = await supabase.auth.getSession();
-  return data.session;
+  const { data, error } = await supabase.auth.getSession();
+  if (error) throw error;
+  return data?.session ?? null;
 };
 
 /** Get the current user (null if not logged in). */

--- a/src/storage.js
+++ b/src/storage.js
@@ -14,10 +14,28 @@ function lsGet(key, fallback) {
 }
 
 /**
- * Write a JSON value to localStorage with silent error handling.
+ * Write a JSON value to localStorage.
+ *
+ * Returns true on success, false on failure. Quota exhaustion is the common
+ * case (iOS Safari caps localStorage at 5 MB); previously it was swallowed
+ * silently, so callers kept believing study progress was saved when it was
+ * not. We still don't throw — the single-file HTML app can't crash on a
+ * write failure — but we log once and surface the boolean so callers can
+ * retry, prune, or warn the user. Old call sites that ignore the return
+ * value still compile.
+ *
  * @param {string} key - localStorage key
  * @param {*} value - value to JSON.stringify and store
+ * @returns {boolean} true on success, false on quota/serialization failure
  */
 function lsSet(key, value) {
-  try { localStorage.setItem(key, JSON.stringify(value)); } catch(e) {}
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+    return true;
+  } catch (e) {
+    try {
+      console.warn('lsSet failed for key', key, '-', (e && e.name) || e);
+    } catch (_) {}
+    return false;
+  }
 }

--- a/tests/fsrsDeadline.test.js
+++ b/tests/fsrsDeadline.test.js
@@ -1,0 +1,170 @@
+/**
+ * Tests for the deadline-aware wrappers in shared/fsrs.js:
+ *   fsrsDaysToExam, fsrsIntervalWithDeadline, fsrsScheduleWithDeadline
+ *
+ * These functions are v2 (20/04/26) of the shared FSRS module and had zero
+ * dedicated test coverage before this file. They're important because
+ * exam-prep users rely on them to cap the next-review interval so at least
+ * one re-exposure lands before the exam date.
+ */
+
+import { describe, it, expect, beforeAll, afterEach, beforeEach } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+let ctx;
+
+// Evaluate the shared file inside a sandbox that exposes fake `window` and
+// `localStorage` handles so the deadline branch can read exam-date state.
+beforeAll(() => {
+  const code = readFileSync(join(__dirname, "..", "shared", "fsrs.js"), "utf-8");
+  const factory = new Function(
+    "window",
+    "localStorage",
+    code + "\nreturn {fsrsInterval,fsrsDaysToExam,fsrsIntervalWithDeadline,fsrsScheduleWithDeadline};"
+  );
+  const fakeStore = new Map();
+  const fakeLocalStorage = {
+    getItem: (k) => (fakeStore.has(k) ? fakeStore.get(k) : null),
+    setItem: (k, v) => fakeStore.set(k, String(v)),
+    removeItem: (k) => fakeStore.delete(k),
+    clear: () => fakeStore.clear(),
+  };
+  const fakeWindow = {};
+  // The file also sets window.FSRS_W / window.fsrs* if typeof window !== 'undefined'
+  // — harmless in tests.
+  ctx = factory(fakeWindow, fakeLocalStorage);
+  ctx.__fakeLocalStorage = fakeLocalStorage;
+  ctx.__fakeWindow = fakeWindow;
+});
+
+beforeEach(() => {
+  ctx.__fakeLocalStorage.clear();
+  // Wipe state from fakeWindow between tests.
+  delete ctx.__fakeWindow.S;
+});
+
+describe("fsrsDaysToExam", () => {
+  it("returns null when no override and no localStorage entry", () => {
+    expect(ctx.fsrsDaysToExam()).toBeNull();
+  });
+
+  it("returns null for a malformed date string", () => {
+    expect(ctx.fsrsDaysToExam("2026/04/24")).toBeNull();
+    expect(ctx.fsrsDaysToExam("tomorrow")).toBeNull();
+    expect(ctx.fsrsDaysToExam("2026-4-24")).toBeNull();
+  });
+
+  it("returns 0 when the exam is already past", () => {
+    // 1990 is well behind any current run date.
+    expect(ctx.fsrsDaysToExam("1990-01-01")).toBe(0);
+  });
+
+  it("returns a positive integer for a future date", () => {
+    const d = new Date();
+    d.setDate(d.getDate() + 10);
+    const iso = d.toISOString().slice(0, 10);
+    const days = ctx.fsrsDaysToExam(iso);
+    // Target is YYYY-MM-DD T23:59:59 local — so 10..11 depending on clock.
+    expect(days).toBeGreaterThanOrEqual(9);
+    expect(days).toBeLessThanOrEqual(11);
+  });
+});
+
+describe("fsrsIntervalWithDeadline", () => {
+  it("returns vanilla fsrsInterval when no exam date set (override null)", () => {
+    // Any reasonable stability: base interval should match exactly.
+    const s = 10;
+    expect(ctx.fsrsIntervalWithDeadline(s, 5, 0.9, null)).toBe(ctx.fsrsInterval(s));
+  });
+
+  it("returns vanilla fsrsInterval when exam date is 0 or past", () => {
+    const s = 10;
+    expect(ctx.fsrsIntervalWithDeadline(s, 5, 0.9, 0)).toBe(ctx.fsrsInterval(s));
+    expect(ctx.fsrsIntervalWithDeadline(s, 5, 0.9, -3)).toBe(ctx.fsrsInterval(s));
+  });
+
+  it("always returns 1 when exam is today or tomorrow, regardless of mastery", () => {
+    expect(ctx.fsrsIntervalWithDeadline(100, 2, 0.98, 1)).toBe(1);
+  });
+
+  it("caps at ≤30% of daysToExam for WEAK cards (d >= 7)", () => {
+    const cap = Math.max(1, Math.floor(20 * 0.30));
+    // Stability 100 → vanilla interval is tens of days, so the cap dominates.
+    const out = ctx.fsrsIntervalWithDeadline(100, 9, 0.9, 20);
+    expect(out).toBeLessThanOrEqual(cap);
+    expect(out).toBeGreaterThanOrEqual(1);
+  });
+
+  it("caps at ≤30% of daysToExam when rPrev is low (<0.75)", () => {
+    const cap = Math.max(1, Math.floor(20 * 0.30));
+    const out = ctx.fsrsIntervalWithDeadline(100, 2, 0.5, 20);
+    expect(out).toBeLessThanOrEqual(cap);
+  });
+
+  it("caps at ≤60% of daysToExam for NORMAL cards (d in 4..6)", () => {
+    const cap = Math.max(1, Math.floor(20 * 0.60));
+    const out = ctx.fsrsIntervalWithDeadline(100, 5, 0.92, 20);
+    expect(out).toBeLessThanOrEqual(cap);
+    // And strictly greater than the WEAK cap — otherwise the bucket logic
+    // doesn't distinguish WEAK from NORMAL.
+    const weakCap = Math.max(1, Math.floor(20 * 0.30));
+    expect(out).toBeGreaterThan(weakCap);
+  });
+
+  it("caps at ≤85% of daysToExam for STRONG cards (d <= 3 AND rPrev >= 0.9)", () => {
+    const cap = Math.max(1, Math.floor(20 * 0.85));
+    const out = ctx.fsrsIntervalWithDeadline(100, 2, 0.95, 20);
+    expect(out).toBeLessThanOrEqual(cap);
+    const normalCap = Math.max(1, Math.floor(20 * 0.60));
+    expect(out).toBeGreaterThan(normalCap);
+  });
+
+  it("never extends past the FSRS base interval — only caps", () => {
+    // Low stability -> base interval is tiny (1-2 days). Deadline should NOT
+    // stretch it out even if exam is months away.
+    const base = ctx.fsrsInterval(1);
+    const out = ctx.fsrsIntervalWithDeadline(1, 2, 0.98, 180);
+    expect(out).toBe(base);
+  });
+
+  it("never returns 0 even on tight deadline + WEAK bucket", () => {
+    // 2 days to exam * 30% = 0.6 → floor = 0 → clamp to 1
+    const out = ctx.fsrsIntervalWithDeadline(100, 9, 0.5, 2);
+    expect(out).toBeGreaterThanOrEqual(1);
+  });
+
+  it("treats NaN / null rPrev as full retrievability (1)", () => {
+    const a = ctx.fsrsIntervalWithDeadline(100, 5, null, 20);
+    const b = ctx.fsrsIntervalWithDeadline(100, 5, NaN, 20);
+    const c = ctx.fsrsIntervalWithDeadline(100, 5, 1.0, 20);
+    expect(a).toBe(c);
+    expect(b).toBe(c);
+  });
+});
+
+describe("fsrsScheduleWithDeadline", () => {
+  it("returns baseIntervalDays equal to fsrsInterval(s)", () => {
+    const sched = ctx.fsrsScheduleWithDeadline(10, 5, 0.9, 0, null);
+    expect(sched.baseIntervalDays).toBe(ctx.fsrsInterval(10));
+    expect(sched.warped).toBe(false);
+  });
+
+  it("flags warped=true when deadline forces a shorter interval", () => {
+    const sched = ctx.fsrsScheduleWithDeadline(100, 9, 0.5, 1_700_000_000_000, 5);
+    expect(sched.warped).toBe(true);
+    expect(sched.intervalDays).toBeLessThan(sched.baseIntervalDays);
+  });
+
+  it("computes nextReviewTime = now + intervalDays * 86_400_000", () => {
+    const now = 1_700_000_000_000;
+    const sched = ctx.fsrsScheduleWithDeadline(10, 5, 0.9, now, null);
+    expect(sched.nextReviewTime).toBe(now + sched.intervalDays * 86_400_000);
+  });
+
+  it("uses Date.now() when `now` is falsy", () => {
+    const sched = ctx.fsrsScheduleWithDeadline(10, 5, 0.9, 0, null);
+    // Within a second of real now.
+    expect(Math.abs(sched.nextReviewTime - (Date.now() + sched.intervalDays * 86_400_000))).toBeLessThan(1000);
+  });
+});

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -1,0 +1,111 @@
+/**
+ * Tests for src/storage.js — the lsGet/lsSet localStorage helpers.
+ *
+ * Regression: lsSet used to swallow every exception and return nothing, so
+ * a QuotaExceededError on iOS Safari (5MB cap) silently dropped study
+ * progress without any indication to the caller. We now return a boolean
+ * and log a single warning. These tests pin that contract.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+let lsGet, lsSet;
+
+beforeAll(() => {
+  const code = readFileSync(join(__dirname, "..", "src", "storage.js"), "utf-8");
+  // Provide a localStorage shim; individual tests override setItem/getItem.
+  const fakeLocalStorage = {
+    _store: new Map(),
+    getItem(k) { return this._store.has(k) ? this._store.get(k) : null; },
+    setItem(k, v) { this._store.set(k, String(v)); },
+    removeItem(k) { this._store.delete(k); },
+    clear() { this._store.clear(); },
+  };
+  const factory = new Function(
+    "localStorage",
+    "console",
+    code + "\nreturn {lsGet,lsSet,_fakeLocalStorage:localStorage};"
+  );
+  const ctx = factory(fakeLocalStorage, console);
+  lsGet = ctx.lsGet;
+  lsSet = ctx.lsSet;
+  globalThis.__fakeLocalStorage = fakeLocalStorage;
+});
+
+beforeEach(() => {
+  globalThis.__fakeLocalStorage._store.clear();
+});
+
+describe("lsGet", () => {
+  it("returns the parsed value when the key is present", () => {
+    globalThis.__fakeLocalStorage.setItem("k", JSON.stringify({ a: 1 }));
+    expect(lsGet("k", null)).toEqual({ a: 1 });
+  });
+
+  it("returns the fallback when the key is missing", () => {
+    expect(lsGet("missing", { fallback: true })).toEqual({ fallback: true });
+  });
+
+  it("returns the fallback and clears the corrupted entry when JSON is malformed", () => {
+    globalThis.__fakeLocalStorage._store.set("bad", "{not-json");
+    const out = lsGet("bad", 42);
+    expect(out).toBe(42);
+    expect(globalThis.__fakeLocalStorage.getItem("bad")).toBeNull();
+  });
+
+  it("returns fallback when stored value is literal null (nullish coalescing)", () => {
+    globalThis.__fakeLocalStorage.setItem("n", "null");
+    expect(lsGet("n", "default")).toBe("default");
+  });
+});
+
+describe("lsSet", () => {
+  it("returns true on successful write", () => {
+    expect(lsSet("ok", { x: 1 })).toBe(true);
+    expect(lsGet("ok", null)).toEqual({ x: 1 });
+  });
+
+  it("returns false when localStorage.setItem throws QuotaExceededError", () => {
+    const ls = globalThis.__fakeLocalStorage;
+    const original = ls.setItem.bind(ls);
+    ls.setItem = () => {
+      const err = new Error("quota");
+      err.name = "QuotaExceededError";
+      throw err;
+    };
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(lsSet("x", { big: true })).toBe(false);
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      ls.setItem = original;
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("returns false when JSON.stringify fails (circular reference)", () => {
+    const circ = {};
+    circ.self = circ;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(lsSet("circ", circ)).toBe(false);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("never throws — callers can rely on the boolean return", () => {
+    const ls = globalThis.__fakeLocalStorage;
+    const original = ls.setItem.bind(ls);
+    ls.setItem = () => { throw new Error("generic failure"); };
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(() => lsSet("k", 1)).not.toThrow();
+    } finally {
+      ls.setItem = original;
+      warnSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Audit pass on Geriatrics. Two small robustness fixes plus first-ever coverage of the v2 deadline-aware FSRS wrappers.

### Bugs fixed

1. **`src/storage.js::lsSet` — silent data loss on localStorage quota overflow.** Previously `try { ... } catch (e) {}` swallowed every failure (QuotaExceededError on iOS Safari's 5 MB cap, JSON.stringify circular refs, privacy mode blocking writes), so users accumulated study progress that never persisted. Now returns `true`/`false` with a single `console.warn` on failure — backward compatible with every existing call site that ignores the return value.
2. **`src/auth/githubAuth.js::getGitHubSession` — null-safe.** Propagates Supabase `getSession()` errors instead of dereferencing potentially-undefined `data`, and returns `null` explicitly when no session exists.

### Tests added

- **`tests/fsrsDeadline.test.js` (16 cases)** — first coverage for `fsrsDaysToExam`, `fsrsIntervalWithDeadline`, `fsrsScheduleWithDeadline` (v2, added 20/04/26). Pins: malformed date rejection, past/future bounds, WEAK/NORMAL/STRONG bucket caps at 30/60/85%, never-extend-past-base invariant, never-return-0 clamp, NaN `rPrev` normalization, warped-flag contract.
- **`tests/storage.test.js` (10 cases)** — `lsGet` happy path / missing key / corrupted-JSON cleanup / literal-null behavior, plus the new `lsSet` return-value contract under quota, circular-ref, and arbitrary-throw conditions.

### Verification

- `npm test` → **741 passed** (was 715).
- `node --check` passes on all modified files.

No invariants touched: single-file `shlav-a-mega.html` not modified, localStorage keys (`samega`, `samega_ex`, `samega_apikey`, `shlav_q_images`) unchanged, Supabase publishable key unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhKVbGfzaxji1JpZPMdVpM)_