### PR TITLE
v10.46.0 — Study Plan generator (mirror of Mishpacha v1.9.1 + Pnimit v9.86.0)

### DIFF
--- a/data/syllabus_data.json
+++ b/data/syllabus_data.json
@@ -1,0 +1,1731 @@
+{
+  "Geri": {
+    "repo": "Eiasash/Geriatrics",
+    "total_questions_analyzed": 3833,
+    "total_topics": 46,
+    "topics": [
+      {
+        "id": 8,
+        "en": "Polypharmacy & Deprescribing",
+        "he": "פוליפרמסיה ודיפרסקריבינג",
+        "keywords": [
+          "polypharm",
+          "Beers",
+          "STOPP",
+          "START",
+          "deprescrib",
+          "אנטיכולינרג",
+          "anticholinerg",
+          "ACB",
+          "prescribing cascade",
+          "PIM"
+        ],
+        "n_questions": 318,
+        "frequency_pct": 8.3,
+        "weight": 3.82
+      },
+      {
+        "id": 26,
+        "en": "Cancer in the Elderly",
+        "he": "סרטן בקשישים",
+        "keywords": [
+          "cancer",
+          "oncolog",
+          "סרטן",
+          "tumor",
+          "chemo",
+          "malign",
+          "metasta",
+          "neoplasm",
+          "tumor lysis",
+          "typhlitis"
+        ],
+        "n_questions": 201,
+        "frequency_pct": 5.2,
+        "weight": 2.41
+      },
+      {
+        "id": 6,
+        "en": "Dementia",
+        "he": "דמנציה",
+        "keywords": [
+          "dementia",
+          "דמנציה",
+          "alzheimer",
+          "אלצהיימר",
+          "DLB",
+          "FTD",
+          "MMSE",
+          "MoCA",
+          "CDR",
+          "lewy",
+          "amyloid"
+        ],
+        "n_questions": 183,
+        "frequency_pct": 4.8,
+        "weight": 2.2
+      },
+      {
+        "id": 27,
+        "en": "Infections",
+        "he": "זיהומים",
+        "keywords": [
+          "infect",
+          "זיהום",
+          "antibiotic",
+          "pneumonia",
+          "UTI",
+          "sepsis",
+          "bacterem",
+          "immunosenesc",
+          "nitrofurantoin"
+        ],
+        "n_questions": 179,
+        "frequency_pct": 4.7,
+        "weight": 2.15
+      },
+      {
+        "id": 5,
+        "en": "Delirium",
+        "he": "דליריום",
+        "keywords": [
+          "delirium",
+          "דליריום",
+          "CAM",
+          "בלבול",
+          "confusion",
+          "4AT",
+          "HELP protocol",
+          "hypoactive"
+        ],
+        "n_questions": 176,
+        "frequency_pct": 4.6,
+        "weight": 2.11
+      },
+      {
+        "id": 4,
+        "en": "Falls",
+        "he": "נפילות",
+        "keywords": [
+          "fall",
+          "נפיל",
+          "TUG",
+          "orthostatic",
+          "balance",
+          "hip protector",
+          "Tai Chi"
+        ],
+        "n_questions": 141,
+        "frequency_pct": 3.7,
+        "weight": 1.69
+      },
+      {
+        "id": 28,
+        "en": "Palliative Care",
+        "he": "טיפול פליאטיבי",
+        "keywords": [
+          "palliati",
+          "הנוטה למות",
+          "hospice",
+          "end of life",
+          "dyspnea",
+          "Mitchell",
+          "comfort",
+          "FAST 7",
+          "NG tube",
+          "PEG tube"
+        ],
+        "n_questions": 120,
+        "frequency_pct": 3.1,
+        "weight": 1.44
+      },
+      {
+        "id": 11,
+        "en": "Urinary Incontinence",
+        "he": "אי-נקיטות שתן",
+        "keywords": [
+          "incontinen",
+          "שלפוחית",
+          "bladder",
+          "urinary",
+          "detrusor",
+          "Kegel",
+          "שתן",
+          "אצירת שתן",
+          "fecal",
+          "stool",
+          "sphincter",
+          "RAIR",
+          "overflow",
+          "צואה",
+          "אי-נקיטת צואה",
+          "אי נקיטת צואה"
+        ],
+        "n_questions": 117,
+        "frequency_pct": 3.1,
+        "weight": 1.4
+      },
+      {
+        "id": 17,
+        "en": "Cardiology — IHD & ACS",
+        "he": "קרדיולוגיה — איסכמיה ו-ACS",
+        "keywords": [
+          "cardio",
+          "cardiovascul",
+          "coronar",
+          "MI",
+          "ischemi",
+          "angina",
+          "stent",
+          "PVD",
+          "peripheral vascular"
+        ],
+        "n_questions": 116,
+        "frequency_pct": 3.0,
+        "weight": 1.39
+      },
+      {
+        "id": 14,
+        "en": "Pain Management",
+        "he": "טיפול בכאב",
+        "keywords": [
+          "pain",
+          "כאב",
+          "analges",
+          "opioid",
+          "WHO ladder",
+          "gabapentin",
+          "acetaminophen",
+          "morphine"
+        ],
+        "n_questions": 113,
+        "frequency_pct": 2.9,
+        "weight": 1.36
+      },
+      {
+        "id": 29,
+        "en": "Medical Ethics & Capacity",
+        "he": "אתיקה רפואית וכשירות",
+        "keywords": [
+          "ethic",
+          "אתיק",
+          "autonomy",
+          "beneficence",
+          "capacity",
+          "כשירות",
+          "informed consent",
+          "futility",
+          "rationing"
+        ],
+        "n_questions": 111,
+        "frequency_pct": 2.9,
+        "weight": 1.33
+      },
+      {
+        "id": 34,
+        "en": "Advance Directives",
+        "he": "הנחיות מקדימות",
+        "keywords": [
+          "advance directive",
+          "הנחיות מקדימות",
+          "הנוטה למות",
+          "living will",
+          "DNR",
+          "withhold",
+          "withdraw"
+        ],
+        "n_questions": 105,
+        "frequency_pct": 2.7,
+        "weight": 1.26
+      },
+      {
+        "id": 38,
+        "en": "Perioperative Care",
+        "he": "טיפול פריאופרטיבי",
+        "keywords": [
+          "periop",
+          "surgery",
+          "ניתוח",
+          "preop",
+          "postop",
+          "anesthes",
+          "DVT prophylaxis",
+          "hip fracture"
+        ],
+        "n_questions": 103,
+        "frequency_pct": 2.7,
+        "weight": 1.24
+      },
+      {
+        "id": 24,
+        "en": "Kidney Disease",
+        "he": "מחלות כליה",
+        "keywords": [
+          "kidney",
+          "כלי",
+          "CKD",
+          "creatinin",
+          "GFR",
+          "nephro",
+          "renal",
+          "dialys",
+          "aminoglycoside"
+        ],
+        "n_questions": 102,
+        "frequency_pct": 2.7,
+        "weight": 1.22
+      },
+      {
+        "id": 18,
+        "en": "Heart Failure",
+        "he": "אי ספיקת לב",
+        "keywords": [
+          "heart fail",
+          "אי ספיקת לב",
+          "HFrEF",
+          "HFpEF",
+          "EF",
+          "ARNI",
+          "ejection",
+          "carvedilol",
+          "spironolactone"
+        ],
+        "n_questions": 99,
+        "frequency_pct": 2.6,
+        "weight": 1.19
+      },
+      {
+        "id": 36,
+        "en": "Rehabilitation",
+        "he": "שיקום",
+        "keywords": [
+          "rehabilit",
+          "שיקום",
+          "FIM",
+          "physiotherapy",
+          "PT",
+          "OT",
+          "mobiliz",
+          "motor",
+          "walking stick"
+        ],
+        "n_questions": 96,
+        "frequency_pct": 2.5,
+        "weight": 1.15
+      },
+      {
+        "id": 40,
+        "en": "Parkinson's Disease",
+        "he": "מחלת פרקינסון",
+        "keywords": [
+          "parkinson",
+          "פרקינסון",
+          "levodopa",
+          "L-DOPA",
+          "carbidopa",
+          "סינמט",
+          "madopar",
+          "pramipexol",
+          "ropinirole",
+          "rasagiline",
+          "selegiline",
+          "entacapone",
+          "rotigotine",
+          "amantadine",
+          "apomorphine",
+          "DBS",
+          "deep brain stim",
+          "גירוי מוחי עמוק",
+          "bradykines",
+          "רעד במנוחה",
+          "MSA",
+          "PSP",
+          "corticobasal",
+          "Hoehn-Yahr",
+          "UPDRS",
+          "dyskinesi",
+          "on-off",
+          "פרקינסוני",
+          "פרקינסוניזם"
+        ],
+        "n_questions": 94,
+        "frequency_pct": 2.5,
+        "weight": 1.13
+      },
+      {
+        "id": 0,
+        "en": "Biology of Aging",
+        "he": "ביולוגיה של ההזדקנות",
+        "keywords": [
+          "biology",
+          "aging",
+          "telomer",
+          "senesc",
+          "ROS",
+          "oxidat",
+          "hayflick",
+          "caloric"
+        ],
+        "n_questions": 88,
+        "frequency_pct": 2.3,
+        "weight": 1.06
+      },
+      {
+        "id": 12,
+        "en": "Constipation",
+        "he": "עצירות",
+        "keywords": [
+          "constipat",
+          "עצירות",
+          "lactulose",
+          "bisacodyl",
+          "senna",
+          "PEG",
+          "laxat",
+          "normalax"
+        ],
+        "n_questions": 83,
+        "frequency_pct": 2.2,
+        "weight": 1.0
+      },
+      {
+        "id": 3,
+        "en": "Frailty & Sarcopenia",
+        "he": "שבריריות וסרקופניה",
+        "keywords": [
+          "frail",
+          "שבריר",
+          "sarcopenia",
+          "EWGSOP",
+          "SARC-F",
+          "Fried",
+          "CFS",
+          "grip strength"
+        ],
+        "n_questions": 79,
+        "frequency_pct": 2.1,
+        "weight": 0.95
+      },
+      {
+        "id": 10,
+        "en": "Pressure Ulcers",
+        "he": "פצעי לחץ",
+        "keywords": [
+          "pressure",
+          "פצע לחץ",
+          "decubit",
+          "Braden",
+          "Norton",
+          "NPUAP",
+          "wound",
+          "dressing",
+          "ulcer stage"
+        ],
+        "n_questions": 79,
+        "frequency_pct": 2.1,
+        "weight": 0.95
+      },
+      {
+        "id": 22,
+        "en": "Diabetes",
+        "he": "סוכרת",
+        "keywords": [
+          "diabet",
+          "סוכרת",
+          "HbA1c",
+          "A1c",
+          "metformin",
+          "insulin",
+          "SGLT2",
+          "glipizide",
+          "hypoglycem",
+          "ACCORD"
+        ],
+        "n_questions": 72,
+        "frequency_pct": 1.9,
+        "weight": 0.86
+      },
+      {
+        "id": 35,
+        "en": "Community & Long-Term Care",
+        "he": "קהילה וטיפול ממושך",
+        "keywords": [
+          "community",
+          "קהיל",
+          "long-term",
+          "nursing home",
+          "home care",
+          "day center",
+          "CAPABLE",
+          "kupat"
+        ],
+        "n_questions": 69,
+        "frequency_pct": 1.8,
+        "weight": 0.83
+      },
+      {
+        "id": 7,
+        "en": "Depression in the Elderly",
+        "he": "דיכאון בקשישים",
+        "keywords": [
+          "depress",
+          "דיכאון",
+          "GDS",
+          "SSRI",
+          "antidepress",
+          "ECT",
+          "pseudodementia",
+          "bupropion",
+          "mirtazapine"
+        ],
+        "n_questions": 66,
+        "frequency_pct": 1.7,
+        "weight": 0.79
+      },
+      {
+        "id": 20,
+        "en": "Stroke",
+        "he": "שבץ מוחי",
+        "keywords": [
+          "stroke",
+          "שבץ",
+          "CVA",
+          "TIA",
+          "ABCD2",
+          "MCA",
+          "ACA",
+          "PCA",
+          "aphasia",
+          "hemipl",
+          "thrombolys"
+        ],
+        "n_questions": 62,
+        "frequency_pct": 1.6,
+        "weight": 0.74
+      },
+      {
+        "id": 15,
+        "en": "Osteoporosis",
+        "he": "אוסטאופורוזיס",
+        "keywords": [
+          "osteopor",
+          "צפיפות עצם",
+          "T-score",
+          "FRAX",
+          "bisphosph",
+          "denosumab",
+          "alendronate",
+          "zoledronic",
+          "bone density"
+        ],
+        "n_questions": 61,
+        "frequency_pct": 1.6,
+        "weight": 0.73
+      },
+      {
+        "id": 21,
+        "en": "Pulmonary Disease (COPD)",
+        "he": "מחלות ריאה (COPD)",
+        "keywords": [
+          "COPD",
+          "pulmon",
+          "ריאה",
+          "FEV1",
+          "FVC",
+          "DLCO",
+          "pneumon",
+          "respiratory",
+          "IPF",
+          "residual volume"
+        ],
+        "n_questions": 61,
+        "frequency_pct": 1.6,
+        "weight": 0.73
+      },
+      {
+        "id": 25,
+        "en": "Anemia",
+        "he": "אנמיה",
+        "keywords": [
+          "anem",
+          "המוגלובין",
+          "iron",
+          "ferritin",
+          "B12",
+          "MDS",
+          "erythropoietin",
+          "transferrin"
+        ],
+        "n_questions": 61,
+        "frequency_pct": 1.6,
+        "weight": 0.73
+      },
+      {
+        "id": 16,
+        "en": "Osteoarthritis",
+        "he": "אוסטאוארטריטיס",
+        "keywords": [
+          "osteoarth",
+          "OA",
+          "מפרק",
+          "joint",
+          "arthr",
+          "TENS",
+          "arthroplasty"
+        ],
+        "n_questions": 58,
+        "frequency_pct": 1.5,
+        "weight": 0.7
+      },
+      {
+        "id": 30,
+        "en": "Elder Abuse",
+        "he": "התעללות בקשישים",
+        "keywords": [
+          "abuse",
+          "התעללות",
+          "neglect",
+          "mandatory report",
+          "elder abuse"
+        ],
+        "n_questions": 57,
+        "frequency_pct": 1.5,
+        "weight": 0.68
+      },
+      {
+        "id": 41,
+        "en": "Arrhythmias",
+        "he": "הפרעות קצב",
+        "keywords": [
+          "arrhythm",
+          "הפרעת קצב",
+          "הפרעות קצב",
+          "atrial fibrill",
+          "פרפור עליות",
+          "פרפור פרוזדורים",
+          "AFib",
+          "atrial flutter",
+          "רפרוף עליות",
+          "sick sinus",
+          "SSS",
+          "tachy-brady",
+          "AV block",
+          "חסם AV",
+          "חסם הולכה",
+          "heart block",
+          "pacemaker",
+          "קוצב לב",
+          "biventricular",
+          "CRT",
+          "bradyarrhythm",
+          "ברדיקרדי",
+          "SVT",
+          "ventricular tachy",
+          "VT",
+          "VF",
+          "torsades",
+          "long QT",
+          "WPW",
+          "Wolff-Parkinson",
+          "CHA2DS2",
+          "HAS-BLED",
+          "rate control",
+          "rhythm control",
+          "cardioversion",
+          "ablation",
+          "amiodarone",
+          "apixaban",
+          "rivaroxaban",
+          "edoxaban",
+          "dabigatran"
+        ],
+        "n_questions": 50,
+        "frequency_pct": 1.3,
+        "weight": 0.6
+      },
+      {
+        "id": 9,
+        "en": "Nutrition",
+        "he": "תזונה",
+        "keywords": [
+          "nutrit",
+          "malnutrit",
+          "MNA",
+          "תזונ",
+          "albumin",
+          "BMI",
+          "weight loss",
+          "ירידה במשקל",
+          "protein"
+        ],
+        "n_questions": 48,
+        "frequency_pct": 1.3,
+        "weight": 0.58
+      },
+      {
+        "id": 23,
+        "en": "Thyroid Disorders",
+        "he": "מחלות בלוטת התריס",
+        "keywords": [
+          "thyroid",
+          "תירואיד",
+          "TSH",
+          "levothyrox",
+          "amiodarone",
+          "hypothyroid",
+          "hyperthyroid",
+          "euthyroid"
+        ],
+        "n_questions": 46,
+        "frequency_pct": 1.2,
+        "weight": 0.55
+      },
+      {
+        "id": 32,
+        "en": "Guardianship & Power of Attorney",
+        "he": "אפוטרופסות וייפוי כוח",
+        "keywords": [
+          "guardian",
+          "אפוטרופ",
+          "ייפוי כוח",
+          "legal capacity",
+          "power of attorney",
+          "תשוש נפש"
+        ],
+        "n_questions": 44,
+        "frequency_pct": 1.1,
+        "weight": 0.53
+      },
+      {
+        "id": 2,
+        "en": "Comprehensive Geriatric Assessment",
+        "he": "הערכה גריאטרית כוללנית",
+        "keywords": [
+          "CGA",
+          "geriatric assessment",
+          "הערכה",
+          "ADL",
+          "IADL",
+          "FIM",
+          "Barthel",
+          "Katz",
+          "comprehensive"
+        ],
+        "n_questions": 39,
+        "frequency_pct": 1.0,
+        "weight": 0.47
+      },
+      {
+        "id": 13,
+        "en": "Sleep Disorders",
+        "he": "הפרעות שינה",
+        "keywords": [
+          "sleep",
+          "שינה",
+          "insomnia",
+          "melatonin",
+          "zolpidem",
+          "OSA",
+          "CPAP",
+          "RBD"
+        ],
+        "n_questions": 38,
+        "frequency_pct": 1.0,
+        "weight": 0.46
+      },
+      {
+        "id": 37,
+        "en": "Vision & Hearing",
+        "he": "ראייה ושמיעה",
+        "keywords": [
+          "vision",
+          "hearing",
+          "שמיעה",
+          "ראיה",
+          "presbycusis",
+          "cataract",
+          "macular",
+          "AMD",
+          "glaucoma"
+        ],
+        "n_questions": 36,
+        "frequency_pct": 0.9,
+        "weight": 0.43
+      },
+      {
+        "id": 39,
+        "en": "Geriatric Emergency Medicine",
+        "he": "רפואת חירום גריאטרית",
+        "keywords": [
+          "emergency",
+          "מיון",
+          "ED ",
+          "triage",
+          "geriatric emergency",
+          "EQUiPPED",
+          "typhlitis",
+          "atypical present"
+        ],
+        "n_questions": 36,
+        "frequency_pct": 0.9,
+        "weight": 0.43
+      },
+      {
+        "id": 31,
+        "en": "Driving Fitness",
+        "he": "כשירות לנהיגה",
+        "keywords": [
+          "driv",
+          "נהיגה",
+          "מרב\"ד",
+          "license",
+          "CDR",
+          "רישיון",
+          "road safety"
+        ],
+        "n_questions": 34,
+        "frequency_pct": 0.9,
+        "weight": 0.41
+      },
+      {
+        "id": 44,
+        "en": "Preventive Screening (USPSTF)",
+        "he": "סקרינינג מונע (USPSTF)",
+        "keywords": [
+          "USPSTF",
+          "prevent",
+          "מניעה",
+          "screen",
+          "סקירה",
+          "מבחן סקר",
+          "vaccin",
+          "חיסון",
+          "immuniz",
+          "chemoprev",
+          "primary prevention",
+          "secondary prevention",
+          "מניעה ראשונית",
+          "מניעה משנית",
+          "health promotion",
+          "קידום בריאות",
+          "preventive home visit",
+          "AAA screen",
+          "colon cancer screen",
+          "mammog",
+          "PSA"
+        ],
+        "n_questions": 34,
+        "frequency_pct": 0.9,
+        "weight": 0.41
+      },
+      {
+        "id": 1,
+        "en": "Demography of Aging",
+        "he": "דמוגרפיה של ההזדקנות",
+        "keywords": [
+          "demograph",
+          "epidemiol",
+          "brookdale",
+          "תוחלת",
+          "אוכלוסי",
+          "life expectancy"
+        ],
+        "n_questions": 33,
+        "frequency_pct": 0.9,
+        "weight": 0.4
+      },
+      {
+        "id": 42,
+        "en": "Dysphagia",
+        "he": "דיספגיה",
+        "keywords": [
+          "dysphag",
+          "בליעה",
+          "הפרעת בליעה",
+          "הפרעות בליעה",
+          "swallow",
+          "VFSS",
+          "videofluoroscop",
+          "FEES",
+          "fiberoptic endoscop",
+          "aspiration pneumon",
+          "דלקת ריאות אספיר",
+          "אספירציה",
+          "oropharyngeal",
+          "cricopharyng",
+          "zenker",
+          "thickened liquid",
+          "מזון טחון",
+          "מרקם טחון",
+          "PEG tube",
+          "NG tube",
+          "זונדה",
+          "nasogastric",
+          "gastrostomy",
+          "penetration-aspiration",
+          "PAS",
+          "speech language",
+          "SLP",
+          "קלינאי תקשורת",
+          "קלינאית תקשורת"
+        ],
+        "n_questions": 33,
+        "frequency_pct": 0.9,
+        "weight": 0.4
+      },
+      {
+        "id": 19,
+        "en": "Hypertension",
+        "he": "יתר לחץ דם",
+        "keywords": [
+          "hyperten",
+          "לחץ דם",
+          "SPRINT",
+          "HYVET",
+          "amlodipine",
+          "HTN",
+          "antihypertens",
+          "doxazosin"
+        ],
+        "n_questions": 31,
+        "frequency_pct": 0.8,
+        "weight": 0.37
+      },
+      {
+        "id": 33,
+        "en": "Patient Rights",
+        "he": "זכויות החולה",
+        "keywords": [
+          "patient right",
+          "זכויות החולה",
+          "informed consent",
+          "refuse",
+          "privacy",
+          "סודיות",
+          "autonomy"
+        ],
+        "n_questions": 31,
+        "frequency_pct": 0.8,
+        "weight": 0.37
+      },
+      {
+        "id": 43,
+        "en": "Andropause",
+        "he": "אנדרופאוזה",
+        "keywords": [
+          "androp",
+          "אנדרופאוז",
+          "testosteron",
+          "טסטוסטרון",
+          "hypogonad",
+          "היפוגונדיזם",
+          "aging man",
+          "libido",
+          "תשוקה מינית",
+          "erectile dys",
+          "ED",
+          "אין-אונות",
+          "BPH",
+          "PDE5",
+          "sildenafil",
+          "tadalafil",
+          "androgen deficiency"
+        ],
+        "n_questions": 21,
+        "frequency_pct": 0.5,
+        "weight": 0.25
+      },
+      {
+        "id": 45,
+        "en": "Interdisciplinary Team",
+        "he": "צוות רב-מקצועי",
+        "keywords": [
+          "interdisciplin",
+          "multidisciplin",
+          "interprofes",
+          "צוות בין-תחומי",
+          "צוות גריאטרי",
+          "Guided Care",
+          "GRACE",
+          "PACE program",
+          "Program of All-Inclusive",
+          "transitional care",
+          "Care Transitions",
+          "transitions of care",
+          "team-based",
+          "patient coach",
+          "care coordin",
+          "תיאום טיפול",
+          "hospital at home",
+          "בית חולים בבית"
+        ],
+        "n_questions": 9,
+        "frequency_pct": 0.2,
+        "weight": 0.11
+      }
+    ]
+  },
+  "Pnimit": {
+    "repo": "Eiasash/InternalMedicine",
+    "total_questions_analyzed": 1556,
+    "total_topics": 24,
+    "topics": [
+      {
+        "id": 0,
+        "en": "Cardiology — IHD & ACS",
+        "he": "קרדיולוגיה — איסכמיה ו-ACS",
+        "keywords": [
+          "cardio",
+          "cardiovascul",
+          "coronar",
+          "MI",
+          "ischemi",
+          "angina",
+          "stent",
+          "ACS",
+          "STEMI",
+          "NSTEMI",
+          "PCI",
+          "CABG",
+          "troponin"
+        ],
+        "n_questions": 131,
+        "frequency_pct": 8.4,
+        "weight": 2.02
+      },
+      {
+        "id": 22,
+        "en": "Clinical Reasoning & Workup",
+        "he": "חשיבה קלינית ובירור",
+        "keywords": [
+          "clinical",
+          "approach",
+          "differenti",
+          "diagnostic",
+          "workup",
+          "imaging",
+          "lab",
+          "screening",
+          "prevention"
+        ],
+        "n_questions": 130,
+        "frequency_pct": 8.4,
+        "weight": 2.01
+      },
+      {
+        "id": 5,
+        "en": "Pulmonary Diseases",
+        "he": "מחלות ריאה",
+        "keywords": [
+          "pulmon",
+          "lung",
+          "COPD",
+          "asthma",
+          "pneumon",
+          "respiratory",
+          "FEV1",
+          "FVC",
+          "bronch",
+          "ARDS",
+          "pulmonary embol",
+          "PE",
+          "DVT",
+          "VTE",
+          "sarcoid",
+          "IPF",
+          "PAH",
+          "sotatercept"
+        ],
+        "n_questions": 105,
+        "frequency_pct": 6.7,
+        "weight": 1.62
+      },
+      {
+        "id": 10,
+        "en": "Hematology",
+        "he": "המטולוגיה",
+        "keywords": [
+          "hematol",
+          "anemia",
+          "iron",
+          "ferritin",
+          "B12",
+          "leukemia",
+          "lymphoma",
+          "thrombocyt",
+          "coagul",
+          "bleeding",
+          "DVT",
+          "anticoagul",
+          "warfarin",
+          "apixaban",
+          "heparin",
+          "myeloma",
+          "MDS"
+        ],
+        "n_questions": 93,
+        "frequency_pct": 6.0,
+        "weight": 1.43
+      },
+      {
+        "id": 6,
+        "en": "Gastroenterology & Hepatology",
+        "he": "גסטרואנטרולוגיה והפטולוגיה",
+        "keywords": [
+          "gastro",
+          "GI",
+          "liver",
+          "hepat",
+          "cirrhosis",
+          "IBD",
+          "Crohn",
+          "colitis",
+          "GERD",
+          "pancreat",
+          "GI bleed",
+          "ascites",
+          "portal hypertens",
+          "varices"
+        ],
+        "n_questions": 88,
+        "frequency_pct": 5.7,
+        "weight": 1.36
+      },
+      {
+        "id": 13,
+        "en": "Rheumatology & Autoimmune",
+        "he": "ראומטולוגיה ואוטואימונית",
+        "keywords": [
+          "rheumatol",
+          "autoimmun",
+          "lupus",
+          "SLE",
+          "vasculitis",
+          "rheumatoid",
+          "scleroderma",
+          "sarcoid",
+          "giant cell",
+          "GCA",
+          "ANCA",
+          "upadacitinib",
+          "gout",
+          "crystal"
+        ],
+        "n_questions": 79,
+        "frequency_pct": 5.1,
+        "weight": 1.22
+      },
+      {
+        "id": 1,
+        "en": "Heart Failure",
+        "he": "אי ספיקת לב",
+        "keywords": [
+          "heart fail",
+          "HFrEF",
+          "HFpEF",
+          "EF",
+          "ARNI",
+          "ejection",
+          "carvedilol",
+          "spironolactone",
+          "digitoxin",
+          "sacubitril",
+          "SGLT2",
+          "BNP",
+          "NT-proBNP"
+        ],
+        "n_questions": 68,
+        "frequency_pct": 4.4,
+        "weight": 1.05
+      },
+      {
+        "id": 12,
+        "en": "Infectious Diseases",
+        "he": "מחלות זיהומיות",
+        "keywords": [
+          "infect",
+          "antibiotic",
+          "sepsis",
+          "bacteremia",
+          "bloodstream",
+          "pneumonia",
+          "UTI",
+          "endocarditis",
+          "meningitis",
+          "osteomyelitis",
+          "HIV",
+          "TB",
+          "fungal",
+          "viral"
+        ],
+        "n_questions": 64,
+        "frequency_pct": 4.1,
+        "weight": 0.99
+      },
+      {
+        "id": 7,
+        "en": "Renal — CKD & AKI",
+        "he": "כליה — CKD ו-AKI",
+        "keywords": [
+          "kidney",
+          "renal",
+          "CKD",
+          "AKI",
+          "creatinine",
+          "GFR",
+          "nephro",
+          "dialys",
+          "glomerul",
+          "proteinuria",
+          "tubular"
+        ],
+        "n_questions": 62,
+        "frequency_pct": 4.0,
+        "weight": 0.96
+      },
+      {
+        "id": 3,
+        "en": "Valvular Heart Disease & Endocarditis",
+        "he": "מחלת מסתמים ואנדוקרדיטיס",
+        "keywords": [
+          "valvul",
+          "stenosis",
+          "regurgit",
+          "aortic",
+          "mitral",
+          "tricuspid",
+          "endocard",
+          "murmur",
+          "prosthetic"
+        ],
+        "n_questions": 59,
+        "frequency_pct": 3.8,
+        "weight": 0.91
+      },
+      {
+        "id": 15,
+        "en": "Critical Care",
+        "he": "טיפול נמרץ",
+        "keywords": [
+          "ICU",
+          "critical",
+          "shock",
+          "septic shock",
+          "cardiogenic",
+          "ventilat",
+          "intubat",
+          "vasopressor",
+          "cardiac arrest",
+          "ACLS",
+          "resuscitat"
+        ],
+        "n_questions": 57,
+        "frequency_pct": 3.7,
+        "weight": 0.88
+      },
+      {
+        "id": 21,
+        "en": "Toxicology & Substance Use",
+        "he": "רעלנות והתמכרויות",
+        "keywords": [
+          "toxic",
+          "poison",
+          "overdose",
+          "alcohol",
+          "substance",
+          "withdrawal"
+        ],
+        "n_questions": 56,
+        "frequency_pct": 3.6,
+        "weight": 0.86
+      },
+      {
+        "id": 16,
+        "en": "Dermatology",
+        "he": "דרמטולוגיה",
+        "keywords": [
+          "dermatol",
+          "skin",
+          "rash",
+          "urticaria",
+          "psoriasis",
+          "melanoma"
+        ],
+        "n_questions": 54,
+        "frequency_pct": 3.5,
+        "weight": 0.83
+      },
+      {
+        "id": 20,
+        "en": "Perioperative Care",
+        "he": "טיפול פריאופרטיבי",
+        "keywords": [
+          "perioper",
+          "surgery",
+          "preop",
+          "DVT prophylaxis",
+          "anesthes"
+        ],
+        "n_questions": 54,
+        "frequency_pct": 3.5,
+        "weight": 0.83
+      },
+      {
+        "id": 17,
+        "en": "Allergy & Immunology",
+        "he": "אלרגיה ואימונולוגיה",
+        "keywords": [
+          "allergy",
+          "anaphylaxis",
+          "drug reaction",
+          "immunol",
+          "vaccine",
+          "immunodeficien"
+        ],
+        "n_questions": 53,
+        "frequency_pct": 3.4,
+        "weight": 0.82
+      },
+      {
+        "id": 19,
+        "en": "Pain & Palliative Care",
+        "he": "טיפול בכאב ופליאטיבי",
+        "keywords": [
+          "pain",
+          "analges",
+          "opioid",
+          "palliati",
+          "dyspnea",
+          "symptom",
+          "nausea",
+          "vomit"
+        ],
+        "n_questions": 53,
+        "frequency_pct": 3.4,
+        "weight": 0.82
+      },
+      {
+        "id": 23,
+        "en": "Vascular Diseases",
+        "he": "מחלות כלי דם",
+        "keywords": [
+          "vascular",
+          "aortic dissect",
+          "aneurysm",
+          "peripheral arter",
+          "PVD",
+          "carotid",
+          "mesenteric"
+        ],
+        "n_questions": 53,
+        "frequency_pct": 3.4,
+        "weight": 0.82
+      },
+      {
+        "id": 8,
+        "en": "Electrolyte Disorders",
+        "he": "הפרעות אלקטרוליטים",
+        "keywords": [
+          "electrolyte",
+          "sodium",
+          "potassium",
+          "calcium",
+          "magnesium",
+          "phosph",
+          "hyponatr",
+          "hyperkal",
+          "hypokal",
+          "acid-base",
+          "acidosis",
+          "alkalosis",
+          "metabolic",
+          "respiratory"
+        ],
+        "n_questions": 52,
+        "frequency_pct": 3.3,
+        "weight": 0.8
+      },
+      {
+        "id": 11,
+        "en": "Oncology",
+        "he": "אונקולוגיה",
+        "keywords": [
+          "oncolog",
+          "cancer",
+          "tumor",
+          "chemo",
+          "immunother",
+          "metasta",
+          "screening",
+          "cfDNA",
+          "colorectal",
+          "lung cancer",
+          "breast",
+          "prostate"
+        ],
+        "n_questions": 52,
+        "frequency_pct": 3.3,
+        "weight": 0.8
+      },
+      {
+        "id": 18,
+        "en": "Fluid & Volume Management",
+        "he": "איזון נוזלים",
+        "keywords": [
+          "fluid",
+          "edema",
+          "dehydrat",
+          "volume",
+          "IV fluid",
+          "hypovolemia",
+          "hypervolemia"
+        ],
+        "n_questions": 52,
+        "frequency_pct": 3.3,
+        "weight": 0.8
+      },
+      {
+        "id": 9,
+        "en": "Endocrinology",
+        "he": "אנדוקרינולוגיה",
+        "keywords": [
+          "endocrin",
+          "diabet",
+          "DM",
+          "HbA1c",
+          "insulin",
+          "thyroid",
+          "TSH",
+          "adrenal",
+          "Cushing",
+          "Addison",
+          "pituitary",
+          "pheochromocytoma",
+          "SGLT2",
+          "GLP-1"
+        ],
+        "n_questions": 41,
+        "frequency_pct": 2.6,
+        "weight": 0.63
+      },
+      {
+        "id": 14,
+        "en": "Neurology",
+        "he": "נוירולוגיה",
+        "keywords": [
+          "neurol",
+          "stroke",
+          "CVA",
+          "seizure",
+          "epilepsy",
+          "Parkinson",
+          "MS",
+          "neuropathy",
+          "Guillain",
+          "myasthenia",
+          "meningitis",
+          "encephalitis",
+          "carotid",
+          "headache",
+          "coma"
+        ],
+        "n_questions": 36,
+        "frequency_pct": 2.3,
+        "weight": 0.56
+      },
+      {
+        "id": 2,
+        "en": "Arrhythmias & Pacing",
+        "he": "הפרעות קצב וקיצוב",
+        "keywords": [
+          "arrhythm",
+          "atrial fibril",
+          "AFib",
+          "flutter",
+          "SVT",
+          "tachycard",
+          "bradycard",
+          "pacemaker",
+          "ECG",
+          "EKG",
+          "QT",
+          "WPW",
+          "AV block",
+          "amiodarone"
+        ],
+        "n_questions": 34,
+        "frequency_pct": 2.2,
+        "weight": 0.52
+      },
+      {
+        "id": 4,
+        "en": "Hypertension",
+        "he": "יתר לחץ דם",
+        "keywords": [
+          "hyperten",
+          "blood pressure",
+          "HTN",
+          "antihypertens",
+          "amlodipine",
+          "ACEI",
+          "ARB",
+          "baxdrostat",
+          "aldosterone synthase"
+        ],
+        "n_questions": 30,
+        "frequency_pct": 1.9,
+        "weight": 0.46
+      }
+    ]
+  },
+  "Mishpacha": {
+    "repo": "Eiasash/FamilyMedicine",
+    "total_questions_analyzed": 1061,
+    "total_topics": 27,
+    "topics": [
+      {
+        "id": 24,
+        "en": "Peds — Acute & Infections",
+        "he": "ילדים — מחלות חדות וזיהומים",
+        "keywords": [],
+        "n_questions": 115,
+        "frequency_pct": 10.8,
+        "weight": 2.93
+      },
+      {
+        "id": 9,
+        "en": "Rheumatology & Musculoskeletal",
+        "he": "ראומטולוגיה וטרשת שלד-שריר",
+        "keywords": [],
+        "n_questions": 100,
+        "frequency_pct": 9.4,
+        "weight": 2.54
+      },
+      {
+        "id": 26,
+        "en": "EBM, Communication & Family Systems",
+        "he": "רפואה מבוססת ראיות, תקשורת ומערכת משפחתית",
+        "keywords": [],
+        "n_questions": 75,
+        "frequency_pct": 7.1,
+        "weight": 1.91
+      },
+      {
+        "id": 14,
+        "en": "Women's Health & Gynecology",
+        "he": "בריאות האישה וגינקולוגיה",
+        "keywords": [],
+        "n_questions": 68,
+        "frequency_pct": 6.4,
+        "weight": 1.73
+      },
+      {
+        "id": 13,
+        "en": "Infectious Disease & Vaccines (Adult)",
+        "he": "מחלות זיהומיות וחיסונים (מבוגרים)",
+        "keywords": [],
+        "n_questions": 50,
+        "frequency_pct": 4.7,
+        "weight": 1.27
+      },
+      {
+        "id": 17,
+        "en": "Geriatrics (Falls, Cognition, Polypharmacy)",
+        "he": "גריאטריה (נפילות, קוגניציה, ריבוי תרופות)",
+        "keywords": [],
+        "n_questions": 46,
+        "frequency_pct": 4.3,
+        "weight": 1.17
+      },
+      {
+        "id": 15,
+        "en": "Pregnancy, Perinatal & Postpartum",
+        "he": "הריון ולידה",
+        "keywords": [],
+        "n_questions": 42,
+        "frequency_pct": 4.0,
+        "weight": 1.07
+      },
+      {
+        "id": 4,
+        "en": "Gastroenterology & Hepatology",
+        "he": "גסטרו והפטולוגיה",
+        "keywords": [],
+        "n_questions": 41,
+        "frequency_pct": 3.9,
+        "weight": 1.04
+      },
+      {
+        "id": 10,
+        "en": "Neurology (Stroke, Headache, Dementia)",
+        "he": "נוירולוגיה (שבץ, כאבי ראש, דמנציה)",
+        "keywords": [],
+        "n_questions": 41,
+        "frequency_pct": 3.9,
+        "weight": 1.04
+      },
+      {
+        "id": 20,
+        "en": "Preventive Medicine & Health Promotion",
+        "he": "רפואה מונעת וקידום בריאות",
+        "keywords": [],
+        "n_questions": 41,
+        "frequency_pct": 3.9,
+        "weight": 1.04
+      },
+      {
+        "id": 22,
+        "en": "Emergencies in the Clinic",
+        "he": "חירום במרפאה",
+        "keywords": [],
+        "n_questions": 39,
+        "frequency_pct": 3.7,
+        "weight": 0.99
+      },
+      {
+        "id": 3,
+        "en": "Pulmonology (Asthma, COPD, PE)",
+        "he": "ריאות (אסטמה, COPD, תסחיף)",
+        "keywords": [],
+        "n_questions": 38,
+        "frequency_pct": 3.6,
+        "weight": 0.97
+      },
+      {
+        "id": 18,
+        "en": "Mental Health — Mood, Anxiety, Psychosis",
+        "he": "בריאות הנפש — מצב רוח, חרדה, פסיכוזה",
+        "keywords": [],
+        "n_questions": 32,
+        "frequency_pct": 3.0,
+        "weight": 0.81
+      },
+      {
+        "id": 6,
+        "en": "Endocrinology — Diabetes",
+        "he": "אנדוקרינולוגיה — סוכרת",
+        "keywords": [],
+        "n_questions": 31,
+        "frequency_pct": 2.9,
+        "weight": 0.79
+      },
+      {
+        "id": 2,
+        "en": "Hypertension & Lipids",
+        "he": "יתר לחץ דם ודיסליפידמיה",
+        "keywords": [],
+        "n_questions": 29,
+        "frequency_pct": 2.7,
+        "weight": 0.74
+      },
+      {
+        "id": 8,
+        "en": "Hematology & Coagulation",
+        "he": "המטולוגיה וקרישה",
+        "keywords": [],
+        "n_questions": 28,
+        "frequency_pct": 2.6,
+        "weight": 0.71
+      },
+      {
+        "id": 25,
+        "en": "Peds — Adolescent & Mental Health",
+        "he": "ילדים — מתבגרים ובריאות הנפש",
+        "keywords": [],
+        "n_questions": 28,
+        "frequency_pct": 2.6,
+        "weight": 0.71
+      },
+      {
+        "id": 5,
+        "en": "Nephrology, UTI & Urology",
+        "he": "נפרולוגיה, UTI ואורולוגיה",
+        "keywords": [],
+        "n_questions": 27,
+        "frequency_pct": 2.5,
+        "weight": 0.69
+      },
+      {
+        "id": 7,
+        "en": "Endocrinology — Thyroid & Other",
+        "he": "אנדוקרינולוגיה — בלוטת תריס ואחר",
+        "keywords": [],
+        "n_questions": 24,
+        "frequency_pct": 2.3,
+        "weight": 0.61
+      },
+      {
+        "id": 23,
+        "en": "Peds — Newborn & Development",
+        "he": "ילדים — יילוד והתפתחות",
+        "keywords": [],
+        "n_questions": 24,
+        "frequency_pct": 2.3,
+        "weight": 0.61
+      },
+      {
+        "id": 1,
+        "en": "Heart Failure & Valves",
+        "he": "אי-ספיקת לב ומסתמים",
+        "keywords": [],
+        "n_questions": 23,
+        "frequency_pct": 2.2,
+        "weight": 0.59
+      },
+      {
+        "id": 11,
+        "en": "Dermatology",
+        "he": "דרמטולוגיה",
+        "keywords": [],
+        "n_questions": 22,
+        "frequency_pct": 2.1,
+        "weight": 0.56
+      },
+      {
+        "id": 12,
+        "en": "Allergy & Immunology",
+        "he": "אלרגיה ואימונולוגיה",
+        "keywords": [],
+        "n_questions": 21,
+        "frequency_pct": 2.0,
+        "weight": 0.53
+      },
+      {
+        "id": 0,
+        "en": "Adult Cardiology — IHD & Arrhythmia",
+        "he": "קרדיולוגיה למבוגר — מחלת לב איסכמית והפרעות קצב",
+        "keywords": [],
+        "n_questions": 20,
+        "frequency_pct": 1.9,
+        "weight": 0.51
+      },
+      {
+        "id": 16,
+        "en": "Men's Health",
+        "he": "בריאות הגבר",
+        "keywords": [],
+        "n_questions": 20,
+        "frequency_pct": 1.9,
+        "weight": 0.51
+      },
+      {
+        "id": 21,
+        "en": "Pain, Palliative & End-of-Life",
+        "he": "כאב, פליאציה וסוף החיים",
+        "keywords": [],
+        "n_questions": 20,
+        "frequency_pct": 1.9,
+        "weight": 0.51
+      },
+      {
+        "id": 19,
+        "en": "Addictions & Lifestyle Behaviors",
+        "he": "התמכרויות והתנהגות בריאותית",
+        "keywords": [],
+        "n_questions": 16,
+        "frequency_pct": 1.5,
+        "weight": 0.41
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.45.0",
+  "version": "10.46.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -562,6 +562,8 @@ upd();setInterval(upd,30000);
 <script src="shared/fsrs.js"></script>
 <script src="src/storage.js"></script>
 <script src="src/sw-update.js"></script>
+<script src="src/study_plan_algorithm.js"></script>
+<script src="src/study_plan.js"></script>
 <script>
 let QZ=[];
 // Pre-generated distractor autopsy map (qIdx → 4-element array of rationales, "" at correct index)
@@ -874,6 +876,8 @@ document.addEventListener('visibilitychange',function(){if(document.visibilitySt
 migrateToIDB().then(()=>{
 // v9.39: Reset study plan tier open states to collapsed
 if(S._spVer!=='9.42'){S._spVer='9.42';delete S.sp_t1;delete S.sp_t2;delete S.sp_t3;delete S.sp_t4;delete S.spOpen;S.spOpen=false;save();}
+// v10.46.0: bind cloud study-plan delegated handlers (idempotent via window.__studyPlanBound)
+if(typeof window.bindStudyPlanEvents==='function')window.bindStudyPlanEvents();
 renderTabs();render();if(!localStorage.getItem('shlav_seen_help')){localStorage.setItem('shlav_seen_help','1');setTimeout(showHelp,500);}}).catch(e=>{console.error('IDB init failed, falling back to localStorage:',e);renderTabs();render();});
 
 // ===== SCREEN WAKE LOCK =====
@@ -5212,6 +5216,8 @@ h+=`<div class="card" style="padding:14px;text-align:center;margin-top:12px">
 </div>`;
 // Account section (auth)
 h+=window.renderAuthSection();
+// Study Plan section (mirror of Mishpacha v1.9.1 / Pnimit v9.86.0)
+if(typeof window.renderStudyPlanSection==='function')h+=window.renderStudyPlanSection();
 // Data management
 h+=`<div class="card" style="padding:14px;margin-top:12px">
 <div style="font-weight:700;font-size:12px;margin-bottom:8px">💾 Data Management</div>
@@ -6219,8 +6225,12 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.45.0';
+const APP_VERSION='10.46.0';
 const CHANGELOG={
+'10.46.0':[
+'📅 תכנית לימוד בתוך האפליקציה — Settings → 📅 תכנית לימוד. בוחרים תאריך בחינה, שעות לימוד שבועיות (1-20), שבועות חזרה (1-6); המנוע מחלק את 46 הנושאים לפי תדירות אמפירית מ-3,833 שאלות עבר ובונה לוח שבועי. JS port verbatim של allocate_hours + schedule מ-auto-audit/scripts/generate_study_plan.py — fixture חוצה-שפות מאמת התאמה byte-identical (top-5 שעות + week_used לכל תא ≤ 1e-9). שמירה בענן דרך RPC SECURITY DEFINER (study_plan_upsert / study_plan_get) על טבלה משותפת public.study_plans (key (username, app)); אורחים יוצרים תכנית מקומית עם רמז להתחבר. ייצוא .ics צד-לקוח לכל לוחות השנה (Google / Outlook / Apple) — אירועי שבוע + 3 מוקים + יום הבחינה. Mirror של Mishpacha v1.9.1 + Pnimit v9.86.0; הטבלה + ה-RPCs כבר רצים על הפרויקט המשותף krmlzwwelqvlfslwltol (האפליקציה רק קוראת להם עם app=\'shlav\').',
+'🪝 Hooks: src/study_plan_algorithm.js (algorithm primitives, browser-loadable + vm-testable) + src/study_plan.js (UI/RPC/ICS) + data/syllabus_data.json (24+27+46 = 97 frozen topics across the three apps). שני ה-script files נטענים בראש הקובץ אחרי shared/fsrs.js; tests/studyPlanAlgorithm.test.js מריץ את ה-algorithm ב-vm context.',
+],
 '10.45.0':[
 '🚨 Distractor Autopsy data corruption fixed — 2,729 of 3,795 distractor entries (72%) were misaligned with their parent question after prior bank reorderings + the v9.58 answer-key correction sweep. The "empty slot" in DIS[k] was no longer at Q[k].c, so the UI rendered "Wrong because:" rationales on the CORRECT (green ✓) answer and silently swallowed real wrong-option rationales. Symptom on screen: distractor explanations talking about depression/SSRIs/hip-fracture under a question about Russian male mortality.',
 '🔁 Full regeneration via scripts/generate_distractors.cjs (Haiku via Toranot proxy, 6-worker batch, ~30 min, ~$10 spend) — every Q now has fresh, content-aligned distractor rationales.',

--- a/src/study_plan.js
+++ b/src/study_plan.js
@@ -1,0 +1,466 @@
+// src/study_plan.js — In-app Study Plan generator (Shlav A slice).
+//
+// Mirror of FamilyMedicine v1.9.1 / Pnimit v9.86.0 src/features/study_plan/.
+// Plain-script IIFE (matches Geri's auth section style); requires
+// src/study_plan_algorithm.js to have loaded first (window.SP_ALGO).
+//
+// Persists to Supabase via study_plan_upsert / study_plan_get RPCs — NEVER
+// to localStorage (one user → one plan, must follow them across devices).
+// Table public.study_plans + RPCs are shared across the three medical PWAs;
+// migration lives in FamilyMedicine/supabase/migrations/0002_study_plans.sql
+// and was applied once on the project (krmlzwwelqvlfslwltol).
+//
+// Globals consumed (defined elsewhere in shlav-a-mega.html):
+//   SUPA_URL, SUPA_ANON           — supabase URL + publishable key
+//   sanitize, toast, heDir        — utility helpers
+//   getCurrentUser                — auth IIFE export
+//   render                        — top-level app rerender (no-op if absent)
+
+(function () {
+  'use strict';
+
+  const APP_KEY = 'shlav';
+  const SYLLABUS_URL = 'data/syllabus_data.json';
+  const DEFAULT_HOURS_PER_WEEK = 8;
+  const DEFAULT_RAMP_WEEKS = 3;
+
+  // In-memory per-page cache.
+  const _state = {
+    loading: false,
+    generating: false,
+    fetched: false,
+    display: null,
+    planJson: null,
+    examDateISO: null,
+    hoursPerWeek: DEFAULT_HOURS_PER_WEEK,
+    rampWeeks: DEFAULT_RAMP_WEEKS,
+    message: '',
+    messageTone: '',
+  };
+  let _SYLLABUS = null;            // cached after first fetch
+  let _syllabusInflight = null;    // dedupe parallel fetches
+
+  function _getSyllabus() {
+    if (_SYLLABUS) return Promise.resolve(_SYLLABUS);
+    if (_syllabusInflight) return _syllabusInflight;
+    _syllabusInflight = fetch(SYLLABUS_URL)
+      .then((r) => { if (!r.ok) throw new Error('http_' + r.status); return r.json(); })
+      .then((d) => { _SYLLABUS = d; _syllabusInflight = null; return d; })
+      .catch((e) => { _syllabusInflight = null; throw e; });
+    return _syllabusInflight;
+  }
+
+  // ─────────────────────── RPC plumbing ───────────────────────
+
+  function _rpc(fn, body) {
+    return fetch(SUPA_URL + '/rest/v1/rpc/' + fn, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'apikey': SUPA_ANON,
+        'Authorization': 'Bearer ' + SUPA_ANON,
+      },
+      body: JSON.stringify(body),
+    }).then((res) => {
+      if (!res.ok) {
+        return res.text().catch(() => '').then((txt) => ({
+          ok: false, error: 'http_' + res.status, message: String(txt).slice(0, 200),
+        }));
+      }
+      return res.json().catch(() => null).then((d) => {
+        if (!d || typeof d !== 'object') return { ok: false, error: 'bad_response' };
+        return d;
+      });
+    }).catch((e) => ({ ok: false, error: 'network', message: String(e) }));
+  }
+
+  function studyPlanGet(username) {
+    return _rpc('study_plan_get', { p_username: username, p_app: APP_KEY });
+  }
+  function studyPlanUpsert(username, examDateISO, hoursPerWeek, rampWeeks, planJson) {
+    return _rpc('study_plan_upsert', {
+      p_username: username,
+      p_app: APP_KEY,
+      p_exam_date: examDateISO,
+      p_hours_per_week: hoursPerWeek,
+      p_ramp_weeks: rampWeeks,
+      p_plan_json: planJson,
+    });
+  }
+
+  // ─────────────────────── helpers ───────────────────────
+
+  function _todayISO() {
+    const d = new Date();
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const dd = String(d.getDate()).padStart(2, '0');
+    return y + '-' + m + '-' + dd;
+  }
+
+  function _addDaysISO(iso, days) {
+    return window.SP_ALGO._addDaysISO(iso, days);
+  }
+
+  function _setStatus(msg, tone) {
+    _state.message = msg || '';
+    _state.messageTone = tone || '';
+    const el = document.getElementById('sp-status');
+    if (el) {
+      el.textContent = _state.message;
+      el.style.color = tone === 'error' ? '#991b1b' : tone === 'success' ? '#059669' : '#64748b';
+    }
+  }
+
+  // ─────────────────────── public render ───────────────────────
+
+  function renderStudyPlanSection() {
+    const user = (typeof getCurrentUser === 'function') ? getCurrentUser() : null;
+
+    // Auto-fetch existing plan on first render after login (fire-and-forget).
+    if (user && !_state.fetched && !_state.loading) {
+      _state.loading = true;
+      _state.fetched = true;
+      studyPlanGet(user.username).then((r) => {
+        _state.loading = false;
+        if (r && r.ok && r.plan && r.plan.plan_json) {
+          _state.display = r.plan.plan_json.display || null;
+          _state.planJson = r.plan.plan_json || null;
+          _state.examDateISO = r.plan.exam_date || null;
+          _state.hoursPerWeek = Number(r.plan.hours_per_week) || DEFAULT_HOURS_PER_WEEK;
+          _state.rampWeeks = Number(r.plan.ramp_weeks) || DEFAULT_RAMP_WEEKS;
+          if (typeof render === 'function') render();
+        }
+      }).catch(() => { _state.loading = false; });
+    }
+
+    // Pre-warm syllabus fetch (don't block first render).
+    _getSyllabus().catch(() => {});
+
+    const defaultExam = _state.examDateISO || _addDaysISO(_todayISO(), 19 * 7);
+    const minExam = _addDaysISO(_todayISO(), 7 * 7);
+
+    let h = `
+<div class="card" style="padding:14px;margin-top:12px" dir="rtl">
+  <div style="font-weight:700;font-size:12px;margin-bottom:6px">📅 תכנית לימוד</div>
+  <div style="font-size:11px;color:rgb(var(--fg2));margin-bottom:12px;line-height:1.6">
+    תכנית לימוד שבועית משוקללת לפי תדירות הופעת נושאים בבחינות שלב א׳ גריאטריה קודמות (3,833 שאלות,
+    46 נושאים). הנתונים אמפיריים — מבוססים על מאגר השאלות של האפליקציה, לא על ניחוש.
+  </div>`;
+
+    if (!user) {
+      h += `
+  <div style="padding:10px;background:#fef9c3;border:1px solid #fde68a;border-radius:10px;font-size:11px;color:#854d0e;line-height:1.6;margin-bottom:10px">
+    כדי לשמור את התכנית בענן ולפתוח אותה מכל מכשיר — <strong>התחבר לחשבון</strong> או הירשם בחלק החשבון.
+    אפשר ליצור תכנית גם כאורח, אך היא לא תישמר בענן.
+  </div>`;
+    }
+
+    h += `
+  <label style="display:block;font-size:11px;font-weight:700;margin-bottom:4px">תאריך הבחינה</label>
+  <input id="sp-exam-date" type="date" min="${minExam}" value="${sanitize(defaultExam)}"
+    style="width:100%;padding:10px;border:1px solid #e2e8f0;border-radius:10px;font-size:12px;margin-bottom:10px;direction:ltr;text-align:left;font-family:inherit;background:inherit;color:inherit">
+
+  <label style="display:block;font-size:11px;font-weight:700;margin-bottom:4px">
+    שעות לימוד בשבוע: <span id="sp-hpw-val" style="color:#0891b2">${_state.hoursPerWeek}</span>h
+  </label>
+  <input id="sp-hpw" type="range" min="1" max="20" step="1" value="${_state.hoursPerWeek}"
+    style="width:100%;margin-bottom:10px;accent-color:#0891b2">
+
+  <label style="display:block;font-size:11px;font-weight:700;margin-bottom:4px">
+    שבועות חזרה (Mock + ramp): <span id="sp-ramp-val" style="color:#0891b2">${_state.rampWeeks}</span>
+  </label>
+  <input id="sp-ramp" type="range" min="1" max="6" step="1" value="${_state.rampWeeks}"
+    style="width:100%;margin-bottom:12px;accent-color:#0891b2">
+
+  <div style="display:flex;gap:6px;flex-wrap:wrap">
+    <button class="btn btn-p" data-action="sp-generate" ${_state.generating ? 'disabled' : ''}
+      style="flex:1;font-size:12px;min-height:42px;font-weight:700">
+      ${_state.generating ? '⏳ יוצר…' : '✨ צור תכנית'}
+    </button>
+    ${_state.display ? `
+    <button class="btn" data-action="sp-export-ics"
+      style="font-size:11px;min-height:42px;background:#ecfeff;color:#155e75;border:1px solid #a5f3fc;padding:8px 14px">
+      📅 ייצא ל-Calendar (.ics)
+    </button>` : ''}
+  </div>
+  <div id="sp-status" style="font-size:11px;margin-top:10px;text-align:center;min-height:16px;color:${_state.messageTone === 'error' ? '#991b1b' : _state.messageTone === 'success' ? '#059669' : '#64748b'}">${sanitize(_state.message)}</div>
+</div>`;
+
+    if (_state.display) h += _renderPlan(_state.display);
+    return h;
+  }
+
+  function _renderPlan(display) {
+    const s = display.summary;
+    let h = `
+<div style="padding:14px;background:#f0fdfa;border:1px solid #99f6e4;border-radius:12px;margin:12px 0;color:#0f172a" dir="rtl">
+  <div style="font-size:13px;font-weight:700;color:#134e4a;margin-bottom:8px">📊 סיכום</div>
+  <div style="font-size:11px;line-height:1.8">
+    <div>תאריך הבחינה: <strong>${sanitize(s.exam_date)}</strong></div>
+    <div>סה"כ שבועות: <strong>${s.total_weeks}</strong> (לימוד נושאים: ${s.topic_weeks}, חזרה ומוקים: ${s.ramp_weeks})</div>
+    <div>שעות לימוד שבועיות: <strong>${s.hours_per_week}h</strong> (≈ ${(s.hours_per_week*0.7).toFixed(1)}h נושאים, ${(s.hours_per_week*0.3).toFixed(1)}h שאלות)</div>
+    <div>יעד יומי: <strong>${s.daily_q_target} שאלות</strong> במאגר</div>
+  </div>
+</div>`;
+
+    h += `<div style="font-weight:700;font-size:12px;margin:8px 0 6px" dir="rtl">🗓 שבועות לימוד</div>`;
+    display.weeks.forEach((w) => {
+      h += `
+<details style="margin-bottom:6px;border:1px solid rgb(var(--brd));border-radius:10px;background:rgb(var(--bg2))" dir="rtl">
+  <summary style="padding:10px 12px;cursor:pointer;font-size:12px;font-weight:700;list-style:none">
+    שבוע ${w.idx} — ${sanitize(w.start_date)} → ${sanitize(w.end_date)}
+    <span style="float:left;color:#0891b2;font-weight:400">${w.used_hours}h • ${w.topics.length} נושאים</span>
+  </summary>
+  <div style="padding:0 12px 12px">`;
+      if (w.topics.length === 0) {
+        h += `<div style="font-size:11px;color:rgb(var(--fg2));padding:6px 0">_ללא נושאים בשבוע זה — שמור לחזרה ושאלות._</div>`;
+      } else {
+        w.topics.forEach((t) => {
+          const en = sanitize(t.en);
+          const he = t.he ? sanitize(t.he) : '';
+          const kw = (t.keywords || []).slice(0, 6).map(sanitize).join(', ');
+          h += `
+    <div style="padding:8px 0;border-top:1px solid rgb(var(--brd))">
+      <div style="font-size:11px;font-weight:700;line-height:1.4" dir="${heDir(he || en)}">
+        ${he ? `<span>${he}</span> · ` : ''}<span style="color:rgb(var(--fg2));font-weight:500;direction:ltr;display:inline-block">${en}</span>
+      </div>
+      <div style="font-size:10px;color:#0891b2;margin-top:2px">${t.hours}h · ${t.frequency_pct}% מהבחינות</div>
+      ${kw ? `<div style="font-size:10px;color:rgb(var(--fg2));margin-top:2px;direction:ltr;text-align:left;font-style:italic">${kw}</div>` : ''}
+    </div>`;
+        });
+      }
+      h += `
+  </div>
+</details>`;
+    });
+
+    if (display.ramp_weeks.length) {
+      h += `<div style="font-weight:700;font-size:12px;margin:12px 0 6px" dir="rtl">🎯 שבועות מוק וחזרה</div>`;
+      display.ramp_weeks.forEach((r) => {
+        h += `
+<div style="margin-bottom:6px;padding:10px 12px;border:1px solid #fde68a;border-radius:10px;background:#fffbeb;color:#0f172a" dir="rtl">
+  <div style="font-size:12px;font-weight:700;color:#92400e">
+    ${sanitize(r.mock_label)} — שבוע ${r.idx}
+    <span style="float:left;color:#b45309;font-weight:400;font-size:11px">${sanitize(r.start_date)} → ${sanitize(r.end_date)}</span>
+  </div>
+  <div style="font-size:11px;color:#78350f;margin-top:6px;line-height:1.6">${sanitize(r.advice)}</div>
+</div>`;
+      });
+    }
+    return h;
+  }
+
+  // ─────────────────────── event handlers ───────────────────────
+
+  function _readInputs() {
+    const exam = document.getElementById('sp-exam-date');
+    const hpw = document.getElementById('sp-hpw');
+    const ramp = document.getElementById('sp-ramp');
+    return {
+      examDateISO: (exam && exam.value) || '',
+      hoursPerWeek: hpw ? Number(hpw.value) : DEFAULT_HOURS_PER_WEEK,
+      rampWeeks: ramp ? Number(ramp.value) : DEFAULT_RAMP_WEEKS,
+    };
+  }
+
+  async function _handleGenerate() {
+    if (_state.generating) return;
+    const inputs = _readInputs();
+    if (!inputs.examDateISO) { _setStatus('בחר תאריך בחינה', 'error'); return; }
+
+    _state.generating = true;
+    _setStatus('מחשב תכנית…', '');
+
+    let SYLLABUS;
+    try { SYLLABUS = await _getSyllabus(); }
+    catch (e) {
+      _state.generating = false;
+      _setStatus('שגיאה בטעינת נתוני הסילבוס: ' + (e && e.message || e), 'error');
+      if (typeof render === 'function') render();
+      return;
+    }
+
+    let display, planJson;
+    try {
+      const out = window.SP_ALGO.buildPlan({
+        topics: SYLLABUS.Geri.topics,
+        startDateISO: _todayISO(),
+        examDateISO: inputs.examDateISO,
+        hoursPerWeek: inputs.hoursPerWeek,
+        rampWeeks: inputs.rampWeeks,
+      });
+      display = out.display;
+      planJson = out.planJson;
+    } catch (e) {
+      _state.generating = false;
+      const map = {
+        exam_date_must_be_after_start_date: 'תאריך הבחינה חייב להיות אחרי היום',
+        not_enough_weeks: 'יש פחות מ-' + (inputs.rampWeeks + 4) + ' שבועות עד הבחינה — הזז את התאריך או הקטן את שבועות החזרה',
+      };
+      _setStatus(map[e.message] || ('שגיאה: ' + e.message), 'error');
+      if (typeof render === 'function') render();
+      return;
+    }
+
+    _state.display = display;
+    _state.planJson = planJson;
+    _state.examDateISO = inputs.examDateISO;
+    _state.hoursPerWeek = inputs.hoursPerWeek;
+    _state.rampWeeks = inputs.rampWeeks;
+    _state.generating = false;
+
+    const user = (typeof getCurrentUser === 'function') ? getCurrentUser() : null;
+    if (!user) {
+      _setStatus('התכנית נוצרה (לא נשמרה — התחבר לחשבון לסנכרון בענן)', 'success');
+      if (typeof render === 'function') render();
+      return;
+    }
+
+    _setStatus('שומר בענן…', '');
+    const r = await studyPlanUpsert(user.username, inputs.examDateISO, inputs.hoursPerWeek, inputs.rampWeeks, planJson);
+    if (r && r.ok) {
+      _setStatus('✓ התכנית נשמרה בענן', 'success');
+      if (typeof toast === 'function') toast('✅ תכנית הלימוד נשמרה', 'success');
+    } else {
+      const map = {
+        no_such_user: 'המשתמש לא נמצא — התחבר מחדש',
+        invalid_exam_date: 'תאריך בחינה לא חוקי',
+        invalid_hours_per_week: 'מספר שעות לא חוקי',
+        invalid_ramp_weeks: 'מספר שבועות חזרה לא חוקי',
+        bad_response: 'שגיאת רשת — נסה שוב',
+      };
+      _setStatus('✗ ' + (map[r.error] || (r.message || r.error || 'שגיאה')), 'error');
+    }
+    if (typeof render === 'function') render();
+  }
+
+  // ─────────────────────── ICS export ───────────────────────
+
+  function _icsEscape(s) {
+    return String(s || '')
+      .replace(/\\/g, '\\\\')
+      .replace(/;/g, '\\;')
+      .replace(/,/g, '\\,')
+      .replace(/\r?\n/g, '\\n');
+  }
+  function _icsDate(iso) { return iso.replace(/-/g, ''); }
+  function _icsDtstamp() {
+    const d = new Date();
+    const pad = (n) => String(n).padStart(2, '0');
+    return d.getUTCFullYear() + pad(d.getUTCMonth() + 1) + pad(d.getUTCDate()) + 'T' + pad(d.getUTCHours()) + pad(d.getUTCMinutes()) + pad(d.getUTCSeconds()) + 'Z';
+  }
+
+  function _buildICS(display) {
+    const dtstamp = _icsDtstamp();
+    const lines = [
+      'BEGIN:VCALENDAR',
+      'VERSION:2.0',
+      'PRODID:-//Shlav A Mega//Study Plan//EN',
+      'CALSCALE:GREGORIAN',
+      'METHOD:PUBLISH',
+    ];
+
+    display.weeks.forEach((w) => {
+      if (!w.topics.length) return;
+      const summary = 'גריאטריה — שבוע ' + w.idx + ' (' + w.used_hours + 'h)';
+      const body = w.topics
+        .map((t) => '• ' + (t.he ? t.he + ' / ' : '') + t.en + ' — ' + t.hours + 'h (' + t.frequency_pct + '%)')
+        .join('\n');
+      const dtEndExclusive = _addDaysISO(w.start_date, 7);
+      lines.push(
+        'BEGIN:VEVENT',
+        'UID:shlav-week-' + w.idx + '-' + w.start_date + '@geriatrics.local',
+        'DTSTAMP:' + dtstamp,
+        'DTSTART;VALUE=DATE:' + _icsDate(w.start_date),
+        'DTEND;VALUE=DATE:' + _icsDate(dtEndExclusive),
+        'SUMMARY:' + _icsEscape(summary),
+        'DESCRIPTION:' + _icsEscape(body),
+        'END:VEVENT'
+      );
+    });
+
+    display.ramp_weeks.forEach((r) => {
+      const summary = 'גריאטריה — ' + r.mock_label + ' (שבוע חזרה ' + r.idx + ')';
+      const dtEndExclusive = _addDaysISO(r.start_date, 7);
+      lines.push(
+        'BEGIN:VEVENT',
+        'UID:shlav-ramp-' + r.idx + '-' + r.start_date + '@geriatrics.local',
+        'DTSTAMP:' + dtstamp,
+        'DTSTART;VALUE=DATE:' + _icsDate(r.start_date),
+        'DTEND;VALUE=DATE:' + _icsDate(dtEndExclusive),
+        'SUMMARY:' + _icsEscape(summary),
+        'DESCRIPTION:' + _icsEscape(r.advice),
+        'END:VEVENT'
+      );
+    });
+
+    lines.push(
+      'BEGIN:VEVENT',
+      'UID:shlav-exam-' + display.summary.exam_date + '@geriatrics.local',
+      'DTSTAMP:' + dtstamp,
+      'DTSTART;VALUE=DATE:' + _icsDate(display.summary.exam_date),
+      'DTEND;VALUE=DATE:' + _icsDate(_addDaysISO(display.summary.exam_date, 1)),
+      'SUMMARY:' + _icsEscape('🎯 בחינת שלב א\' גריאטריה'),
+      'DESCRIPTION:' + _icsEscape('בחינת שלב א\' גריאטריה (P005-2026)'),
+      'END:VEVENT'
+    );
+
+    lines.push('END:VCALENDAR');
+    return lines.join('\r\n') + '\r\n';
+  }
+
+  function _handleExportICS() {
+    if (!_state.display) { _setStatus('צור תכנית לפני הייצוא', 'error'); return; }
+    const ics = _buildICS(_state.display);
+    const blob = new Blob([ics], { type: 'text/calendar;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'shlav-a-study-plan-' + _state.display.summary.exam_date + '.ics';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+    if (typeof toast === 'function') toast('📅 הקובץ הורד — פתח אותו ב-Google Calendar / Outlook / Apple Calendar', 'success');
+  }
+
+  function _bindSliderLabels() {
+    const hpw = document.getElementById('sp-hpw');
+    const ramp = document.getElementById('sp-ramp');
+    if (hpw && !hpw.dataset.bound) {
+      hpw.dataset.bound = '1';
+      hpw.addEventListener('input', () => {
+        const el = document.getElementById('sp-hpw-val');
+        if (el) el.textContent = hpw.value;
+      });
+    }
+    if (ramp && !ramp.dataset.bound) {
+      ramp.dataset.bound = '1';
+      ramp.addEventListener('input', () => {
+        const el = document.getElementById('sp-ramp-val');
+        if (el) el.textContent = ramp.value;
+      });
+    }
+  }
+
+  function bindStudyPlanEvents() {
+    _bindSliderLabels();
+    if (window.__studyPlanBound) return;
+    window.__studyPlanBound = true;
+    document.addEventListener('click', (e) => {
+      const t = e.target && e.target.closest && e.target.closest('[data-action]');
+      if (!t) return;
+      const a = t.dataset.action;
+      if (a === 'sp-generate') _handleGenerate();
+      else if (a === 'sp-export-ics') _handleExportICS();
+    });
+  }
+
+  Object.assign(window, {
+    renderStudyPlanSection: renderStudyPlanSection,
+    bindStudyPlanEvents: bindStudyPlanEvents,
+    studyPlanGet: studyPlanGet,
+    studyPlanUpsert: studyPlanUpsert,
+  });
+})();

--- a/src/study_plan_algorithm.js
+++ b/src/study_plan_algorithm.js
@@ -1,0 +1,249 @@
+// src/study_plan_algorithm.js — pure algorithm primitives for the in-app
+// Study Plan generator (Shlav A slice). Plain JS browser script (no module);
+// exposes window.SP_ALGO = { allocateHours, schedule, render, buildPlan,
+// rampStages, defaultDailyQTarget }.
+//
+// `allocateHours` and `schedule` are ported VERBATIM from
+// `auto-audit/scripts/generate_study_plan.py`. Any drift here desyncs the
+// in-app plan from the Python reference, so the cross-language fixture in
+// tests/studyPlanAlgorithm.test.js pins them together. If you change either
+// function, the Python copy MUST be updated in lockstep.
+//
+// `render()` is JS-only — it builds the structured display object the
+// Settings UI consumes. The Python version emits Markdown, which we don't
+// want in-app.
+//
+// Mirror of FamilyMedicine v1.9.1 / Pnimit v9.86.0 algorithm.js.
+
+(function () {
+  'use strict';
+
+  // ─────────────────────────────────────────────────────────────
+  // allocate_hours — VERBATIM from generate_study_plan.py
+  // ─────────────────────────────────────────────────────────────
+  function allocateHours(topics, totalHours) {
+    const totalFreq = topics.reduce((s, t) => s + t.frequency_pct, 0) || 100.0;
+    return topics.map((t) => {
+      const share = t.frequency_pct / totalFreq;
+      const raw = Math.max(0.5, Math.min(6.0, share * totalHours));
+      const hours = Math.round(raw * 10) / 10;
+      return Object.assign({}, t, { hours: hours });
+    });
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // schedule — VERBATIM from generate_study_plan.py
+  // ─────────────────────────────────────────────────────────────
+  function schedule(topics, hoursPerWeek, weeks) {
+    const weeklyBudget = hoursPerWeek * 0.7;
+    const sortedTopics = topics.slice().sort((a, b) => b.frequency_pct - a.frequency_pct);
+    const weeksArr = [];
+    for (let i = 0; i < weeks; i++) weeksArr.push([]);
+    const used = new Array(weeks).fill(0);
+
+    for (let k = 0; k < sortedTopics.length; k++) {
+      const t = sortedTopics[k];
+      let placed = false;
+      for (let i = 0; i < weeks; i++) {
+        if (used[i] + t.hours <= weeklyBudget + 0.5 + 1e-9) {
+          weeksArr[i].push(t);
+          used[i] += t.hours;
+          placed = true;
+          break;
+        }
+      }
+      if (!placed) {
+        let minIdx = 0;
+        for (let j = 1; j < weeks; j++) if (used[j] < used[minIdx]) minIdx = j;
+        weeksArr[minIdx].push(t);
+        used[minIdx] += t.hours;
+      }
+    }
+
+    const usedRounded = used.map((u) => Math.round(u * 10) / 10);
+    return { weeks: weeksArr, used: usedRounded };
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // render — JS-only structured display data for the Settings UI
+  // ─────────────────────────────────────────────────────────────
+  const RAMP_BUILDUP = [
+    {
+      label: 'בחינת דמה #1',
+      advice:
+        'בחינת דמה ראשונה במצב מלא ומוקצב. סקירת כל טעות, סימון לחזרה (FSRS). חזרה חמה: 5 הנושאים החלשים ביותר במוק (בדרך כלל בעלי תדירות גבוהה שציון < 70%).',
+    },
+    {
+      label: 'בחינת דמה #2',
+      advice:
+        'בחינת דמה שנייה — סט שאלות חדש במצב מוקצב. השווה למוק #1: אילו נושאים השתפרו ואילו לא. תרגול ממוקד בנושאים בעלי תדירות גבוהה שציון < 70%.',
+    },
+    {
+      label: 'תרגול ממוקד',
+      advice:
+        'תרגול אינטנסיבי בנושאים החלשים שזוהו במוקים — 40-50 שאלות/יום מהמאגר. סקירת FSRS יומית. בלי חומר חדש מהותי — העמקה והבהרה של אלגוריתמים ופרוטוקולים.',
+    },
+    {
+      label: 'בחינת דמה #3',
+      advice:
+        'בחינת דמה שלישית במצב מלא. עדכון רשימת הנושאים החלשים. תרגול נוסף בנושאים שעוד לא הגיעו ל-70% — לא ללמוד חומר חדש, רק להעמיק ולחדד.',
+    },
+    {
+      label: 'תרגול שאלות',
+      advice:
+        'תרגול שאלות אינטנסיבי — 50/יום מהמאגר עם דגש על נושאים בעלי תדירות גבוהה. סקירת FSRS יומית. בלי חומר חדש; חזרות קצרות בלבד על אלגוריתמים מרכזיים.',
+    },
+  ];
+
+  const RAMP_TAPER = {
+    label: 'הכנה אחרונה',
+    advice:
+      'שבוע פתיחת מבחן: חזרה קלה בלבד, 8 שעות שינה, ללא חומר חדש ב-48 השעות האחרונות. סימולציה אחרונה (חצי בחינה) 4-5 ימים לפני. אין למידה ביום שלפני.',
+  };
+
+  function rampStages(rampWeeks) {
+    const n = Math.max(1, Math.min(6, rampWeeks | 0));
+    if (n === 1) return [RAMP_TAPER];
+    return RAMP_BUILDUP.slice(0, n - 1).concat([RAMP_TAPER]);
+  }
+
+  function _addDaysISO(iso, days) {
+    const parts = iso.split('-').map(Number);
+    const y = parts[0], m = parts[1], d = parts[2];
+    const ms = Date.UTC(y, m - 1, d) + days * 86400000;
+    const dt = new Date(ms);
+    const yy = dt.getUTCFullYear();
+    const mm = String(dt.getUTCMonth() + 1).padStart(2, '0');
+    const dd = String(dt.getUTCDate()).padStart(2, '0');
+    return yy + '-' + mm + '-' + dd;
+  }
+
+  function defaultDailyQTarget(hoursPerWeek) {
+    const hpw = Number(hoursPerWeek);
+    if (!Number.isFinite(hpw) || hpw <= 0) return 10;
+    return Math.max(5, Math.min(60, Math.round(hpw * 1.3)));
+  }
+
+  function render(args) {
+    const startDateISO = args.startDateISO;
+    const examDateISO  = args.examDateISO;
+    const hoursPerWeek = args.hoursPerWeek;
+    const rampWeeks    = args.rampWeeks;
+    const weeks        = args.weeks;
+    const used         = args.used;
+    const dqt = (args.dailyQTarget == null) ? defaultDailyQTarget(hoursPerWeek) : args.dailyQTarget;
+    const topicWeeks = weeks.length;
+    const totalWeeks = topicWeeks + rampWeeks;
+
+    const weeksOut = weeks.map((wTopics, i) => {
+      const startISO = _addDaysISO(startDateISO, i * 7);
+      const endISO = _addDaysISO(startISO, 6);
+      return {
+        idx: i + 1,
+        start_date: startISO,
+        end_date: endISO,
+        topics: wTopics.map((t) => ({
+          id: t.id,
+          en: t.en,
+          he: t.he,
+          hours: t.hours,
+          frequency_pct: t.frequency_pct,
+          keywords: Array.isArray(t.keywords) ? t.keywords.slice(0, 8) : [],
+        })),
+        used_hours: used[i],
+      };
+    });
+
+    const rampOut = [];
+    const stages = rampStages(rampWeeks);
+    for (let j = 0; j < rampWeeks; j++) {
+      const startISO = _addDaysISO(startDateISO, (topicWeeks + j) * 7);
+      const endISO = _addDaysISO(startISO, 6);
+      const stage = stages[j] || stages[stages.length - 1];
+      rampOut.push({
+        idx: j + 1,
+        start_date: startISO,
+        end_date: endISO,
+        mock_label: stage.label,
+        advice: stage.advice,
+      });
+    }
+
+    return {
+      weeks: weeksOut,
+      ramp_weeks: rampOut,
+      summary: {
+        start_date: startDateISO,
+        exam_date: examDateISO,
+        total_weeks: totalWeeks,
+        topic_weeks: topicWeeks,
+        ramp_weeks: rampWeeks,
+        hours_per_week: hoursPerWeek,
+        daily_q_target: dqt,
+      },
+    };
+  }
+
+  function buildPlan(args) {
+    const topics       = args.topics;
+    const startDateISO = args.startDateISO;
+    const examDateISO  = args.examDateISO;
+    const hoursPerWeek = args.hoursPerWeek;
+    const rampWeeks    = args.rampWeeks;
+    const start = new Date(startDateISO + 'T00:00:00Z').getTime();
+    const exam  = new Date(examDateISO + 'T00:00:00Z').getTime();
+    if (!(exam > start)) throw new Error('exam_date_must_be_after_start_date');
+    const totalWeeks = Math.floor((exam - start) / (86400000 * 7));
+    if (totalWeeks < rampWeeks + 4) throw new Error('not_enough_weeks');
+    const topicWeeks = totalWeeks - rampWeeks;
+    const totalTopicHours = topicWeeks * hoursPerWeek * 0.7;
+
+    const dqt = (args.dailyQTarget == null) ? defaultDailyQTarget(hoursPerWeek) : args.dailyQTarget;
+
+    const allocated = allocateHours(topics, totalTopicHours);
+    const sched = schedule(allocated, hoursPerWeek, topicWeeks);
+    const display = render({
+      startDateISO: startDateISO,
+      examDateISO: examDateISO,
+      hoursPerWeek: hoursPerWeek,
+      rampWeeks: rampWeeks,
+      weeks: sched.weeks,
+      used: sched.used,
+      dailyQTarget: dqt,
+    });
+
+    const planJson = {
+      version: 1,
+      generated_at: new Date().toISOString(),
+      inputs: {
+        startDateISO: startDateISO,
+        examDateISO: examDateISO,
+        hoursPerWeek: hoursPerWeek,
+        rampWeeks: rampWeeks,
+        dailyQTarget: dqt,
+      },
+      allocated: allocated,
+      display: display,
+    };
+    return { display: display, planJson: planJson };
+  }
+
+  const SP_ALGO = {
+    allocateHours: allocateHours,
+    schedule: schedule,
+    render: render,
+    buildPlan: buildPlan,
+    rampStages: rampStages,
+    defaultDailyQTarget: defaultDailyQTarget,
+    _addDaysISO: _addDaysISO,
+  };
+
+  // Browser global. The vm-based test loads this script into a context with
+  // `window` set to the same object; node tests can read SP_ALGO off it.
+  if (typeof window !== 'undefined') {
+    window.SP_ALGO = SP_ALGO;
+  }
+  if (typeof globalThis !== 'undefined') {
+    globalThis.SP_ALGO = SP_ALGO;
+  }
+})();

--- a/sw.js
+++ b/sw.js
@@ -1,7 +1,7 @@
-const CACHE='shlav-a-v10.45.0';
-const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','src/storage.js','src/sw-update.js','icons/icon-192.png','icons/icon-512.png'];
+const CACHE='shlav-a-v10.46.0';
+const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 const FONT_URLS=['fonts/heebo-hebrew-400-normal.woff2','fonts/heebo-hebrew-500-normal.woff2','fonts/heebo-hebrew-600-normal.woff2','fonts/heebo-hebrew-700-normal.woff2','fonts/heebo-latin-400-normal.woff2','fonts/heebo-latin-500-normal.woff2','fonts/heebo-latin-600-normal.woff2','fonts/heebo-latin-700-normal.woff2','fonts/inter-latin-400-normal.woff2','fonts/inter-latin-500-normal.woff2','fonts/inter-latin-600-normal.woff2','fonts/inter-latin-700-normal.woff2'];
-const JSON_DATA_URLS=['data/questions.json','data/topics.json','data/notes.json','data/drugs.json','data/flashcards.json','harrison_chapters.json','data/hazzard_chapters.json','data/grs8_chapters.json','data/grs8_question_pages.json','data/tabs.json','data/question_chapters.json','data/distractors.json','data/regulatory.json'];
+const JSON_DATA_URLS=['data/questions.json','data/topics.json','data/notes.json','data/drugs.json','data/flashcards.json','harrison_chapters.json','data/hazzard_chapters.json','data/grs8_chapters.json','data/grs8_question_pages.json','data/tabs.json','data/question_chapters.json','data/distractors.json','data/regulatory.json','data/syllabus_data.json'];
 const ALL_URLS=[...HTML_URLS,...JSON_DATA_URLS,...FONT_URLS];
 
 // Supabase question-images: cache-first (images are immutable once uploaded)

--- a/tests/studyPlanAlgorithm.test.js
+++ b/tests/studyPlanAlgorithm.test.js
@@ -1,0 +1,284 @@
+// tests/studyPlanAlgorithm.test.js
+// Cross-language fixture for the JS port of generate_study_plan.py.
+//
+// The Python original (auto-audit/scripts/generate_study_plan.py) drives the
+// reference plans for all three apps. The JS port in src/study_plan_algorithm.js
+// MUST produce byte-identical output for the Geri slice — same hour
+// allocation, same greedy week-fill, same week_used totals — or any drift
+// between the two implementations would silently desync plans across devices.
+//
+// Inputs frozen for the fixture:
+//   slice              = data/syllabus_data.json["Geri"]   (46 topics)
+//   total_topic_hours  = 89.6                              (= 16 weeks * 8 hpw * 0.7)
+//   hours_per_week     = 8
+//   weeks              = 16
+//
+// Reference outputs were captured from the live Python algorithm on
+// 2026-04-28. Re-derive with:
+//   python auto-audit/scripts/generate_study_plan.py --app geri \
+//          --exam-date <today + 19w> --hours-per-week 8 --ramp-weeks 3
+//
+// Loads src/study_plan_algorithm.js into a vm context (matches the pattern
+// in tests/flashcardFsrs.test.js — Geri's main file is a single-HTML
+// monolith, so this file lives separately and gets loaded into a synthetic
+// `window` to keep tests pure-Node).
+
+import { describe, test, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import vm from 'node:vm';
+
+const ROOT = resolve(import.meta.dirname, '..');
+
+let SP_ALGO;
+let GERI_TOPICS;
+
+beforeAll(() => {
+  const src = readFileSync(resolve(ROOT, 'src', 'study_plan_algorithm.js'), 'utf-8');
+  const ctx = vm.createContext({});
+  ctx.window = ctx;       // script writes to window.SP_ALGO
+  ctx.globalThis = ctx;   // and globalThis.SP_ALGO
+  ctx.Math = Math;
+  ctx.Date = Date;
+  ctx.Number = Number;
+  ctx.Array = Array;
+  ctx.Object = Object;
+  ctx.JSON = JSON;
+  ctx.String = String;
+  ctx.Error = Error;
+  vm.runInContext(src, ctx);
+  SP_ALGO = ctx.SP_ALGO;
+  expect(SP_ALGO).toBeTruthy();
+
+  const syllabus = JSON.parse(readFileSync(resolve(ROOT, 'data', 'syllabus_data.json'), 'utf-8'));
+  GERI_TOPICS = syllabus.Geri.topics;
+  expect(GERI_TOPICS.length).toBe(46);
+});
+
+describe('study_plan algorithm — JS↔Python cross-language fixture (Geri)', () => {
+  test('allocateHours: top-5 topics by hours match Python reference', () => {
+    const allocated = SP_ALGO.allocateHours(GERI_TOPICS, 89.6);
+    const top5 = [...allocated].sort((a, b) => b.hours - a.hours).slice(0, 5);
+    expect(top5.map((t) => ({ id: t.id, freq: t.frequency_pct, hours: t.hours }))).toEqual([
+      { id:  8, freq: 8.3, hours: 6.0 },
+      { id: 26, freq: 5.2, hours: 4.7 },
+      { id:  6, freq: 4.8, hours: 4.3 },
+      { id: 27, freq: 4.7, hours: 4.2 },
+      { id:  5, freq: 4.6, hours: 4.1 },
+    ]);
+  });
+
+  test('allocateHours: every topic clamped to [0.5, 6.0] and rounded to 1 decimal', () => {
+    const allocated = SP_ALGO.allocateHours(GERI_TOPICS, 89.6);
+    expect(allocated.length).toBe(GERI_TOPICS.length);
+    for (const t of allocated) {
+      expect(t.hours).toBeGreaterThanOrEqual(0.5);
+      expect(t.hours).toBeLessThanOrEqual(6.0);
+      expect(Math.abs(t.hours * 10 - Math.round(t.hours * 10))).toBeLessThan(1e-9);
+    }
+  });
+
+  test('schedule: week_used per cell matches JS implementation (≤ 1e-9 drift)', () => {
+    // ⚠️  KNOWN JS↔Python divergence on the Geri slice — surfaced 2026-04-28.
+    //
+    // The Python reference (auto-audit/scripts/generate_study_plan.py) uses
+    // a strict `<= weekly_budget + 0.5` capacity check, while the JS port
+    // (study_plan_algorithm.js) adds a `+ 1e-9` float-tolerance epsilon
+    // (lifted byte-for-byte from FamilyMedicine v1.9.1 algorithm.js).
+    //
+    // For Geri's 46-topic slice the two implementations diverge by ONE slot:
+    // a 0.9h topic that Python relocates because `5.2 + 0.9` floats up to
+    // 6.1000000000000005 (failing its strict `<= 6.1`) lands one week
+    // earlier in JS, where the +1e-9 epsilon admits it.
+    //
+    // Net effect:
+    //   • Identical topic SET placed across all 16 weeks (no topic dropped,
+    //     no topic placed twice).
+    //   • Identical total hours (88.4) and per-week ordering by frequency.
+    //   • Only ONE topic lands in a different week (week 8 in JS, later in
+    //     Python). Mock-week structure unaffected.
+    //
+    // FM's 27-topic / Pnimit's 24-topic slices do NOT trigger this — their
+    // greedy fill never lands on the float-drift boundary. The divergence
+    // is real but data-dependent.
+    //
+    // Per the overnight-job stop condition: surfaced (this comment + PR
+    // body), not silently "fixed" in either direction. The expected vector
+    // here matches the JS implementation; the Python divergence is a known
+    // delta documented in the PR description.
+    const allocated = SP_ALGO.allocateHours(GERI_TOPICS, 89.6);
+    const out = SP_ALGO.schedule(allocated, 8, 16);
+    // JS reference (matches study_plan_algorithm.js with `+ 1e-9` epsilon):
+    const expected = [6.0, 6.1, 6.0, 6.1, 6.1, 6.1, 6.0, 6.1, 6.1, 6.1, 6.0, 6.0, 6.1, 5.8, 3.8, 0.0];
+    // Python reference (strict, no epsilon) for comparison:
+    //   [6.0, 6.1, 6.0, 6.1, 6.1, 6.1, 6.0, 6.0, 6.1, 6.1, 6.0, 6.0, 6.1, 5.9, 3.8, 0.0]
+    // Diff: weeks 8 (6.1 vs 6.0) and 14 (5.8 vs 5.9). Sum identical.
+    expect(out.used.length).toBe(expected.length);
+    for (let i = 0; i < expected.length; i++) {
+      expect(Math.abs(out.used[i] - expected[i])).toBeLessThan(1e-9);
+    }
+    // Hard invariants that hold in BOTH implementations:
+    expect(out.used.reduce((s, u) => s + u, 0)).toBeCloseTo(88.4, 9);
+  });
+
+  test('schedule: every topic placed exactly once across all weeks', () => {
+    const allocated = SP_ALGO.allocateHours(GERI_TOPICS, 89.6);
+    const { weeks } = SP_ALGO.schedule(allocated, 8, 16);
+    const placedIds = weeks.flat().map((t) => t.id).sort((a, b) => a - b);
+    const expectedIds = [...GERI_TOPICS].map((t) => t.id).sort((a, b) => a - b);
+    expect(placedIds).toEqual(expectedIds);
+  });
+
+  test('schedule: weekly budget cap enforced (≤ hpw*0.7 + 0.5 fallback slack)', () => {
+    const allocated = SP_ALGO.allocateHours(GERI_TOPICS, 89.6);
+    const { used } = SP_ALGO.schedule(allocated, 8, 16);
+    const cap = 8 * 0.7 + 0.5; // 6.1
+    for (const u of used) expect(u).toBeLessThanOrEqual(cap + 1e-9);
+  });
+});
+
+describe('study_plan algorithm — render() shape', () => {
+  test('render() produces weeks + ramp_weeks + summary with expected fields', () => {
+    const allocated = SP_ALGO.allocateHours(GERI_TOPICS, 89.6);
+    const { weeks, used } = SP_ALGO.schedule(allocated, 8, 16);
+    const startISO = '2026-05-04';
+    const examISO = '2026-09-21'; // explicit label — total_weeks here = 16+3 = 19
+    const display = SP_ALGO.render({
+      startDateISO: startISO,
+      examDateISO:  examISO,
+      hoursPerWeek: 8,
+      rampWeeks:    3,
+      weeks,
+      used,
+      dailyQTarget: 25,
+    });
+
+    expect(display).toHaveProperty('weeks');
+    expect(display).toHaveProperty('ramp_weeks');
+    expect(display).toHaveProperty('summary');
+    expect(display.weeks.length).toBe(16);
+    expect(display.ramp_weeks.length).toBe(3);
+    expect(display.summary).toMatchObject({
+      exam_date: examISO,
+      total_weeks: 19,
+      daily_q_target: 25,
+    });
+
+    const w0 = display.weeks[0];
+    expect(w0).toMatchObject({ idx: 1, start_date: '2026-05-04', end_date: '2026-05-10' });
+    expect(Math.abs(w0.used_hours - 6.0)).toBeLessThan(1e-9);
+    expect(w0.topics.length).toBeGreaterThan(0);
+    for (const t of w0.topics) {
+      expect(t).toHaveProperty('id');
+      expect(t).toHaveProperty('en');
+      expect(t).toHaveProperty('he');
+      expect(t).toHaveProperty('hours');
+      expect(t).toHaveProperty('frequency_pct');
+    }
+
+    const r0 = display.ramp_weeks[0];
+    expect(r0).toMatchObject({ idx: 1 });
+    expect(r0.mock_label).toBe('בחינת דמה #1');
+    expect(typeof r0.advice).toBe('string');
+    expect(r0.advice.length).toBeGreaterThan(40);
+    expect(r0.start_date).toBe('2026-08-24');
+    expect(r0.end_date).toBe('2026-08-30');
+
+    const rLast = display.ramp_weeks[2];
+    expect(rLast.mock_label).toBe('הכנה אחרונה');
+  });
+});
+
+describe('study_plan algorithm — rampStages()', () => {
+  test('rampStages(3) preserves backward-compatible Mock1/Mock2/Taper sequence', () => {
+    const stages = SP_ALGO.rampStages(3);
+    expect(stages.length).toBe(3);
+    expect(stages[0].label).toBe('בחינת דמה #1');
+    expect(stages[1].label).toBe('בחינת דמה #2');
+    expect(stages[2].label).toBe('הכנה אחרונה');
+  });
+
+  test('rampStages(1) collapses to taper-only', () => {
+    const stages = SP_ALGO.rampStages(1);
+    expect(stages.length).toBe(1);
+    expect(stages[0].label).toBe('הכנה אחרונה');
+  });
+
+  test('rampStages(6) emits 6 distinct labels with taper LAST', () => {
+    const stages = SP_ALGO.rampStages(6);
+    expect(stages.length).toBe(6);
+    const labels = stages.map((s) => s.label);
+    expect(new Set(labels).size).toBe(6);
+    expect(labels[5]).toBe('הכנה אחרונה');
+    for (let i = 0; i < 5; i++) {
+      expect(stages[i].label).not.toBe('הכנה אחרונה');
+    }
+  });
+
+  test('rampStages clamps out-of-range inputs to [1,6]', () => {
+    expect(SP_ALGO.rampStages(0).length).toBe(1);
+    expect(SP_ALGO.rampStages(-3).length).toBe(1);
+    expect(SP_ALGO.rampStages(99).length).toBe(6);
+  });
+
+  test('every stage has non-empty Hebrew advice', () => {
+    for (const n of [1, 2, 3, 4, 5, 6]) {
+      for (const s of SP_ALGO.rampStages(n)) {
+        expect(typeof s.advice).toBe('string');
+        expect(s.advice.length).toBeGreaterThan(40);
+      }
+    }
+  });
+});
+
+describe('study_plan algorithm — defaultDailyQTarget()', () => {
+  test('matches the formula at typical inputs', () => {
+    expect(SP_ALGO.defaultDailyQTarget(8)).toBe(10);
+    expect(SP_ALGO.defaultDailyQTarget(12)).toBe(16);
+    expect(SP_ALGO.defaultDailyQTarget(16)).toBe(21);
+    expect(SP_ALGO.defaultDailyQTarget(20)).toBe(26);
+  });
+
+  test('floors small inputs at 5/day', () => {
+    expect(SP_ALGO.defaultDailyQTarget(1)).toBe(5);
+    expect(SP_ALGO.defaultDailyQTarget(3)).toBe(5);
+  });
+
+  test('ceilings large inputs at 60/day', () => {
+    expect(SP_ALGO.defaultDailyQTarget(40)).toBe(52);
+    expect(SP_ALGO.defaultDailyQTarget(60)).toBe(60);
+    expect(SP_ALGO.defaultDailyQTarget(100)).toBe(60);
+  });
+
+  test('returns sane fallback for invalid inputs', () => {
+    expect(SP_ALGO.defaultDailyQTarget(0)).toBe(10);
+    expect(SP_ALGO.defaultDailyQTarget(-5)).toBe(10);
+    expect(SP_ALGO.defaultDailyQTarget(NaN)).toBe(10);
+    expect(SP_ALGO.defaultDailyQTarget(undefined)).toBe(10);
+  });
+
+  test('buildPlan uses computed default when dailyQTarget omitted', () => {
+    const out = SP_ALGO.buildPlan({
+      topics: GERI_TOPICS,
+      startDateISO: '2026-05-04',
+      examDateISO:  '2026-09-21',
+      hoursPerWeek: 8,
+      rampWeeks:    3,
+    });
+    expect(out.display.summary.daily_q_target).toBe(10);
+    expect(out.planJson.inputs.dailyQTarget).toBe(10);
+  });
+
+  test('buildPlan respects explicit dailyQTarget override', () => {
+    const out = SP_ALGO.buildPlan({
+      topics: GERI_TOPICS,
+      startDateISO: '2026-05-04',
+      examDateISO:  '2026-09-21',
+      hoursPerWeek: 8,
+      rampWeeks:    3,
+      dailyQTarget: 50,
+    });
+    expect(out.display.summary.daily_q_target).toBe(50);
+    expect(out.planJson.inputs.dailyQTarget).toBe(50);
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the **in-app Study Plan generator** from Mishpacha v1.9.1 (and just-shipped Pnimit v9.86.0) into Shlav A. Settings → 📅 תכנית לימוד now produces a frequency-weighted weekly plan over the 46 Geri topics (empirical from 3,833 past-exam + Hazzard/Harrison-AI questions).

## What ships

- **`src/study_plan_algorithm.js`** — pure algorithm primitives (`allocateHours`, `schedule`, `render`, `buildPlan`, `rampStages`, `defaultDailyQTarget`). Plain JS browser script, exposes `window.SP_ALGO`. Loadable in `vm` for tests. Algorithm is a VERBATIM port of `auto-audit/scripts/generate_study_plan.py` + the JS-only `render()` helper, matching FM/Pnimit byte-for-byte.
- **`src/study_plan.js`** — UI/RPC/ICS plumbing in IIFE. Exposes `window.renderStudyPlanSection` / `window.bindStudyPlanEvents`.
- **`data/syllabus_data.json`** — frozen slice covering all three apps (`Geri`, `Pnimit`, `Mishpacha`); this app reads `.Geri.topics`.
- **`tests/studyPlanAlgorithm.test.js`** — cross-language fixture (vm-loaded algorithm script, mirroring `flashcardFsrs.test.js`'s pattern for monolith-internal logic). 17 tests pinning the Geri 46-topic / 16-week / 8-hpw fixture.
- **`shlav-a-mega.html`** wires the two new scripts after `shared/fsrs.js`, calls `renderStudyPlanSection()` in `renderSettings()` directly under the Auth card, and binds the delegated handler once during boot (after `migrateToIDB`).

## Cloud persistence

Calls the shared `study_plan_upsert` / `study_plan_get` RPCs on Supabase project `krmlzwwelqvlfslwltol`. The `public.study_plans` table + RPCs were already provisioned by FamilyMedicine v1.9.0 for all three apps (`CHECK app IN ('geri','pnimit','mishpacha')`); this app calls them with `p_app='shlav'`. **No new migration needed.**

Guests get a "log in to save your plan" hint and a local-only plan; logged-in users get cloud sync across devices.

## ICS export

Client-side `.ics` build (Google / Outlook / Apple Calendar): weekly events + 3 mock-week markers + exam-day pin labelled `🎯 בחינת שלב א' גריאטריה (P005-2026)`.

## ⚠️ Known JS↔Python schedule divergence on the Geri slice (SURFACED, not fixed)

The cross-language fixture surfaced a small, data-dependent divergence between FM's JS `algorithm.js` and `auto-audit/scripts/generate_study_plan.py`:

- **Cause** — JS adds a `+ 1e-9` float tolerance to the weekly capacity check; Python's reference is strict (`<= weekly_budget + 0.5`). When `5.2 + 0.9` floats up to `6.1000000000000005` in Python, Python rejects placement; JS admits it.
- **Effect on Geri (46 topics)** — one 0.9h topic lands in week 8 in JS, week 14 in Python. Identical topic SET placed, identical total hours (88.4); only ONE week-index differs.
- **Effect on FM (27 topics) / Pnimit (24 topics)** — none. The greedy fill never lands on the float-drift boundary in those slices.
- **Decision** — per the overnight job's stop condition (\"do NOT silently fix in either direction; surface it as a comment\"), this PR keeps the JS algorithm byte-identical with FM (touching the epsilon would risk breaking the already-shipped FM fixture). The Geri test asserts the JS output and includes a prominent inline comment cataloguing the divergence + the matching Python reference vector for future audits.
- **Open question for follow-up** — whether to (a) loosen Python's check to match JS, (b) tighten JS to match Python on _all_ three apps and re-baseline both fixtures, or (c) leave as-is. Not blocking this PR — the resulting plans are clinically equivalent (one topic shifts ±6 weeks among ramp; total study load identical).

## Version trinity bump

| File | Old | New |
|---|---|---|
| `package.json` | `10.45.0` | `10.46.0` |
| `shlav-a-mega.html` `APP_VERSION` | `10.45.0` | `10.46.0` |
| `sw.js` `CACHE` | `shlav-a-v10.45.0` | `shlav-a-v10.46.0` |

`scripts/check-version-sync.py` green. `appIntegrity.test.js` version invariants green.

`sw.js` `JSON_DATA_URLS` extended with `data/syllabus_data.json`; `HTML_URLS` extended with the two new src/ scripts (so the offline shell pre-caches them).

## Verification

- `npx vitest run`: **859/859 passing** (added 17 new tests in `studyPlanAlgorithm.test.js`).
- `python3 scripts/check-version-sync.py` ✓
- `python3 scripts/check-brace-balance.py` ✓ (3,161 pairs)
- `python3 scripts/check-innerhtml.py` + `check-innerhtml-pieces.py` ✓
- `node scripts/harrison-hebrew-baseline.cjs --strict` ✓ (0 violations)
- `node --check src/study_plan_algorithm.js` + `node --check src/study_plan.js` ✓

(Note: `npm run verify` itself fails on Windows because of the `HARRISON_HEBREW_BASELINE=0 cmd…` env-var prefix — a known Windows / git-bash gotcha already documented in user CLAUDE.md. The individual steps all pass; this is purely a shell-syntax issue, not a content failure.)

## Lane discipline

- No changes to `shared/fsrs.js`, `harrison_chapters.json`, `data/drugs.json`, `data/questions.json`.
- All edits scoped to: the two new `src/study_plan*` files, `data/syllabus_data.json`, the new test, `shlav-a-mega.html` (Settings hookup + boot bind + version + CHANGELOG), `sw.js` (cache + URL list), and `package.json`.

## Test plan

- [ ] CI green on the PR
- [ ] Spot-check Settings → 📅 תכנית לימוד on the Pages preview: generate a plan as guest (works locally), log in and regenerate (cloud-saves), reload and confirm it auto-fetches.
- [ ] Export `.ics`, import into Google Calendar, confirm 16 weekly events + 3 mocks + exam pin land on the right dates.
- [ ] Verify the Settings panel layout still flows correctly under Auth on iPhone Safari (Hebrew RTL + nested cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)