### PR TITLE
v10.54.0: UI cleanup — Learn+Library merge, warm-cream tokens, exam trend rewrite

### DIFF
--- a/data/tabs.json
+++ b/data/tabs.json
@@ -1,27 +1,22 @@
 [
   {
     "id": "quiz",
-    "ic": "\ud83d\udcdd",
+    "ic": "📝",
     "l": "Quiz"
   },
   {
     "id": "learn",
-    "ic": "\ud83d\udcda",
-    "l": "Learn"
-  },
-  {
-    "id": "lib",
-    "ic": "\ud83d\udcd6",
-    "l": "Library"
+    "ic": "📚",
+    "l": "Study"
   },
   {
     "id": "track",
-    "ic": "\ud83d\udcca",
+    "ic": "📊",
     "l": "Track"
   },
   {
     "id": "more",
-    "ic": "\u2699\ufe0f",
+    "ic": "⚙️",
     "l": "More"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.53.0",
+  "version": "10.54.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -153,13 +153,13 @@ body.study [style*="background:#ede9fe"]{background:#2a1e0d!important;color:#e8d
 
 /* ──── end Clinical Kit ──── */
 *{box-sizing:border-box;margin:0;padding:0}
-:root{--sky:59 130 246;--em:16 185 129;--sl8:30 41 59;--red:239 68 68;--amb:245 158 11;
---bg:248 250 252;--bg2:241 245 249;--bg3:255 255 255;--fg:30 41 59;--fg2:100 116 139;--fg3:148 163 184;
---brd:226 232 240;--card-bg:255 255 255;
---green-bg:240 253 244;--green-brd:187 247 208;--green-fg:22 101 52;
---blue-bg:239 246 255;--blue-brd:191 219 254;--blue-fg:30 64 175;
---yellow-bg:255 251 235;--yellow-brd:253 230 138;--yellow-fg:146 64 14;
---red-bg:254 242 242;--red-brd:254 202 202;--red-fg:153 27 27}
+:root{--sky:29 77 62;--em:29 77 62;--sl8:26 24 23;--red:168 50 50;--amb:156 107 24;
+--bg:250 247 242;--bg2:243 239 231;--bg3:255 255 255;--fg:26 24 23;--fg2:94 91 84;--fg3:138 132 120;
+--brd:224 217 205;--card-bg:255 255 255;
+--green-bg:223 233 227;--green-brd:182 207 191;--green-fg:29 77 62;
+--blue-bg:228 233 240;--blue-brd:185 198 217;--blue-fg:58 91 138;
+--yellow-bg:248 240 217;--yellow-brd:226 198 138;--yellow-fg:117 81 24;
+--red-bg:245 224 224;--red-brd:225 184 184;--red-fg:142 42 42}
 body{font-family:var(--font-body);background:var(--color-bg);color:var(--color-fg);-webkit-font-smoothing:antialiased;overflow-x:hidden;-webkit-text-size-adjust:100%;text-size-adjust:100%;font-size:var(--text-md);line-height:var(--leading-body)}
 /* Body keeps the legacy --bg/--fg vars wired so non-migrated surfaces (cards
  * with rgb(var(--card-bg)), pills, etc.) still render. The Editorial-Clinical
@@ -1426,6 +1426,7 @@ let TABS=[];
 
 let tab='quiz';
 let learnSub='study'; // sub-tab within Learn: study|flash|drugs
+let _studyMode='learn'; // v10.54.0: which mode is active in unified Study tab — 'learn'|'lib'
 let moreSub='calc';   // sub-tab within More: calc|search|chat|feedback
 let calcView='calc'; // sub-view within Calc: calc|basket|eol|lab|aging
 let libSec='haz-pdf';
@@ -4076,6 +4077,24 @@ h+=_rlExams();
 h+=_rlFooter();
 return h;
 }
+// v10.54.0: body-only variant used by merged Study tab — skips _rlHeader/_rlFooter
+// because the unified pill bar replaces the per-section sub-tab UI in _rlHeader.
+function renderLibraryBody(){
+if(libSec==='grs8'&&!_grsData&&!_grsLoading){
+_grsLoading=true;
+Promise.all([
+fetch('data/grs8_chapters.json').then(r=>r.json()),
+fetch('data/grs8_question_pages.json').then(r=>r.json()).catch(()=>({}))
+]).then(([ch,pages])=>{_grsData=ch;window._grsPages=pages;_grsLoading=false;render();}).catch(e=>{console.error('Failed to load GRS8 chapters',e);_grsData={};window._grsPages={};_grsLoading=false;render();});
+}
+let h=_rlHazzard();
+h+=_rlHarrison();
+h+=_rlGrs8();
+h+=_rlLaws();
+h+=_rlArticles();
+h+=_rlExams();
+return h;
+}
 
 
 
@@ -4752,35 +4771,51 @@ function renderExamTrendCard(){
     const delta=(newN/newTot - oldN/oldTot)*100;
     return{ti,name,oldN,newN,oldPct:oldN/oldTot*100,newPct:newN/newTot*100,delta};
   }).filter(r=>r.oldN+r.newN>0);
-  
-  const growing=trends.filter(r=>r.delta>0.5).sort((a,b)=>b.delta-a.delta).slice(0,6);
-  const shrinking=trends.filter(r=>r.delta<-0.5).sort((a,b)=>a.delta-b.delta).slice(0,4);
-  
-  let h=`<div class="card" style="padding:14px;margin-bottom:10px;border-left:4px solid #7c3aed">
-<div style="font-weight:700;font-size:12px;margin-bottom:4px;color:#7c3aed">📈 Exam Trend — 2020-23 vs 2024-25</div>
-<div style="font-size:9px;color:rgb(var(--fg3));margin-bottom:10px">Where the exam is heading. Study accordingly.</div>`;
-  
-  h+=`<div style="font-size:10px;font-weight:700;color:#059669;margin-bottom:5px">▲ GROWING — prioritize</div>`;
-  growing.forEach(r=>{
-    const barW=Math.min(100,Math.round(r.delta*15));
-    h+=`<div style="margin-bottom:5px">
-<div style="display:flex;justify-content:space-between;font-size:10px;margin-bottom:2px">
-  <span style="font-weight:${r.delta>1.5?'700':'400'}">${r.name}</span>
-  <span style="color:#059669">+${r.delta.toFixed(1)}pp · ${r.newPct.toFixed(1)}% of exam</span>
+
+  const growing=trends.filter(r=>r.delta>0.5).sort((a,b)=>b.delta-a.delta).slice(0,5);
+  const shrinking=trends.filter(r=>r.delta<-0.5).sort((a,b)=>a.delta-b.delta).slice(0,5);
+  const maxAbs=Math.max(1,...growing.map(r=>r.delta),...shrinking.map(r=>-r.delta));
+
+  let h=`<div class="card" style="padding:14px;margin-bottom:10px">
+<div style="display:flex;align-items:baseline;gap:8px;margin-bottom:2px">
+  <span style="font-weight:700;font-size:13px;color:var(--color-fg);font-family:var(--font-display)">Exam Trend</span>
+  <span style="font-size:10px;color:var(--color-fg-subtle);font-family:var(--font-mono);letter-spacing:.04em">2020–23 vs 2024–25</span>
 </div>
-<div style="height:4px;background:#e2e8f0;border-radius:2px"><div style="width:${barW}%;height:100%;background:#10b981;border-radius:2px"></div></div>
+<div style="font-size:10px;color:var(--color-fg-muted);margin-bottom:12px">Where the exam is heading. Study accordingly.</div>`;
+
+  // Two-column on wider, stacked on mobile
+  h+=`<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:14px">`;
+  // Growing column
+  h+=`<div><div style="font-size:10px;font-weight:700;color:var(--color-success);text-transform:uppercase;letter-spacing:.05em;margin-bottom:6px">▲ Growing</div>`;
+  if(growing.length===0)h+=`<div style="font-size:10px;color:var(--color-fg-subtle)">no significant growth</div>`;
+  growing.forEach(r=>{
+    const barW=Math.round(r.delta/maxAbs*100);
+    h+=`<div style="margin-bottom:6px">
+<div style="display:flex;justify-content:space-between;font-size:11px;margin-bottom:2px;gap:8px">
+  <span style="color:var(--color-fg);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1;min-width:0">${r.name}</span>
+  <span style="color:var(--color-success);font-variant-numeric:tabular-nums;flex-shrink:0">+${r.delta.toFixed(1)}pp</span>
+</div>
+<div style="height:3px;background:var(--color-surface-2);border-radius:2px"><div style="width:${barW}%;height:100%;background:var(--color-success);border-radius:2px"></div></div>
 </div>`;
   });
-  
-  h+=`<div style="font-size:10px;font-weight:700;color:#dc2626;margin-bottom:5px;margin-top:10px">▼ SHRINKING — less priority</div>`;
+  h+=`</div>`;
+  // Shrinking column
+  h+=`<div><div style="font-size:10px;font-weight:700;color:var(--color-danger);text-transform:uppercase;letter-spacing:.05em;margin-bottom:6px">▼ Shrinking</div>`;
+  if(shrinking.length===0)h+=`<div style="font-size:10px;color:var(--color-fg-subtle)">no significant decline</div>`;
   shrinking.forEach(r=>{
-    h+=`<div style="display:flex;justify-content:space-between;font-size:10px;margin-bottom:3px">
-<span style="color:rgb(var(--fg2))">${r.name}</span>
-<span style="color:#dc2626">${r.delta.toFixed(1)}pp</span>
+    const barW=Math.round(-r.delta/maxAbs*100);
+    h+=`<div style="margin-bottom:6px">
+<div style="display:flex;justify-content:space-between;font-size:11px;margin-bottom:2px;gap:8px">
+  <span style="color:var(--color-fg-muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1;min-width:0">${r.name}</span>
+  <span style="color:var(--color-danger);font-variant-numeric:tabular-nums;flex-shrink:0">${r.delta.toFixed(1)}pp</span>
+</div>
+<div style="height:3px;background:var(--color-surface-2);border-radius:2px"><div style="width:${barW}%;height:100%;background:var(--color-danger);border-radius:2px"></div></div>
 </div>`;
   });
-  
-  h+=`<div style="font-size:9px;color:rgb(var(--fg3));margin-top:8px;border-top:1px solid rgb(var(--brd));padding-top:6px">Old: 2020-2023 (${oldTot}q) · New: 2024-May, 2024-Sep, 2025-Jun (${newTot}q)</div>`;
+  h+=`</div>`;
+  h+=`</div>`;
+
+  h+=`<div style="font-size:9px;color:var(--color-fg-subtle);margin-top:10px;border-top:1px solid var(--color-border);padding-top:8px;font-family:var(--font-mono);letter-spacing:.04em">Old: ${oldTot}q (2020–2023) · New: ${newTot}q (2024-May, 2024-Sep, 2025-Jun)</div>`;
   h+=`</div>`;
   return h;
 }
@@ -5414,7 +5449,7 @@ h+=`</div>`;
 }
 }
 // Syllabus
-h+=`<div class="card" style="padding:14px"><div style="font-weight:700;font-size:12px;margin-bottom:10px">📋 Syllabus (${done}/40)</div>`;
+h+=`<div class="card" style="padding:14px"><div style="font-weight:700;font-size:12px;margin-bottom:10px">📋 Syllabus (${done}/${TOPICS.length})</div>`;
 // v10.50.0: removed "📊 Accuracy by Topic" list — it duplicated the 🗺️ Topic Mastery Map
 // already shown at the top of Track in _rtTop(). One topic-accuracy view is enough.
 const tSt=getTopicStats();
@@ -5443,7 +5478,7 @@ h+=`<div class="card" style="padding:14px;margin-bottom:10px">`;
 h+=`<div onclick="S._wsmOpen=!S._wsmOpen;save();render()" style="display:flex;align-items:center;gap:8px;cursor:pointer;font-weight:700;font-size:12px;${_wsmOpen?'margin-bottom:8px':''}" role="button" tabindex="0" aria-expanded="${_wsmOpen?'true':'false'}" aria-label="Toggle weak spots map"><span style="flex:1">🗺️ Weak Spots Map <span style="font-weight:400;color:rgb(var(--fg3));font-size:10px">· ${heatData.length} topic${heatData.length>1?'s':''} × ${years.length} exam${years.length>1?'s':''}</span></span><span style="color:rgb(var(--fg2))">${_wsmOpen?'▲':'▼'}</span></div>`;
 if(_wsmOpen){
 h+=`<div style="overflow-x:auto"><table style="width:100%;border-collapse:collapse;font-size:9px"><thead><tr><th style="text-align:right;padding:3px;font-size:8px">Topic</th>`;
-const _yearAbbr={'2020':'20','2021':'21','2021-Jun':"21·6",'2022':'22','2023-Jun':"23·6",'2023-Sep':"23·9",'2024-May':"24·5",'2024-Sep':"24·9",'2025-Jun':"25·6",'Hazzard':'Haz','Harrison':'Har','Exam':'Ex','Hazzard-suppl':'Sup'};
+const _yearAbbr={'2020':'20','2021':'21','2021-Jun':"21·6",'2022':'22','2023-Jun':"23·6",'2023-Sep':"23·9",'2024-May':"24·5",'2024-Sep':"24·9",'2025-Jun':"25·6",'Hazzard':'Haz','Harrison':'Har','Exam':'Ex','Hazzard-suppl':'Sup','FM-Core':'FM','GRS8':'GRS','Harrison-suppl':'HSup'};
 years.forEach(y=>{h+=`<th style="padding:3px;text-align:center;font-size:8px;white-space:nowrap;min-width:28px" title="${y}">${_yearAbbr[y]||y}</th>`;});
 h+=`</tr></thead><tbody>`;
 heatData.sort((a,b)=>{
@@ -5454,19 +5489,20 @@ return avgA-avgB;
 heatData.forEach(row=>{
 h+=`<tr><td style="padding:3px;text-align:right;white-space:nowrap;font-size:10px;min-width:80px;padding-right:6px">${row.topic}</td>`;
 row.cells.forEach(c=>{
-if(c.n===0){h+=`<td style="padding:2px;text-align:center;background:rgb(var(--bg2));color:#cbd5e1">·</td>`;}
-else if(c.n===1){h+=`<td style="padding:2px;text-align:center;background:rgb(var(--bg2));color:rgb(var(--fg3));font-size:8px" title="Only 1 attempt — too few for a meaningful score">${c.pct}%<br><span style="font-size:7px">1q</span></td>`;}
+if(c.n===0){h+=`<td style="padding:3px 2px;text-align:center;background:var(--color-surface-2);color:var(--color-fg-subtle)">·</td>`;}
+else if(c.n===1){h+=`<td style="padding:3px 2px;text-align:center;background:var(--color-surface-2);color:var(--color-fg-muted);font-size:8px" title="Only 1 attempt — too few for a meaningful score">${c.pct}%<br><span style="font-size:7px">1q</span></td>`;}
 else{
-const bg=c.pct>=75?'#dcfce7':c.pct>=50?'#fef9c3':'#fecaca';
-h+=`<td style="padding:2px;text-align:center;background:${bg};font-weight:600;border-radius:2px" title="${c.pct}% on ${c.n} attempts">${c.pct}%<br><span style="font-size:7px;opacity:0.7">${c.n}q</span></td>`;}
+const bg=c.pct>=75?'rgb(223 233 227)':c.pct>=50?'rgb(248 240 217)':'rgb(245 224 224)';
+const fg=c.pct>=75?'rgb(29 77 62)':c.pct>=50?'rgb(117 81 24)':'rgb(142 42 42)';
+h+=`<td style="padding:3px 2px;text-align:center;background:${bg};color:${fg};font-weight:600;border-radius:3px" title="${c.pct}% on ${c.n} attempts">${c.pct}%<br><span style="font-size:7px;opacity:0.7">${c.n}q</span></td>`;}
 });
 h+=`</tr>`;
 });
 h+=`</tbody></table></div>`;
 h+=`<div style="display:flex;gap:8px;margin-top:6px;font-size:8px;color:rgb(var(--fg3));justify-content:center">
-<span style="display:flex;align-items:center;gap:2px"><span style="width:10px;height:10px;background:#fecaca;border-radius:2px"></span>&lt;50%</span>
-<span style="display:flex;align-items:center;gap:2px"><span style="width:10px;height:10px;background:#fef9c3;border-radius:2px"></span>50-74%</span>
-<span style="display:flex;align-items:center;gap:2px"><span style="width:10px;height:10px;background:#dcfce7;border-radius:2px"></span>&ge;75%</span>
+<span style="display:flex;align-items:center;gap:2px"><span style="width:10px;height:10px;background:rgb(245 224 224);border-radius:2px"></span>&lt;50%</span>
+<span style="display:flex;align-items:center;gap:2px"><span style="width:10px;height:10px;background:rgb(248 240 217);border-radius:2px"></span>50-74%</span>
+<span style="display:flex;align-items:center;gap:2px"><span style="width:10px;height:10px;background:rgb(223 233 227);border-radius:2px"></span>&ge;75%</span>
 </div>`;
 }
 h+=`</div>`;}
@@ -5505,15 +5541,7 @@ return h;
 }
 function _rtFooter(){
 let h='';
-// IMA Links
-h+=`<div class="card" style="padding:14px"><div style="font-weight:700;font-size:12px;margin-bottom:8px">📥 IMA Exam Archive</div><div style="font-size:10px">`;
-[["2022","639899_34c9618e-ff88-4811-84d5-ba1fdd9d5f1c","639902_9a12e7aa-9876-40e1-bdea-0786dc417406"],
-["2023","639904_14aa53eb-d114-4ab8-8bfe-938b32d02fc0","639907_33601987-d23e-4f5f-8180-53890b2cfcb4"],
-["May 24","652285_f10c088f-c183-4f9c-8324-b37bedabe522","652288_5f94445c-1fe5-4207-bd42-e223be8064a0"],
-["Sep 24","652291_5946c97e-78c1-4920-81e3-1081d46fdb6e","652294_46e7d570-db16-4307-b4f1-66f002ed456e"],
-["Jun 25","749665_d23a3de1-a2af-4467-b2b0-71f297f6b800","766892_d886488d-27d3-487c-8088-56f67ae43409"],
-].forEach(([y,q,a])=>{h+=`<div style="display:flex;gap:8px;padding:3px 0"><b style="width:48px">${y}</b><a href="https://ima-files.s3.amazonaws.com/${q}.pdf" target="_blank" style="color:rgb(var(--sky));text-decoration:underline">שאלון</a><a href="https://ima-files.s3.amazonaws.com/${a}.pdf" target="_blank" style="color:rgb(var(--sky));text-decoration:underline">תשובות</a></div>`;});
-h+=`</div></div>`;
+// v10.54.0: IMA Exam Archive moved/deleted — duplicates Library → Exams. Use Study tab → 📝 Exams.
 // Reset
 // Share with friends
 h+=`<div class="card" style="padding:14px;text-align:center;margin-top:12px">
@@ -6405,19 +6433,43 @@ if(tab!==lastTab){el.classList.remove('fade-in');void el.offsetWidth;el.classLis
 switch(tab){
 case'quiz':el.innerHTML=onCallMode?renderOnCall():renderQuiz();break;
 case'learn':
-  {const _subBar='<div style="display:flex;gap:4px;margin-bottom:12px;padding:4px;background:rgb(var(--bg2));border-radius:12px">'+
-  [{id:'study',ic:'📚',l:'Study'},{id:'flash',ic:'🃏',l:'Cards'},{id:'drugs',ic:'💊',l:'Drugs'}].map(s=>
-    '<button onclick="learnSub=\''+s.id+'\';render()" style="flex:1;padding:8px 4px;border:none;border-radius:10px;font-size:11px;font-weight:'+(learnSub===s.id?'700':'400')+';cursor:pointer;background:'+(learnSub===s.id?'#fff':'transparent')+';color:'+(learnSub===s.id?'#0f172a':'#64748b')+';box-shadow:'+(learnSub===s.id?'0 1px 3px rgba(0,0,0,.1)':'none')+'">'+s.ic+' '+s.l+'</button>'
-  ).join('')+'</div>';
+  // v10.54.0: unified Study tab — merges old Learn (Notes/Cards/Drugs) + Library (Hazzard/Harrison/GRS8/Laws/Articles/Exams)
+  // into one horizontally-scrollable pill bar. _studyMode tracks which mode is current.
+  // Existing onclick handlers `tab='lib';libSec='haz-pdf'` still work via case 'lib' alias below.
+  {const _learnPills=[
+    {id:'study', mode:'learn', ic:'📝', l:'Notes'},
+    {id:'flash', mode:'learn', ic:'🃏', l:'Cards'},
+    {id:'drugs', mode:'learn', ic:'💊', l:'Drugs'},
+    {id:'haz-pdf',mode:'lib',  ic:'📕', l:'Hazzard'},
+    {id:'harrison',mode:'lib', ic:'📗', l:'Harrison'},
+    {id:'grs8',  mode:'lib',   ic:'📙', l:'GRS8'},
+    {id:'laws',  mode:'lib',   ic:'⚖️', l:'Laws'},
+    {id:'articles',mode:'lib', ic:'📄', l:'Articles'},
+    {id:'exams', mode:'lib',   ic:'📝', l:'Exams'}
+  ];
+  const _curId = _studyMode==='learn' ? learnSub : libSec;
+  let _subBar='<div style="display:flex;gap:6px;overflow-x:auto;padding:4px 0 6px;margin-bottom:12px;-webkit-overflow-scrolling:touch;scrollbar-width:none">';
+  _learnPills.forEach(p=>{
+    const _on = (p.id===_curId);
+    const _click = p.mode==='learn'
+      ? `_studyMode='learn';learnSub='${p.id}';render()`
+      : `_studyMode='lib';libSec='${p.id}';render()`;
+    _subBar += `<button onclick="${_click}" style="flex:0 0 auto;padding:7px 14px;border:1px solid ${_on?'var(--color-accent)':'var(--color-border)'};border-radius:999px;font-size:11px;font-weight:${_on?'700':'500'};cursor:pointer;background:${_on?'var(--color-accent)':'var(--color-surface)'};color:${_on?'var(--color-accent-fg)':'var(--color-fg-muted)'};white-space:nowrap;font-family:var(--font-body);transition:all var(--motion-fast) var(--easing-out)">${p.ic} ${p.l}</button>`;
+  });
+  _subBar += '</div>';
   let _body='';
-  if(learnSub==='study')_body=renderStudy();
-  else if(learnSub==='flash')_body=renderFlash();
-  else if(learnSub==='drugs')_body=renderDrugs();
-  el.innerHTML=_subBar+_body;}break; // safe-innerhtml: _subBar is static HTML; _body from internal render*() functions (no user input)
+  if(_studyMode==='lib'){
+    _body = renderLibraryBody(); // lib body without its own sub-bar
+  } else {
+    if(learnSub==='study')_body=renderStudy();
+    else if(learnSub==='flash')_body=renderFlash();
+    else if(learnSub==='drugs')_body=renderDrugs();
+  }
+  el.innerHTML=_subBar+_body;}break; // safe-innerhtml: _subBar is built from a hardcoded pill array (no user input)
 case'study':tab='learn';learnSub='study';el.innerHTML='';render();break;
 case'flash':tab='learn';learnSub='flash';el.innerHTML='';render();break;
 case'drugs':tab='learn';learnSub='drugs';el.innerHTML='';render();break;
-case'lib':el.innerHTML=renderLibrary();break;
+case'lib':_studyMode='lib';tab='learn';render();break; // v10.54.0: alias to merged Study tab
 case'calc':tab='more';moreSub='calc';el.innerHTML='';render();break;
 case'track':
   // Save session summary when switching to track tab
@@ -6563,7 +6615,7 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.53.0';
+const APP_VERSION='10.54.0';
 const CHANGELOG={
 '10.50.0':[
 '💾 Backup is now one tap away — clicking the "🟢 Synced" pill in the top-left used to show a static toast pointing to a stale "Track → Backup to Cloud" location (the Backup card moved to Settings in v10.48.0; the toast was lying). It is now a proper bottom-sheet modal with three actions: 💾 Backup now (one-tap call to cloudBackup), ☁️ Restore from cloud (cloudRestore), and a "Manage all data →" link that deep-links to More → Settings and scrolls smoothly to the Data Management section. Offline state disables the Backup/Restore buttons and shows a clear hint instead of silently failing.',

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.53.0';
+const CACHE='shlav-a-v10.54.0';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/layout-primitives.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 const FONT_URLS=['fonts/heebo-hebrew-400-normal.woff2','fonts/heebo-hebrew-500-normal.woff2','fonts/heebo-hebrew-600-normal.woff2','fonts/heebo-hebrew-700-normal.woff2','fonts/heebo-latin-400-normal.woff2','fonts/heebo-latin-500-normal.woff2','fonts/heebo-latin-600-normal.woff2','fonts/heebo-latin-700-normal.woff2','fonts/inter-latin-400-normal.woff2','fonts/inter-latin-500-normal.woff2','fonts/inter-latin-600-normal.woff2','fonts/inter-latin-700-normal.woff2'];
 const JSON_DATA_URLS=['data/questions.json','data/topics.json','data/notes.json','data/drugs.json','data/flashcards.json','harrison_chapters.json','data/hazzard_chapters.json','data/grs8_chapters.json','data/grs8_question_pages.json','data/tabs.json','data/question_chapters.json','data/distractors.json','data/regulatory.json','data/syllabus_data.json'];

--- a/tests/expandedDataIntegrity.test.js
+++ b/tests/expandedDataIntegrity.test.js
@@ -242,7 +242,7 @@ describe("flashcards.json — content quality", () => {
 
 describe("tabs.json — app navigation", () => {
   it("has the expected number of tabs", () => {
-    expect(tabs.length).toBeGreaterThanOrEqual(5);
+    expect(tabs.length).toBeGreaterThanOrEqual(4); // v10.54.0: merged Learn+Library into Study
   });
 
   it("every tab has id, icon (ic), and label (l)", () => {

--- a/tests/visualOverhaul2026.test.js
+++ b/tests/visualOverhaul2026.test.js
@@ -145,16 +145,16 @@ describe('v10.53.0 — Source-link in explanations', () => {
   });
 });
 
-describe('v10.53.0 — version trinity', () => {
-  it('shlav-a-mega.html APP_VERSION is 10.53.0', () => {
-    expect(html).toMatch(/APP_VERSION\s*=\s*['"]10\.53\.0['"]/);
+describe('version trinity', () => {
+  it('shlav-a-mega.html APP_VERSION is 10.54.0', () => {
+    expect(html).toMatch(/APP_VERSION\s*=\s*['"]10\.54\.0['"]/);
   });
-  it('sw.js CACHE key is shlav-a-v10.53.0', () => {
+  it('sw.js CACHE key is shlav-a-v10.54.0', () => {
     const sw = readFileSync(resolve(rootDir, 'sw.js'), 'utf-8');
-    expect(sw).toMatch(/CACHE\s*=\s*['"]shlav-a-v10\.53\.0['"]/);
+    expect(sw).toMatch(/CACHE\s*=\s*['"]shlav-a-v10\.54\.0['"]/);
   });
-  it('package.json version is 10.53.0', () => {
+  it('package.json version is 10.54.0', () => {
     const pkg = JSON.parse(readFileSync(resolve(rootDir, 'package.json'), 'utf-8'));
-    expect(pkg.version).toBe('10.53.0');
+    expect(pkg.version).toBe('10.54.0');
   });
 });


### PR DESCRIPTION
Surgical UI overhaul addressing user feedback:

## Tabs (5 → 4): Quiz · Study · Track · More
- Learn + Library merged into single Study tab with horizontally-scrollable pill bar (Notes / Cards / Drugs / Hazzard / Harrison / GRS8 / Laws / Articles / Exams)
- `_studyMode` state tracks which mode is active; `learnSub` + `libSec` preserved for back-compat (test locks)
- `case lib` becomes alias to learn tab

## Light mode
Legacy color tokens re-tinted to warm cream + forest accent palette matching `shared/tokens.css` editorial surface. Hundreds of inline `rgb(var(--bg2))` etc. now sit on cream instead of cool slate — no more floating white blocks on cream body.

## Track
- IMA Exam Archive removed (duplicates Library → Exams)
- Syllabus `X/40` hardcode → `X/${TOPICS.length}`
- `renderExamTrendCard()` rewritten: editorial typography, 2-col responsive grid, balanced 5+5 lists, design-token colors

## Exam Matrix (Weak Spots Map)
- `_yearAbbr` adds FM-Core, GRS8, Harrison-suppl
- Cell colors → warm cream-toned green/yellow/red matching editorial palette

## Tests
- Trinity locks bumped 10.53.0 → 10.54.0
- Tab-count test relaxed ≥5 → ≥4
- All 883 tests + verify chain green ✓