### PR TITLE
feat: editorial-clinical redesign — body baseline, page header, underline tabs, hairline cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.52.0",
+  "version": "10.53.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shared/layout-primitives.css
+++ b/shared/layout-primitives.css
@@ -1,0 +1,228 @@
+/* ============================================================================
+ * Layout Primitives — Editorial Clinical, 2026-04
+ *
+ * Loaded AFTER tokens.css. Defines reusable structural components.
+ * Each consuming repo copies this file byte-identical.
+ * RTL-safe: uses logical properties.
+ * ========================================================================= */
+
+/* ---------- App shell ----------------------------------------------------- */
+.app-shell {
+  max-inline-size: var(--max-content);
+  margin-inline: auto;
+  padding-inline: var(--space-4);
+  padding-block: var(--space-4);
+}
+@media (min-width: 720px) {
+  .app-shell { padding-inline: var(--space-8); }
+}
+
+/* ---------- Page header (display headline + small mono version chip) ----- */
+.page-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding-block-end: var(--space-4);
+  border-block-end: 1px solid var(--color-border);
+  margin-block-end: var(--space-6);
+}
+.page-header__title {
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-bold);
+  line-height: var(--leading-tight);
+  letter-spacing: -0.01em;
+  color: var(--color-fg);
+  margin: 0;
+}
+.page-header__meta {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-fg-muted);
+  letter-spacing: 0.04em;
+}
+
+/* ---------- Underline tabs ----------------------------------------------- */
+.tabs {
+  position: relative;
+  display: flex;
+  gap: var(--space-6);
+  border-block-end: 1px solid var(--color-border);
+  margin-block-end: var(--space-6);
+  list-style: none;
+  padding: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.tabs::-webkit-scrollbar { display: none; }
+
+.tab-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding-block: var(--space-3);
+  padding-inline: 0;
+  min-block-size: var(--touch-min);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  letter-spacing: 0.02em;
+  color: var(--color-fg-muted);
+  background: none;
+  border: 0;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color var(--motion-fast) var(--easing-out);
+  text-decoration: none;
+}
+.tab-link:hover { color: var(--color-fg); }
+.tab-link:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 4px;
+  border-radius: var(--radius-sm);
+}
+.tab-link.is-active { color: var(--color-fg); font-weight: var(--weight-bold); }
+
+.tab-indicator {
+  position: absolute;
+  inset-block-end: -1px;
+  inset-inline-start: 0;
+  block-size: 2px;
+  background: var(--color-accent);
+  transform: translateX(0);
+  transition:
+    transform var(--motion-base) var(--easing-out),
+    inline-size var(--motion-base) var(--easing-out);
+  pointer-events: none;
+}
+
+/* ---------- Card ---------------------------------------------------------- */
+.card {
+  background: var(--color-surface);
+  color: var(--color-fg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-6);
+  transition: border-color var(--motion-fast) var(--easing-out);
+}
+.card--interactive {
+  cursor: pointer;
+}
+.card--interactive:hover,
+.card--interactive:focus-visible {
+  border-color: var(--color-border-strong);
+  outline: none;
+}
+.card__title {
+  font-family: var(--font-display);
+  font-size: var(--text-lg);
+  font-weight: var(--weight-bold);
+  line-height: var(--leading-snug);
+  margin: 0 0 var(--space-2);
+  color: var(--color-fg);
+}
+.card__meta {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-fg-muted);
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+/* ---------- Buttons (three tiers only) ----------------------------------- */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  min-block-size: var(--touch-min);
+  padding-block: var(--space-3);
+  padding-inline: var(--space-5);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  letter-spacing: 0.02em;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  cursor: pointer;
+  user-select: none;
+  transition:
+    background-color var(--motion-fast) var(--easing-out),
+    border-color var(--motion-fast) var(--easing-out),
+    color var(--motion-fast) var(--easing-out);
+}
+.btn:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* Primary — accent fill */
+.btn--primary {
+  background: var(--color-accent);
+  color: var(--color-accent-fg);
+  border-color: var(--color-accent);
+}
+.btn--primary:hover:not(:disabled) { filter: brightness(0.92); }
+
+/* Secondary — hairline */
+.btn--secondary {
+  background: transparent;
+  color: var(--color-fg);
+  border-color: var(--color-border);
+}
+.btn--secondary:hover:not(:disabled) { border-color: var(--color-border-strong); }
+
+/* Ghost — text-only */
+.btn--ghost {
+  background: transparent;
+  color: var(--color-fg-muted);
+  border-color: transparent;
+}
+.btn--ghost:hover:not(:disabled) { color: var(--color-fg); }
+
+/* ---------- Pill (badges, status) ---------------------------------------- */
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding-inline: var(--space-3);
+  padding-block: var(--space-1);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  color: var(--color-fg-muted);
+  background: var(--color-surface-2);
+}
+.pill--accent  { color: var(--color-accent);  background: var(--color-accent-soft); border-color: transparent; }
+.pill--success { color: var(--color-success); background: var(--color-accent-soft); border-color: transparent; }
+.pill--warn    { color: var(--color-warn);    background: color-mix(in srgb, var(--color-warn) 14%, transparent); border-color: transparent; }
+.pill--danger  { color: var(--color-danger);  background: color-mix(in srgb, var(--color-danger) 12%, transparent); border-color: transparent; }
+
+/* ---------- Stack utilities (replace the eight margin variants) --------- */
+.stack > * + * { margin-block-start: var(--space-4); }
+.stack-sm > * + * { margin-block-start: var(--space-2); }
+.stack-lg > * + * { margin-block-start: var(--space-8); }
+
+.row { display: flex; gap: var(--space-3); align-items: center; flex-wrap: wrap; }
+.row-between { display: flex; gap: var(--space-3); align-items: center; justify-content: space-between; }
+
+/* ---------- Hebrew/RTL hygiene ------------------------------------------- */
+.heb {
+  font-family: var(--font-body);
+  unicode-bidi: plaintext;
+  text-align: start;
+}
+
+/* ---------- Body baseline (apply once, on body) -------------------------- */
+.app-body-baseline {
+  font-family: var(--font-body);
+  font-size: var(--text-md);
+  line-height: var(--leading-body);
+  color: var(--color-fg);
+  background: var(--color-bg);
+}

--- a/shared/tokens.css
+++ b/shared/tokens.css
@@ -1,49 +1,46 @@
 /* ============================================================================
- * Shared Design Tokens — Medical PWA Suite
+ * Shared Design Tokens — Medical PWA Suite (Editorial Clinical, 2026-04)
  * Used by: Geriatrics, InternalMedicine, FamilyMedicine
  *
  * BYTE-IDENTICAL across the three medical PWAs (same precedent as fsrs.js).
  * Source of truth: C:\Users\User\repos\.shared\tokens.css
- * Each consuming repo copies this file to its own location and `@import`s it.
  *
- * Conventions:
- *   --color-* → palette. Light + dark variants via [data-theme="dark"]
- *   --type-*  → font-family + scale (1.25 ratio, fluid clamps)
- *   --space-* → 4px-base scale, 0..16
- *   --radius-*, --shadow-*, --motion-*, --easing-*
+ * Aesthetic direction: see .shared/aesthetic-2026-04.md (Editorial Clinical —
+ * warm-cream/forest-green, Frank Ruhl Libre + Heebo, hairline cards,
+ * underline tabs, restrained motion).
  *
- * RTL/Hebrew note: all sizing is logical (no `right`/`left`). Use
- *   `inset-inline-start/end`, `margin-inline-*`, `padding-inline-*`.
+ * RTL/Hebrew: all sizing uses logical properties (inset-inline-*, margin-inline-*,
+ *   padding-inline-*). Never use right/left.
  * ========================================================================= */
 
 :root {
-  /* ---------- Color: light theme (default) ---------- */
-  --color-bg:           #fafaf7;
+  /* ---------- Color: light theme (default) — warm cream + forest green ---- */
+  --color-bg:           #faf7f2;
   --color-surface:      #ffffff;
-  --color-surface-2:    #f3f3ee;
-  --color-border:       #e3e2dc;
-  --color-border-strong:#bdbcb4;
+  --color-surface-2:    #f3efe7;
+  --color-border:       #e0d9cd;
+  --color-border-strong:#a89f8d;
 
-  --color-fg:           #1a1916;
-  --color-fg-muted:     #5b5a52;
-  --color-fg-subtle:    #8d8b80;
+  --color-fg:           #1a1817;
+  --color-fg-muted:     #5e5b54;
+  --color-fg-subtle:    #8a8478;
 
-  --color-accent:       #5b3df5;     /* primary action — purple-blue, neutral on Hebrew & English */
-  --color-accent-fg:    #ffffff;
-  --color-accent-soft:  #efe9ff;
+  --color-accent:       #1d4d3e;     /* deep forest — calm, distinctive */
+  --color-accent-fg:    #faf7f2;
+  --color-accent-soft:  #dfe9e3;
 
-  --color-success:      #2f7a3a;
-  --color-warn:         #c98a1d;
-  --color-danger:       #c4332e;
-  --color-info:         #1c6ea4;
+  --color-success:      #1d4d3e;
+  --color-warn:         #9c6b18;
+  --color-danger:       #a83232;
+  --color-info:         #3a5b8a;
 
-  /* Mastery heat scale (colorblind-safe Viridis-derived, 5 steps) */
-  --heat-0: #440154;  /* lowest mastery */
-  --heat-1: #3b528b;
-  --heat-2: #21918c;
-  --heat-3: #5ec962;
-  --heat-4: #fde725;  /* highest mastery */
-  --heat-na:#7a7a72;  /* not enough data */
+  /* Mastery heat scale (Cividis-derived, colorblind-safe, 5 steps + na) */
+  --heat-0: #00204d;
+  --heat-1: #2c4875;
+  --heat-2: #65749d;
+  --heat-3: #a3a8a5;
+  --heat-4: #f1cb33;
+  --heat-na:#7a7a72;
 
   /* ---------- Type ---------- */
   /* Hebrew display — Frank Ruhl Libre. Hebrew body — Heebo.
@@ -73,16 +70,18 @@
 
   /* ---------- Space (4px base) ---------- */
   --space-0:  0;
-  --space-1:  0.25rem;  /*  4px */
-  --space-2:  0.5rem;   /*  8px */
-  --space-3:  0.75rem;  /* 12px */
-  --space-4:  1rem;     /* 16px */
-  --space-5:  1.25rem;  /* 20px */
-  --space-6:  1.5rem;   /* 24px */
-  --space-8:  2rem;     /* 32px */
-  --space-10: 2.5rem;   /* 40px */
-  --space-12: 3rem;     /* 48px */
-  --space-16: 4rem;     /* 64px */
+  --space-1:  0.25rem;
+  --space-2:  0.5rem;
+  --space-3:  0.75rem;
+  --space-4:  1rem;
+  --space-5:  1.25rem;
+  --space-6:  1.5rem;
+  --space-8:  2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+
+  --max-content: 1100px;
 
   /* ---------- Radius / Shadow ---------- */
   --radius-sm: 0.25rem;
@@ -91,10 +90,9 @@
   --radius-xl: 1rem;
   --radius-pill: 999px;
 
-  --shadow-1: 0 1px 2px rgb(0 0 0 / 0.06), 0 1px 1px rgb(0 0 0 / 0.04);
-  --shadow-2: 0 2px 6px rgb(0 0 0 / 0.08), 0 1px 2px rgb(0 0 0 / 0.04);
-  --shadow-3: 0 8px 24px rgb(0 0 0 / 0.10), 0 2px 6px rgb(0 0 0 / 0.06);
-  --shadow-inset: inset 0 0 0 1px rgb(0 0 0 / 0.06);
+  /* No drop shadows by default — Editorial Clinical relies on surface contrast.
+   * --shadow-* kept available for modal/overlay layers only. */
+  --shadow-modal: 0 12px 32px rgb(0 0 0 / 0.18), 0 4px 8px rgb(0 0 0 / 0.06);
 
   /* ---------- Motion ---------- */
   --motion-fast:   120ms;
@@ -105,7 +103,7 @@
   --easing-spring: cubic-bezier(0.18, 0.89, 0.32, 1.28);
 
   /* ---------- Component sizing ---------- */
-  --touch-min: 44px;       /* WCAG 2.5.5 + iOS HIG */
+  --touch-min: 44px;
   --tap-pad:   var(--space-3);
   --hairline:  1px;
 
@@ -117,78 +115,52 @@
   --z-toast:   2000;
 }
 
-/* ---------- Color: dark theme ---------- */
-[data-theme="dark"] {
-  --color-bg:           #0e0e10;
-  --color-surface:      #17171a;
-  --color-surface-2:    #1f1f23;
-  --color-border:       #2a2a30;
-  --color-border-strong:#41414a;
+/* ---------- Dark theme — warm-black + lighter forest ----------------------- */
+[data-theme="dark"], body.dark {
+  --color-bg:           #0d0c0a;
+  --color-surface:      #15140f;
+  --color-surface-2:    #1d1c17;
+  --color-border:       #2a2823;
+  --color-border-strong:#4a4740;
 
-  --color-fg:           #f1f0eb;
-  --color-fg-muted:     #b6b5ad;
-  --color-fg-subtle:    #7c7b73;
+  --color-fg:           #ece8de;
+  --color-fg-muted:     #a8a39a;
+  --color-fg-subtle:    #6e6a62;
 
-  --color-accent:       #9b8aff;
-  --color-accent-fg:    #1a1916;
-  --color-accent-soft:  #2a2240;
+  --color-accent:       #7eb89a;
+  --color-accent-fg:    #0d0c0a;
+  --color-accent-soft:  #1f3128;
 
-  --color-success:      #5fbf6e;
-  --color-warn:         #e8b25e;
-  --color-danger:       #e87770;
-  --color-info:         #6fb6e0;
+  --color-success:      #7eb89a;
+  --color-warn:         #d29651;
+  --color-danger:       #d8746f;
+  --color-info:         #7da0c4;
 }
 
-/* Auto-prefers-dark fallback if app didn't set [data-theme] yet */
 @media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) {
-    --color-bg:           #0e0e10;
-    --color-surface:      #17171a;
-    --color-surface-2:    #1f1f23;
-    --color-border:       #2a2a30;
-    --color-border-strong:#41414a;
-    --color-fg:           #f1f0eb;
-    --color-fg-muted:     #b6b5ad;
-    --color-fg-subtle:    #7c7b73;
-    --color-accent:       #9b8aff;
-    --color-accent-fg:    #1a1916;
-    --color-accent-soft:  #2a2240;
-    --color-success:      #5fbf6e;
-    --color-warn:         #e8b25e;
-    --color-danger:       #e87770;
-    --color-info:         #6fb6e0;
+  :root:not([data-theme="light"]):not(body.light *) {
+    --color-bg:           #0d0c0a;
+    --color-surface:      #15140f;
+    --color-surface-2:    #1d1c17;
+    --color-border:       #2a2823;
+    --color-border-strong:#4a4740;
+    --color-fg:           #ece8de;
+    --color-fg-muted:     #a8a39a;
+    --color-fg-subtle:    #6e6a62;
+    --color-accent:       #7eb89a;
+    --color-accent-fg:    #0d0c0a;
+    --color-accent-soft:  #1f3128;
+    --color-success:      #7eb89a;
+    --color-warn:         #d29651;
+    --color-danger:       #d8746f;
+    --color-info:         #7da0c4;
   }
 }
 
-/* ---------- Reduced motion ---------- */
 @media (prefers-reduced-motion: reduce) {
   :root {
     --motion-fast: 0ms;
     --motion-base: 0ms;
     --motion-slow: 0ms;
   }
-}
-
-/* ---------- Common base utilities (opt-in via class) ---------- */
-.t-display { font-family: var(--font-display); font-weight: var(--weight-bold); line-height: var(--leading-tight); }
-.t-body    { font-family: var(--font-body); font-weight: var(--weight-regular); line-height: var(--leading-body); }
-.t-mono    { font-family: var(--font-mono); }
-
-.surface   { background: var(--color-surface); color: var(--color-fg); border: var(--hairline) solid var(--color-border); border-radius: var(--radius-lg); }
-.surface-2 { background: var(--color-surface-2); color: var(--color-fg); border-radius: var(--radius-md); }
-
-.heat-cell { display: inline-block; width: 64px; height: 64px; border-radius: var(--radius-sm); transition: transform var(--motion-fast) var(--easing-out); }
-.heat-cell:hover { transform: scale(1.06); }
-.heat-0 { background: var(--heat-0); }
-.heat-1 { background: var(--heat-1); }
-.heat-2 { background: var(--heat-2); }
-.heat-3 { background: var(--heat-3); }
-.heat-4 { background: var(--heat-4); }
-.heat-na{ background: var(--heat-na); }
-
-/* Hebrew/RTL hygiene — applies wherever class is set; doesn't force */
-.heb {
-  font-family: var(--font-body);
-  unicode-bidi: plaintext;
-  text-align: start;
 }

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -14,6 +14,7 @@
 <link rel="manifest" href="manifest.json">
 <title>Shlav A Mega — Board Prep</title>
 <link rel="stylesheet" href="shared/tokens.css">
+<link rel="stylesheet" href="shared/layout-primitives.css">
 <style>
 /* ──── SZMC Clinical Kit v1 (injected) ──── */
 /* SZMC Clinical Kit — semantic tokens + per-app skin. Additive layer; does
@@ -57,6 +58,22 @@
   src:url("fonts/inter-latin-600-normal.woff2") format("woff2");}
 @font-face{font-family:"Inter";font-style:normal;font-weight:700;font-display:swap;
   src:url("fonts/inter-latin-700-normal.woff2") format("woff2");}
+
+/* ── Editorial Clinical 2026-04: Frank Ruhl Libre (display, Hebrew + Latin)
+ * Loaded from Google Fonts CDN (no local woff2 yet — fall back to Heebo+Georgia
+ * via --font-display until cached). font-display:swap prevents FOIT. ── */
+@font-face{font-family:"Frank Ruhl Libre";font-style:normal;font-weight:500;font-display:swap;
+  src:url("https://fonts.gstatic.com/s/frankruhllibre/v22/j8_96_fAw7jrcalD7oKYNX0QfAnP.woff2") format("woff2");
+  unicode-range:U+0590-05FF,U+FB1D-FB4F;}
+@font-face{font-family:"Frank Ruhl Libre";font-style:normal;font-weight:700;font-display:swap;
+  src:url("https://fonts.gstatic.com/s/frankruhllibre/v22/j8_q6_fAw7jrcalD7oKYNX0Q-zT_BX0H1A.woff2") format("woff2");
+  unicode-range:U+0590-05FF,U+FB1D-FB4F;}
+@font-face{font-family:"Frank Ruhl Libre";font-style:normal;font-weight:500;font-display:swap;
+  src:url("https://fonts.gstatic.com/s/frankruhllibre/v22/j8_96_fAw7jrcalD7oKYNX0QfAnP.woff2") format("woff2");
+  unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+2000-206F,U+2074,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;}
+@font-face{font-family:"Frank Ruhl Libre";font-style:normal;font-weight:700;font-display:swap;
+  src:url("https://fonts.gstatic.com/s/frankruhllibre/v22/j8_q6_fAw7jrcalD7oKYNX0Q-zT_BX0H1A.woff2") format("woff2");
+  unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+2000-206F,U+2074,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;}
 
 /* ── Semantic tokens (clinical — reserved, never decorative) ── */
 :root{
@@ -143,21 +160,37 @@ body.study [style*="background:#ede9fe"]{background:#2a1e0d!important;color:#e8d
 --blue-bg:239 246 255;--blue-brd:191 219 254;--blue-fg:30 64 175;
 --yellow-bg:255 251 235;--yellow-brd:253 230 138;--yellow-fg:146 64 14;
 --red-bg:254 242 242;--red-brd:254 202 202;--red-fg:153 27 27}
-body{font-family:'Heebo','Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif;background:rgb(var(--bg));color:rgb(var(--fg));-webkit-font-smoothing:antialiased;overflow-x:hidden;-webkit-text-size-adjust:100%;text-size-adjust:100%}
+body{font-family:var(--font-body);background:var(--color-bg);color:var(--color-fg);-webkit-font-smoothing:antialiased;overflow-x:hidden;-webkit-text-size-adjust:100%;text-size-adjust:100%;font-size:var(--text-md);line-height:var(--leading-body)}
+/* Body keeps the legacy --bg/--fg vars wired so non-migrated surfaces (cards
+ * with rgb(var(--card-bg)), pills, etc.) still render. The Editorial-Clinical
+ * top layer below that uses var(--color-*) is the new visible surface. */
 .heb{font-family:'Heebo',sans-serif;unicode-bidi:plaintext;text-align:start}
 button{cursor:pointer;border:none;background:none;font:inherit}
 input,textarea,select{font:inherit}
-.hdr{background:linear-gradient(135deg,#0f172a,#1e293b);color:#fff;padding:calc(10px + env(safe-area-inset-top)) 16px 10px;position:sticky;top:0;z-index:40}
-.hdr h1{font-size:16px;font-weight:700;letter-spacing:-.5px}
-.hdr p{font-size:10px;color:rgb(var(--fg2));margin-top:1px}
-.tabs{position:fixed;bottom:0;left:0;right:0;background:rgb(var(--card-bg));border-top:1px solid #e2e8f0;display:flex;z-index:50;box-shadow:0 -2px 10px rgba(0,0,0,.06);padding-bottom:max(4px,env(safe-area-inset-bottom));overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none}
+/* Editorial Clinical header — cream surface, hairline border, display headline.
+ * Replaces the dark-gradient bar that read as "lazy" against the new baseline. */
+.hdr{background:var(--color-bg);color:var(--color-fg);padding:calc(var(--space-4) + env(safe-area-inset-top)) var(--space-4) var(--space-4);position:sticky;top:0;z-index:40;border-block-end:1px solid var(--color-border)}
+.hdr h1{font-family:var(--font-display);font-size:var(--text-xl);font-weight:var(--weight-bold);letter-spacing:-.01em;line-height:var(--leading-tight);color:var(--color-fg)}
+.hdr p{font-family:var(--font-mono);font-size:var(--text-xs);color:var(--color-fg-muted);margin-top:var(--space-1);letter-spacing:.04em}
+.hdr #headerVer{font-family:var(--font-mono)!important;letter-spacing:.04em;color:var(--color-fg-muted)!important}
+.hdr .dm-btn{color:var(--color-fg-muted);background:transparent}
+.hdr .dm-btn:hover{color:var(--color-fg);background:var(--color-surface-2)}
+/* Editorial Clinical underline tabs — sliding indicator, no pills, no shadows.
+ * Bottom-fixed for the mobile PWA shell; top border serves as the rail the
+ * indicator rides. RTL handled via getBoundingClientRect math (browser-native). */
+.tabs{position:fixed;bottom:0;left:0;right:0;background:var(--color-bg);border-top:1px solid var(--color-border);display:flex;z-index:50;padding-bottom:max(4px,env(safe-area-inset-bottom));overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;gap:0}
 .tabs::-webkit-scrollbar{display:none}
-.tabs button{flex:0 0 auto;min-width:52px;display:flex;flex-direction:column;align-items:center;gap:2px;padding:8px 6px 6px;transition:.15s;font-size:10px;font-weight:600}
-.tabs button.on{color:var(--app-primary)}
-.tabs button:not(.on){color:rgb(var(--fg3))}
-.tabs .ic{font-size:18px}
+.tabs button{flex:1 1 0;min-width:52px;min-height:var(--touch-min);display:flex;flex-direction:column;align-items:center;gap:2px;padding:var(--space-2) var(--space-2) var(--space-2);background:transparent;border:0;font-family:var(--font-body);font-size:var(--text-xs);font-weight:var(--weight-medium);letter-spacing:.02em;color:var(--color-fg-muted);transition:color var(--motion-fast) var(--easing-out);cursor:pointer;white-space:nowrap}
+.tabs button:hover{color:var(--color-fg)}
+.tabs button.on{color:var(--color-fg);font-weight:var(--weight-bold)}
+.tabs button:focus-visible{outline:2px solid var(--color-accent);outline-offset:-2px}
+.tabs .ic{font-size:18px;color:inherit}
+.tab-indicator{position:absolute;top:0;left:0;height:2px;background:var(--color-accent);transform:translateX(0);transition:transform var(--motion-base) var(--easing-out),width var(--motion-base) var(--easing-out);pointer-events:none;z-index:1}
 .ct{max-width:640px;margin:0 auto;padding:12px 12px 80px}
-.card{background:rgb(var(--card-bg));border-radius:16px;border:1px solid rgb(var(--brd));box-shadow:0 1px 3px rgba(0,0,0,.04);overflow:hidden;margin-bottom:10px}
+/* Editorial Clinical card — hairline border, no shadow, 8px radius.
+ * Cards float by surface contrast (cream bg vs white card), not shadow theatrics. */
+.card{background:var(--color-surface);color:var(--color-fg);border-radius:var(--radius-md);border:1px solid var(--color-border);overflow:hidden;margin-bottom:var(--space-3);transition:border-color var(--motion-fast) var(--easing-out)}
+.card:hover{border-color:var(--color-border-strong)}
 .pill{display:inline-block;padding:5px 12px;border-radius:20px;font-size:11px;font-weight:600;transition:.15s;cursor:pointer}
 .pill.on{background:var(--app-primary);color:var(--app-on-primary);box-shadow:0 2px 6px rgba(59,130,246,.25)}
 .pill:not(.on){background:rgb(var(--card-bg));color:rgb(var(--fg2));border:1px solid rgb(var(--brd))}
@@ -167,12 +200,20 @@ input,textarea,select{font:inherit}
 .qo.ok{border-color:rgb(var(--em));background:#ecfdf5;color:rgb(var(--green-fg))}
 .qo.no{border-color:rgb(var(--red));background:rgb(var(--red-bg));color:rgb(var(--red-fg))}
 .qo.dim{border-color:#f1f5f9;color:#cbd5e1}
-.btn{padding:7px 18px;border-radius:12px;font-size:12px;font-weight:700;transition:.15s;display:inline-block}
-.btn:disabled{opacity:.35}
-.btn-p{background:var(--app-primary);color:var(--app-on-primary)}
-.btn-d{background:rgb(var(--sl8));color:#fff}
-.btn-g{background:rgb(var(--em));color:#fff}
-.btn-o{background:rgb(var(--bg2));color:rgb(var(--fg2))}
+/* Editorial Clinical buttons — three tiers (primary/secondary/ghost).
+ * Legacy class names retained (.btn-p/.btn-d/.btn-g/.btn-o) so existing call
+ * sites keep working unchanged; new look applied via these selectors. */
+.btn{padding:var(--space-2) var(--space-5);border-radius:var(--radius-md);font-family:var(--font-body);font-size:var(--text-sm);font-weight:var(--weight-medium);letter-spacing:.02em;border:1px solid transparent;transition:background-color var(--motion-fast) var(--easing-out),border-color var(--motion-fast) var(--easing-out),color var(--motion-fast) var(--easing-out);display:inline-flex;align-items:center;justify-content:center;gap:var(--space-2);min-height:var(--touch-min);cursor:pointer}
+.btn:focus-visible{outline:2px solid var(--color-accent);outline-offset:2px}
+.btn:disabled{opacity:.5;cursor:not-allowed}
+.btn-p{background:var(--color-accent);color:var(--color-accent-fg);border-color:var(--color-accent)}
+.btn-p:hover:not(:disabled){filter:brightness(.92)}
+.btn-d{background:transparent;color:var(--color-fg);border-color:var(--color-border)}
+.btn-d:hover:not(:disabled){border-color:var(--color-border-strong)}
+.btn-g{background:var(--color-accent);color:var(--color-accent-fg);border-color:var(--color-accent)}
+.btn-g:hover:not(:disabled){filter:brightness(.92)}
+.btn-o{background:transparent;color:var(--color-fg-muted);border-color:transparent}
+.btn-o:hover:not(:disabled){color:var(--color-fg)}
 .ab{max-height:0;overflow:hidden;transition:max-height .3s ease}.ab.op{max-height:5000px}
 .acc-h{width:100%;padding:12px 14px;display:flex;justify-content:space-between;align-items:center;text-align:left;transition:.1s}
 .acc-h:hover{background:rgb(var(--bg2))}
@@ -1403,10 +1444,25 @@ const _svgIcons={
 };
 document.getElementById('tb').innerHTML=TABS.map(t=>
 // safe-innerhtml: TABS is a hardcoded array of tab definitions (id/label/icon); _svgIcons is a hardcoded map; no user input
-`<button class="${t.id===tab?'on':''}" onclick="go('${t.id}')" aria-label="${t.l}" style="transition:all .15s ease"><span class="ic">${_svgIcons[t.id]||t.ic}</span>${t.l}</button>`
-).join('');
+`<button class="${t.id===tab?'on':''}" role="tab" aria-selected="${t.id===tab}" onclick="go('${t.id}')" aria-label="${t.l}" style="transition:all .15s ease"><span class="ic">${_svgIcons[t.id]||t.ic}</span>${t.l}</button>`
+).join('')+'<span class="tab-indicator" aria-hidden="true"></span>';
+// v10.53: Editorial-Clinical underline indicator — slides to active tab.
+// RTL-safe: getBoundingClientRect() returns layout coords the browser already
+// adjusted for direction, so the math works for both LTR/RTL with no branching.
+requestAnimationFrame(updateTabIndicator);
 }
-function go(t){tab=t;renderTabs();render()}
+function updateTabIndicator(){
+  const tb=document.getElementById('tb');if(!tb)return;
+  const ind=tb.querySelector('.tab-indicator');if(!ind)return;
+  const active=tb.querySelector('button.on');if(!active){ind.style.opacity='0';return;}
+  const pr=tb.getBoundingClientRect();const ar=active.getBoundingClientRect();
+  const x=ar.left-pr.left+tb.scrollLeft;
+  ind.style.opacity='1';
+  ind.style.width=ar.width+'px';
+  ind.style.transform='translateX('+x+'px)';
+}
+window.addEventListener('resize',()=>{requestAnimationFrame(updateTabIndicator);});
+function go(t){tab=t;renderTabs();render();requestAnimationFrame(updateTabIndicator);}
 
 // ===== QUIZ ENGINE =====
 let qi=0,sel=null,ans=false,pool=[],filt='all',topicFilt=-1,examMode=false,examTimer=null,examSec=0;
@@ -6507,7 +6563,7 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.52.0';
+const APP_VERSION='10.53.0';
 const CHANGELOG={
 '10.50.0':[
 '💾 Backup is now one tap away — clicking the "🟢 Synced" pill in the top-left used to show a static toast pointing to a stale "Track → Backup to Cloud" location (the Backup card moved to Settings in v10.48.0; the toast was lying). It is now a proper bottom-sheet modal with three actions: 💾 Backup now (one-tap call to cloudBackup), ☁️ Restore from cloud (cloudRestore), and a "Manage all data →" link that deep-links to More → Settings and scrolls smoothly to the Data Management section. Offline state disables the Backup/Restore buttons and shows a clear hint instead of silently failing.',

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -9,7 +9,7 @@
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="mobile-web-app-capable" content="yes">
 <meta name="theme-color" content="#0f172a">
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: blob: https://*.supabase.co https://ima-contentfiles.s3.amazonaws.com https://ima-files.s3.amazonaws.com; connect-src 'self' https://*.supabase.co https://api.anthropic.com https://toranot.netlify.app; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self';">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://*.supabase.co https://ima-contentfiles.s3.amazonaws.com https://ima-files.s3.amazonaws.com; connect-src 'self' https://*.supabase.co https://api.anthropic.com https://toranot.netlify.app; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self';">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🩺</text></svg>">
 <link rel="manifest" href="manifest.json">
 <title>Shlav A Mega — Board Prep</title>

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-const CACHE='shlav-a-v10.52.0';
-const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
+const CACHE='shlav-a-v10.53.0';
+const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/layout-primitives.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 const FONT_URLS=['fonts/heebo-hebrew-400-normal.woff2','fonts/heebo-hebrew-500-normal.woff2','fonts/heebo-hebrew-600-normal.woff2','fonts/heebo-hebrew-700-normal.woff2','fonts/heebo-latin-400-normal.woff2','fonts/heebo-latin-500-normal.woff2','fonts/heebo-latin-600-normal.woff2','fonts/heebo-latin-700-normal.woff2','fonts/inter-latin-400-normal.woff2','fonts/inter-latin-500-normal.woff2','fonts/inter-latin-600-normal.woff2','fonts/inter-latin-700-normal.woff2'];
 const JSON_DATA_URLS=['data/questions.json','data/topics.json','data/notes.json','data/drugs.json','data/flashcards.json','harrison_chapters.json','data/hazzard_chapters.json','data/grs8_chapters.json','data/grs8_question_pages.json','data/tabs.json','data/question_chapters.json','data/distractors.json','data/regulatory.json','data/syllabus_data.json'];
 const ALL_URLS=[...HTML_URLS,...JSON_DATA_URLS,...FONT_URLS];

--- a/tests/visualOverhaul2026.test.js
+++ b/tests/visualOverhaul2026.test.js
@@ -1,7 +1,7 @@
 /**
- * v10.52.0 visual overhaul guards.
+ * v10.53.0 visual overhaul guards.
  *
- * Three features shipped in v10.52.0 — this file pins the wiring so future
+ * Three features shipped in v10.53.0 — this file pins the wiring so future
  * refactors don't silently rip them out:
  *
  *   1. Topic Heatmap (Track view): a single SVG-styled grid of all 46 TOPICS
@@ -24,7 +24,7 @@ import { resolve } from 'path';
 const rootDir = resolve(import.meta.dirname, '..');
 const html = readFileSync(resolve(rootDir, 'shlav-a-mega.html'), 'utf-8');
 
-describe('v10.52.0 — Topic Heatmap', () => {
+describe('v10.53.0 — Topic Heatmap', () => {
   it('renderTopicHeatmap function is defined', () => {
     expect(html).toMatch(/function\s+renderTopicHeatmap\s*\(/);
   });
@@ -57,7 +57,7 @@ describe('v10.52.0 — Topic Heatmap', () => {
   });
 });
 
-describe('v10.52.0 — Wrong-answer review mode', () => {
+describe('v10.53.0 — Wrong-answer review mode', () => {
   it('S.wrongQs is initialised at boot', () => {
     expect(html).toMatch(/S\.wrongQs\s*=\s*\{\}/);
   });
@@ -94,7 +94,7 @@ describe('v10.52.0 — Wrong-answer review mode', () => {
   });
 });
 
-describe('v10.52.0 — Source-link in explanations', () => {
+describe('v10.53.0 — Source-link in explanations', () => {
   it('parseQuestionRef helper is defined', () => {
     expect(html).toMatch(/function\s+parseQuestionRef\s*\(/);
   });
@@ -145,16 +145,16 @@ describe('v10.52.0 — Source-link in explanations', () => {
   });
 });
 
-describe('v10.52.0 — version trinity', () => {
-  it('shlav-a-mega.html APP_VERSION is 10.52.0', () => {
-    expect(html).toMatch(/APP_VERSION\s*=\s*['"]10\.52\.0['"]/);
+describe('v10.53.0 — version trinity', () => {
+  it('shlav-a-mega.html APP_VERSION is 10.53.0', () => {
+    expect(html).toMatch(/APP_VERSION\s*=\s*['"]10\.53\.0['"]/);
   });
-  it('sw.js CACHE key is shlav-a-v10.52.0', () => {
+  it('sw.js CACHE key is shlav-a-v10.53.0', () => {
     const sw = readFileSync(resolve(rootDir, 'sw.js'), 'utf-8');
-    expect(sw).toMatch(/CACHE\s*=\s*['"]shlav-a-v10\.52\.0['"]/);
+    expect(sw).toMatch(/CACHE\s*=\s*['"]shlav-a-v10\.53\.0['"]/);
   });
-  it('package.json version is 10.52.0', () => {
+  it('package.json version is 10.53.0', () => {
     const pkg = JSON.parse(readFileSync(resolve(rootDir, 'package.json'), 'utf-8'));
-    expect(pkg.version).toBe('10.52.0');
+    expect(pkg.version).toBe('10.53.0');
   });
 });


### PR DESCRIPTION
## Summary

Migrates Shlav A Mega's most-visible surfaces to the **Editorial Clinical** aesthetic (warm cream + forest green, Frank Ruhl Libre + Heebo, hairline cards, underline tabs, no shadows). Re-skin only — zero JS refactor, zero named functions removed (one added: \`updateTabIndicator\`), all **883 tests still pass**.

Closes the gap left by the v1 tokens.css landing (which was a no-op — file copied + linked but no consumer in the app).

### Surfaces shipped (all 5 priority items)

- **(a) Body baseline** — \`body\` rule now consumes \`var(--color-bg / --color-fg / --font-body)\` from the v2 tokens. Frank Ruhl Libre loaded via Google Fonts CDN with the Heebo-style unicode-range split (Hebrew + Latin), \`font-display: swap\`. CSP \`font-src\` extended to allow \`fonts.gstatic.com\`.
- **(b) Page header** — \`.hdr\` repainted: cream surface, hairline border, display headline in Frank Ruhl Libre, version chip in mono. Class kept so existing tests (auditPhases) still locate the data-action delegated buttons.
- **(c) Tab bar** — pill-shaped \`.on\` indicator replaced with sliding 2px underline (\`--color-accent\`). Single \`.tab-indicator\` \`<span>\` + \`updateTabIndicator()\` recomputes \`width\` / \`translateX\` from \`getBoundingClientRect()\` (RTL-safe via browser-native coords). Wired into \`go()\` and \`window\` resize.
- **(d) Cards** — \`.card\` loses \`box-shadow\`, drops to 8px radius, hairline becomes \`--color-border\`. Hover transitions to \`--color-border-strong\` (no shadow). Floats by surface contrast.
- **(e) Buttons** — \`.btn-p\` repainted to forest-green accent fill. \`.btn-d\` becomes hairline secondary; \`.btn-o\` becomes text-only ghost. Legacy class names preserved → existing call sites unchanged.

### Foundation

- \`shared/tokens.css\` overwritten with opinionated v2 from \`.shared/\` (warm-cream + forest-green, fluid type scale, motion + spacing rhythm).
- \`shared/layout-primitives.css\` added (byte-identical to \`.shared/\`) and linked AFTER tokens.css.
- \`sw.js\` pre-cache list extended to include \`shared/layout-primitives.css\`.

### Deferred (intentional)

- SZMC Clinical Kit's \`--sem-*\` / \`--app-*\` token layer left untouched — coexists as legacy layer for non-migrated surfaces (calc results, decision trees, leaderboard rows). Out of scope per brief.
- Bottom-fixed mobile-PWA tab position retained (top-tabs would break one-handed mobile UX); only the visual treatment changed.
- Self-hosted Frank Ruhl Libre WOFF2 — currently CDN-loaded; replacing with local fonts is a follow-up.

### Version trinity

\`10.52.0\` → \`10.53.0\` (APP_VERSION + sw.js CACHE + package.json + visualOverhaul2026.test.js pin).

## Test plan

- [x] \`npm test\` — 883/883 pass (unchanged from baseline; visualOverhaul2026 version pin updated to 10.53.0)
- [x] \`python scripts/check-version-sync.py\` — OK, all aligned at v10.53.0
- [x] \`python scripts/check-brace-balance.py\` — OK (3287 pairs)
- [x] Integrity-guard rule: 0 named functions removed, 1 added (\`updateTabIndicator\`)
- [ ] Manual: open deploy preview on iPhone Safari (RTL Hebrew + Latin runs)
- [ ] Manual: confirm tab indicator slides on tap, snaps on resize
- [ ] Manual: dark mode + study (sepia) modes still legible against new palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)