### PR TITLE
feat(v10.58.0): Track tab visual consolidation — collapsibles, empty-state hiding, layout tightening

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.57.1",
+  "version": "10.58.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -4991,11 +4991,9 @@ h+=`<div id="leaderboard-box" style="font-size:10px;color:rgb(var(--fg3));text-a
 h+=`</div>`;
 }
 
-// Feature 10: Cheat sheet export button
-h+=`<div class="card" style="padding:14px;margin-bottom:10px;text-align:center">
-<button class="btn btn-d" onclick="exportCheatSheet()" style="font-size:11px" aria-label="Export cheat sheet">📄 Export Weak Topics Cheat Sheet</button>
-<div style="font-size:9px;color:rgb(var(--fg3));margin-top:4px">Print-ready 2-page summary of your 15 weakest topics</div>
-</div>`;
+// Feature 10: Cheat sheet export — v10.58.0 demoted from full card to small text
+// link under the Priority Matrix in _rtProgress(). The standalone card was
+// disproportionate for a one-tap utility action.
 // v10.57.0: removed standalone Change exam date underline link — duplicates
 // More → Settings → Exam Date. setExamDate() is still wired everywhere it
 // was; the button just isn't surfaced from here.
@@ -5127,6 +5125,8 @@ ${_blindSpots>0?`<div style="margin-top:8px;font-size:10px;color:#dc2626;font-we
 }
 // ROI Matrix and Radar chart removed — accuracy bars above are sufficient
 h+=renderPriorityMatrix();
+// v10.58.0: Cheat-sheet export link, demoted from full card in _rtMid()
+h+=`<div style="text-align:center;margin:-4px 0 10px"><a href="#" onclick="event.preventDefault();exportCheatSheet()" style="font-size:10px;color:rgb(var(--sky));text-decoration:underline;cursor:pointer" aria-label="Export cheat sheet">📄 Export Weak Topics Cheat Sheet</a></div>`;
 
 TOPICS.forEach((t,i)=>{h+=`<div class="topic${S.ck[i]?' done':''}" onclick="S.ck[${i}]=!S.ck[${i}];save();render()" style="display:${S._sylOpen?'flex':'none'}" role="checkbox" aria-checked="${S.ck[i]?'true':'false'}" tabindex="0" aria-label="${t}">
 <input type="checkbox" ${S.ck[i]?'checked':''} readonly style="width:13px;height:13px" tabindex="-1"><span>${t}</span></div>`;});

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -6115,8 +6115,14 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.57.1';
+const APP_VERSION='10.58.0';
 const CHANGELOG={
+'10.58.0':[
+'🧹 Track tab visual consolidation — Activity Heatmap (last 30 days) and Leaderboard demoted to collapsibles (default closed) with status inline in the header. Both ate vertical space even when empty.',
+'🔗 "Export Weak Topics Cheat Sheet" demoted from full card to a small underline link directly under the Priority Matrix — that is where the action belongs.',
+'🧷 "Today\'s Session" merged into the "Today\'s Study Plan" card as an inline strip below the plan steps. No more two adjacent same-day cards.',
+'📐 No removed features. Bookmark/folder cards already empty-state-gated since v10.49.x; renderTopicHeatmap + renderPriorityMatrix call sites untouched.',
+],
 '10.50.0':[
 '💾 Backup is now one tap away — clicking the "🟢 Synced" pill in the top-left used to show a static toast pointing to a stale "Track → Backup to Cloud" location (the Backup card moved to Settings in v10.48.0; the toast was lying). It is now a proper bottom-sheet modal with three actions: 💾 Backup now (one-tap call to cloudBackup), ☁️ Restore from cloud (cloudRestore), and a "Manage all data →" link that deep-links to More → Settings and scrolls smoothly to the Data Management section. Offline state disables the Backup/Restore buttons and shows a clear hint instead of silently failing.',
 '🧹 Track tab redundancy purge — three sections cut or collapsed because they showed data already visible elsewhere on the same tab:',

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -4974,15 +4974,22 @@ _harDue.slice(0,5).forEach(c=>{
 h+=`</div>`;
 }
 
-// Feature 8: Leaderboard
-h+=`<div class="card" style="padding:14px;margin-bottom:10px">
-<div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
-<span style="font-size:14px">🏆</span>
-<div style="font-size:12px;font-weight:700;flex:1">Leaderboard</div>
-<button onclick="showLeaderboard()" style="font-size:9px;padding:4px 10px;background:#f59e0b;color:#fff;border:none;border-radius:6px;cursor:pointer">Refresh</button>
-</div>
-<div id="leaderboard-box" style="font-size:10px;color:rgb(var(--fg3));text-align:center">Tap refresh to load</div>
-</div>`;
+// Feature 8: Leaderboard — v10.58.0 collapsible (default closed). The card was
+// always showing the "Tap refresh to load" placeholder, eating space. Now header
+// shows readiness/answered inline; expanding reveals the full board + refresh.
+{
+const _lbOpen=S._lbOpen===true;
+const _lbReadiness=calcEstScore();
+const _lbAnswered=Object.values(S.sr||{}).reduce((a,s)=>a+(s.tot||0),0);
+const _lbInline=_lbReadiness!==null?`${_lbReadiness}% · ${_lbAnswered} answered`:'submit ≥20 answers to rank';
+h+=`<div class="card" style="padding:14px;margin-bottom:10px">`;
+h+=`<div onclick="S._lbOpen=!S._lbOpen;save();render()" style="display:flex;align-items:center;gap:8px;cursor:pointer;font-weight:700;font-size:12px;${_lbOpen?'margin-bottom:8px':''}" role="button" tabindex="0" aria-expanded="${_lbOpen?'true':'false'}" aria-label="Toggle leaderboard"><span style="font-size:14px">🏆</span><span style="flex:1">Leaderboard <span style="font-weight:400;color:rgb(var(--fg3));font-size:10px">· ${_lbInline}</span></span><span style="color:rgb(var(--fg2))">${_lbOpen?'▲':'▼'}</span></div>`;
+if(_lbOpen){
+h+=`<div style="display:flex;justify-content:flex-end;margin-bottom:8px"><button onclick="showLeaderboard()" style="font-size:9px;padding:4px 10px;background:#f59e0b;color:#fff;border:none;border-radius:6px;cursor:pointer">Refresh</button></div>`;
+h+=`<div id="leaderboard-box" style="font-size:10px;color:rgb(var(--fg3));text-align:center">Tap refresh to load</div>`;
+}
+h+=`</div>`;
+}
 
 // Feature 10: Cheat sheet export button
 h+=`<div class="card" style="padding:14px;margin-bottom:10px;text-align:center">

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -5128,9 +5128,15 @@ h+=`</div>`;
 // v10.57.0: Activity Calendar (30 days) — moved here from _rtTop where it
 // was buried under the action CTAs. This is a passive progress view, so it
 // belongs at the bottom of _rtProgress alongside the other history widgets.
-h+=`<div class="card" style="padding:14px;margin-bottom:10px">
-<div style="font-size:12px;font-weight:700;margin-bottom:8px">📊 Activity Heatmap (last 30 days)</div>
-<div style="display:grid;grid-template-columns:repeat(10,1fr);gap:3px">`;
+// v10.58.0: Demoted to collapsible (default closed). 30 squares of mostly-empty
+// cells eat screen height; power users can expand via S._actOpen toggle.
+{
+const _actOpen=S._actOpen===true;
+const _actDays=(function(){let n=0;for(let _i=29;_i>=0;_i--){const _d=new Date();_d.setDate(_d.getDate()-_i);const _dk=_d.toISOString().slice(0,10);const _act=S.dailyAct&&S.dailyAct[_dk];if(_act&&_act.q>0)n++;}return n;})();
+h+=`<div class="card" style="padding:14px;margin-bottom:10px">`;
+h+=`<div onclick="S._actOpen=!S._actOpen;save();render()" style="display:flex;align-items:center;gap:8px;cursor:pointer;font-weight:700;font-size:12px;${_actOpen?'margin-bottom:8px':''}" role="button" tabindex="0" aria-expanded="${_actOpen?'true':'false'}" aria-label="Toggle activity heatmap"><span style="flex:1">📊 Activity Heatmap (last 30 days) <span style="font-weight:400;color:rgb(var(--fg3));font-size:10px">· ${_actDays} active day${_actDays===1?'':'s'}</span></span><span style="color:rgb(var(--fg2))">${_actOpen?'▲':'▼'}</span></div>`;
+if(_actOpen){
+h+=`<div style="display:grid;grid-template-columns:repeat(10,1fr);gap:3px">`;
 for(let _i=29;_i>=0;_i--){
 const _d=new Date();_d.setDate(_d.getDate()-_i);
 const _dk=_d.toISOString().slice(0,10);
@@ -5140,7 +5146,10 @@ const _int=_qc===0?0:_qc<5?1:_qc<15?2:_qc<30?3:4;
 const _cols=[document.body.classList.contains('dark')||document.body.classList.contains('study')?'#1e293b':'#f1f5f9','#dcfce7','#86efac','#22c55e','#15803d'];
 h+=`<div style="aspect-ratio:1;border-radius:3px;background:${_cols[_int]}" title="${_dk}: ${_qc} Qs"></div>`;
 }
-h+=`</div></div>`;
+h+=`</div>`;
+}
+h+=`</div>`;
+}
 return h;
 }
 function _rtFooter(){

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -4472,8 +4472,37 @@ h+=`<div>3️⃣ Drill: <b>20q mini-exam on ${w.name}</b> <button onclick="start
 if(trapCount>0)h+=`<div>4️⃣ Review <b>${trapCount} trap questions</b> <button onclick="setFilt('traps');tab='quiz';render()" style="font-size:9px;padding:2px 8px;background:rgb(var(--yellow-bg));color:rgb(var(--yellow-fg));border:none;border-radius:6px;cursor:pointer">🪤 Start</button></div>`;
 // Step 4: Replay last mock wrong (if any)
 try{const _mh=JSON.parse(localStorage.getItem('samega_mock_hist')||'[]');const _last=_mh[_mh.length-1];const _wn=_last&&_last.wrongIdxs?_last.wrongIdxs.length:0;if(_wn>0){const _dt=new Date(_last.date).toLocaleDateString('en-GB',{day:'numeric',month:'short'});h+=`<div>5️⃣ Replay <b>${_wn} wrong answers</b> from mock on ${_dt} <button onclick="replayLastMockWrong()" style="font-size:9px;padding:2px 8px;background:#fee2e2;color:#dc2626;border:none;border-radius:6px;cursor:pointer">🔁 Start</button></div>`;}}catch(e){}
-h+=`</div></div>`;
+h+=`</div>`;
+// v10.58.0: append today's session stats inline below the plan steps,
+// inside the same card, instead of a separate "Today's Session" card.
+const _sessInline=renderSessionInline();
+if(_sessInline)h+=_sessInline;
+h+=`</div>`;
 return h;
+}
+// v10.58.0: inline session block — no outer card; rendered inside the daily
+// plan card to merge "Today's Study Plan" + "Today's Session" into one block.
+function renderSessionInline(){
+  try{
+    const hist=JSON.parse(localStorage.getItem('samega_sessions')||'[]');
+    if(!hist.length)return '';
+    const last=hist[hist.length-1];
+    const tot=last.ok+last.no;
+    const pct=tot?Math.round(last.ok/tot*100):0;
+    const mins=Math.round(last.dur/60);
+    const today=new Date().toDateString();
+    const sessDate=new Date(last.date).toDateString();
+    if(sessDate!==today)return '';
+    return `<div style="margin-top:10px;padding-top:10px;border-top:1px dashed rgb(var(--brd))">
+<div style="font-weight:700;font-size:11px;margin-bottom:6px;color:#7c3aed">📊 Today's Session</div>
+<div style="display:flex;gap:12px;margin-bottom:4px">
+  <div style="text-align:center"><div style="font-size:16px;font-weight:700;color:${pct>=70?'#059669':pct>=50?'#d97706':'#dc2626'}">${pct}%</div><div style="font-size:9px;color:rgb(var(--fg3))">${last.ok}/${tot} correct</div></div>
+  <div style="text-align:center"><div style="font-size:16px;font-weight:700">${mins}m</div><div style="font-size:9px;color:rgb(var(--fg3))">duration</div></div>
+  <div style="text-align:center"><div style="font-size:16px;font-weight:700;color:#f59e0b">${last.due}</div><div style="font-size:9px;color:rgb(var(--fg3))">due tomorrow</div></div>
+</div>
+${last.best?`<div style="font-size:10px">✅ Best: <b>${last.best.name}</b> (${last.best.n} correct)</div>`:''}
+</div>`;
+  }catch(e){return '';}
 }
 function setExamDate(){
 const d=prompt('Enter exam date (YYYY-MM-DD):',S.examDate||'');
@@ -4509,29 +4538,9 @@ doc+='</body></html>';
 const w=window.open('','_blank');w.document.write(doc);w.document.close();
 setTimeout(()=>w.print(),500);
 }
-function renderSessionCard(){
-  try{
-    const hist=JSON.parse(localStorage.getItem('samega_sessions')||'[]');
-    if(!hist.length)return '';
-    const last=hist[hist.length-1];
-    const tot=last.ok+last.no;
-    const pct=tot?Math.round(last.ok/tot*100):0;
-    const mins=Math.round(last.dur/60);
-    const today=new Date().toDateString();
-    const sessDate=new Date(last.date).toDateString();
-    if(sessDate!==today)return '';
-    return `<div class="card" style="padding:14px;margin-bottom:10px;border-left:4px solid #7c3aed">
-<div style="font-weight:700;font-size:12px;margin-bottom:6px;color:#7c3aed">📊 Today's Session</div>
-<div style="display:flex;gap:12px;margin-bottom:8px">
-  <div style="text-align:center"><div style="font-size:18px;font-weight:700;color:${pct>=70?'#059669':pct>=50?'#d97706':'#dc2626'}">${pct}%</div><div style="font-size:9px;color:rgb(var(--fg3))">${last.ok}/${tot} correct</div></div>
-  <div style="text-align:center"><div style="font-size:18px;font-weight:700">${mins}m</div><div style="font-size:9px;color:rgb(var(--fg3))">duration</div></div>
-  <div style="text-align:center"><div style="font-size:18px;font-weight:700;color:#f59e0b">${last.due}</div><div style="font-size:9px;color:rgb(var(--fg3))">due tomorrow</div></div>
-</div>
-${last.best?`<div style="font-size:10px;margin-bottom:2px">✅ Best: <b>${last.best.name}</b> (${last.best.n} correct)</div>`:''}
-<button onclick="this.parentElement.style.display='none'" style="margin-top:8px;font-size:9px;color:rgb(var(--fg3));background:none;border:none;cursor:pointer" aria-label="Dismiss notification">dismiss</button>
-</div>`;
-  }catch(e){return '';}
-}
+// v10.58.0: renderSessionCard merged into renderDailyPlan via renderSessionInline().
+// Kept as a stub returning '' so any external/cached references no-op cleanly.
+function renderSessionCard(){return '';}
 function calcEstScore(){
   // FSRS-aware estimated score: weight by retrievability for seen questions
   const now2=Date.now();

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.57.1';
+const CACHE='shlav-a-v10.58.0';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 const FONT_URLS=['fonts/heebo-hebrew-400-normal.woff2','fonts/heebo-hebrew-500-normal.woff2','fonts/heebo-hebrew-600-normal.woff2','fonts/heebo-hebrew-700-normal.woff2','fonts/heebo-latin-400-normal.woff2','fonts/heebo-latin-500-normal.woff2','fonts/heebo-latin-600-normal.woff2','fonts/heebo-latin-700-normal.woff2','fonts/inter-latin-400-normal.woff2','fonts/inter-latin-500-normal.woff2','fonts/inter-latin-600-normal.woff2','fonts/inter-latin-700-normal.woff2'];
 const JSON_DATA_URLS=['data/questions.json','data/topics.json','data/notes.json','data/drugs.json','data/flashcards.json','harrison_chapters.json','data/hazzard_chapters.json','data/grs8_chapters.json','data/grs8_question_pages.json','data/tabs.json','data/question_chapters.json','data/distractors.json','data/regulatory.json','data/syllabus_data.json'];

--- a/tests/visualOverhaul2026.test.js
+++ b/tests/visualOverhaul2026.test.js
@@ -146,15 +146,15 @@ describe('v10.52.0 — Source-link in explanations', () => {
 });
 
 describe('v10.52.0 — version trinity', () => {
-  it('shlav-a-mega.html APP_VERSION is 10.57.1', () => {
-    expect(html).toMatch(/APP_VERSION\s*=\s*['"]10\.57\.1['"]/);
+  it('shlav-a-mega.html APP_VERSION is 10.58.0', () => {
+    expect(html).toMatch(/APP_VERSION\s*=\s*['"]10\.58\.0['"]/);
   });
-  it('sw.js CACHE key is shlav-a-v10.57.1', () => {
+  it('sw.js CACHE key is shlav-a-v10.58.0', () => {
     const sw = readFileSync(resolve(rootDir, 'sw.js'), 'utf-8');
-    expect(sw).toMatch(/CACHE\s*=\s*['"]shlav-a-v10\.57\.1['"]/);
+    expect(sw).toMatch(/CACHE\s*=\s*['"]shlav-a-v10\.58\.0['"]/);
   });
-  it('package.json version is 10.57.1', () => {
+  it('package.json version is 10.58.0', () => {
     const pkg = JSON.parse(readFileSync(resolve(rootDir, 'package.json'), 'utf-8'));
-    expect(pkg.version).toBe('10.57.1');
+    expect(pkg.version).toBe('10.58.0');
   });
 });


### PR DESCRIPTION
## Summary
Consolidate the Track tab without removing any features — purely visual / structural cleanup. After v10.57.0 the page still had ~17 sections; this trims it.

## Sub-task outcomes
1. **Hide redundant headers when empty** — *skipped (already-shipped)*. Bookmark card was already gated by `if(bkCount>0)` and the folder card by `if(_topicKeys.length>1)` since the v10.49 decomposition. No change.
2. **Demote "Activity (last 30 days)" grid to collapsible** — *shipped*. Default closed; `S._actOpen` persists. Header shows `· N active days` inline.
3. **Demote Leaderboard to collapsible** — *shipped*. Default closed; `S._lbOpen` persists. Header shows `<est-score>% · <answered> answered` inline.
4. **Move "Export Weak Topics Cheat Sheet" into a small text link under Priority Matrix** — *shipped*. Was a full card in `_rtMid`; now a single 10px underline link directly below `renderPriorityMatrix()` in `_rtProgress`.
5. **Combine "Today's Study Plan" + "Today's Session" into one card** — *shipped*. New `renderSessionInline()` returns just the inner block (no outer card); appended inside the daily-plan card with a dashed top border. `renderSessionCard()` kept as a no-op stub for backward-compat.

## Guardrails
- `function renderTopicHeatmap()` and `function renderPriorityMatrix()` definitions intact, both still called from `_rtTop()` / `_rtProgress()`.
- All 854 vitest tests pass. The 3 trinity-version tests in `visualOverhaul2026.test.js` were updated from `10.57.1` → `10.58.0` (no semantic test gutted).
- `npm run verify` passes (brace balance, innerHTML sanitization, version sync, Harrison Hebrew baseline).

## Trinity bump
`package.json` 10.57.1 → 10.58.0, `APP_VERSION` 10.57.1 → 10.58.0, `sw.js` `CACHE` 10.57.1 → 10.58.0.

## Test plan
- [ ] Open `/Geriatrics/shlav-a-mega.html` and click the Track tab
- [ ] Confirm the Activity Heatmap shows as a collapsed `📊 Activity Heatmap (last 30 days) · N active days ▼` row
- [ ] Confirm the Leaderboard shows as a collapsed row with `est-score% · answered` inline
- [ ] Confirm "Today's Session" no longer renders as its own card; if a session was saved today, its stats appear inside the Today's Study Plan card with a dashed top border
- [ ] Confirm the Cheat Sheet card is gone from `_rtMid`; a small "📄 Export Weak Topics Cheat Sheet" link appears right under the Priority Matrix
- [ ] Confirm Topic Heatmap and Priority Matrix render unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)