### PR TITLE
chore(v10.57.1): drop unused calc{View,Vals,Up} state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.57.0",
+  "version": "10.57.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -1387,7 +1387,6 @@ let tab='quiz';
 let learnSub='study'; // sub-tab within Learn: study|flash|drugs
 let _studyMode='learn'; // v10.54.0: 'learn'|'lib' — which mode in unified Study tab
 let moreSub='calc';   // sub-tab within More: calc|search|chat|feedback
-let calcView='calc'; // sub-view within Calc: calc|basket|eol|lab|aging
 let libSec='haz-pdf';
 let harChOpen=null,_harData=null,_harLoading=false;
 let hazChOpen=null,_hazData=null,_hazLoading=false;
@@ -4278,8 +4277,6 @@ return h;
 }
 
 // ===== CALCULATORS =====
-let calcVals={};
-function calcUp(k,v){calcVals[k]=parseFloat(v)||0;render();}
 
 // ===== CALCULATOR HELPERS (_rc* prefix) =====
 function renderCalc(){
@@ -6093,7 +6090,7 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.57.0';
+const APP_VERSION='10.57.1';
 const CHANGELOG={
 '10.50.0':[
 '💾 Backup is now one tap away — clicking the "🟢 Synced" pill in the top-left used to show a static toast pointing to a stale "Track → Backup to Cloud" location (the Backup card moved to Settings in v10.48.0; the toast was lying). It is now a proper bottom-sheet modal with three actions: 💾 Backup now (one-tap call to cloudBackup), ☁️ Restore from cloud (cloudRestore), and a "Manage all data →" link that deep-links to More → Settings and scrolls smoothly to the Data Management section. Offline state disables the Backup/Restore buttons and shows a clear hint instead of silently failing.',

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.57.0';
+const CACHE='shlav-a-v10.57.1';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 const FONT_URLS=['fonts/heebo-hebrew-400-normal.woff2','fonts/heebo-hebrew-500-normal.woff2','fonts/heebo-hebrew-600-normal.woff2','fonts/heebo-hebrew-700-normal.woff2','fonts/heebo-latin-400-normal.woff2','fonts/heebo-latin-500-normal.woff2','fonts/heebo-latin-600-normal.woff2','fonts/heebo-latin-700-normal.woff2','fonts/inter-latin-400-normal.woff2','fonts/inter-latin-500-normal.woff2','fonts/inter-latin-600-normal.woff2','fonts/inter-latin-700-normal.woff2'];
 const JSON_DATA_URLS=['data/questions.json','data/topics.json','data/notes.json','data/drugs.json','data/flashcards.json','harrison_chapters.json','data/hazzard_chapters.json','data/grs8_chapters.json','data/grs8_question_pages.json','data/tabs.json','data/question_chapters.json','data/distractors.json','data/regulatory.json','data/syllabus_data.json'];

--- a/tests/migrationWiring.test.js
+++ b/tests/migrationWiring.test.js
@@ -184,7 +184,7 @@ function buildScopeHarness(helperBlock, targetName) {
     let onCallMode=false, flipRevealed=false;
     let timedMode=false, timedSec=90, timedInt=null, timedPaused=false;
     let _optShuffle=null, _sessionSaved=false, _sessionOk=0, _sessionNo=0;
-    let learnSub="study", moreSub="calc", calcView="calc", libSec="haz-pdf";
+    let learnSub="study", moreSub="calc", libSec="haz-pdf";
     let hazChOpen=null, _hazData=null, _hazLoading=false;
     let harChOpen=null, _harData=null, _harLoading=false;
     const S = new Proxy({sr:{}, dark:false, studyMode:false, streak:0}, __stubHandler);

--- a/tests/visualOverhaul2026.test.js
+++ b/tests/visualOverhaul2026.test.js
@@ -146,15 +146,15 @@ describe('v10.52.0 — Source-link in explanations', () => {
 });
 
 describe('v10.52.0 — version trinity', () => {
-  it('shlav-a-mega.html APP_VERSION is 10.57.0', () => {
-    expect(html).toMatch(/APP_VERSION\s*=\s*['"]10\.57\.0['"]/);
+  it('shlav-a-mega.html APP_VERSION is 10.57.1', () => {
+    expect(html).toMatch(/APP_VERSION\s*=\s*['"]10\.57\.1['"]/);
   });
-  it('sw.js CACHE key is shlav-a-v10.57.0', () => {
+  it('sw.js CACHE key is shlav-a-v10.57.1', () => {
     const sw = readFileSync(resolve(rootDir, 'sw.js'), 'utf-8');
-    expect(sw).toMatch(/CACHE\s*=\s*['"]shlav-a-v10\.57\.0['"]/);
+    expect(sw).toMatch(/CACHE\s*=\s*['"]shlav-a-v10\.57\.1['"]/);
   });
-  it('package.json version is 10.57.0', () => {
+  it('package.json version is 10.57.1', () => {
     const pkg = JSON.parse(readFileSync(resolve(rootDir, 'package.json'), 'utf-8'));
-    expect(pkg.version).toBe('10.57.0');
+    expect(pkg.version).toBe('10.57.1');
   });
 });


### PR DESCRIPTION
## Summary

After v10.56.0 deleted the calculator helpers, three state declarations were orphaned (declared but never read). This PR removes them and bumps the trinity to v10.57.1 (patch — no user-visible change).

## Identifiers removed

Confirmed via grep that each identifier had exactly one occurrence in `shlav-a-mega.html` (the declaration itself; no readers anywhere).

- `shlav-a-mega.html:1390` — `let calcView='calc';`
- `shlav-a-mega.html:4281` — `let calcVals={};`
- `shlav-a-mega.html:4282` — `function calcUp(k,v){calcVals[k]=parseFloat(v)||0;render();}`
- `tests/migrationWiring.test.js:187` — also dropped `calcView` from the proxy stub-globals scaffold so it mirrors production.

## Trinity bump (10.57.0 → 10.57.1)

- `package.json` `version`
- `shlav-a-mega.html` `APP_VERSION`
- `sw.js` `CACHE`
- `tests/visualOverhaul2026.test.js` version-trinity assertions

## Test plan

- [x] `python3 scripts/check-version-sync.py` — OK (v10.57.1 across all three)
- [x] `python3 scripts/check-brace-balance.py` — OK (3046 pairs)
- [x] `python3 scripts/check-innerhtml.py` — OK
- [x] `python3 scripts/check-innerhtml-pieces.py` — OK (11 sites, all annotated)
- [x] `HARRISON_HEBREW_BASELINE=0 node scripts/harrison-hebrew-baseline.cjs --strict` — OK
- [x] `vitest run` — 854/854 pass (39 files)
- [ ] Pages deploy picks up `shlav-a-v10.57.1` in `sw.js`