### PR TITLE
ci: drop deleted-in-v10.56.0 functions from Integrity Guard list

### DIFF
--- a/.github/workflows/integrity-guard.yml
+++ b/.github/workflows/integrity-guard.yml
@@ -94,9 +94,6 @@ jobs:
               'renderFeedback',
               # Geriatrics-specific tools
               'renderMedBasket',
-              'renderEOLTree',
-              'renderLabOverlay',
-              'renderAgingSheet',
               # Cloud + backup
               'cloudBackup',
               'cloudRestore',


### PR DESCRIPTION
renderEOLTree, renderLabOverlay, renderAgingSheet were hard-deleted in v10.56.0 (PR #104) but still listed in .github/workflows/integrity-guard.yml's critical-functions check. Drops the 3 lines.