### PR TITLE
v10.61.2 — fix takeWeeklySnapshot dropping topics 40-45

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.61.1",
+  "version": "10.61.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -6426,8 +6426,11 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.61.1';
+const APP_VERSION='10.61.2';
 const CHANGELOG={
+'10.61.2':[
+'🐛 תיקון — takeWeeklySnapshot איטרציה קבועה ל-i<40 דילגה על 6 הנושאים שנוספו ב-v10.41 (Parkinson\'s, Arrhythmia, Dysphagia, Andropause, Prevention, Interdisciplinary Care, indices 40-45). תיקון: i<TOPICS.length. תוצאה: snapshots שבועיים קולטים את כל 46 הנושאים, getTopicTrend() החזיר null קבוע על הנושאים האלה ועכשיו פעיל. נתונים היסטוריים לא מושפעים — snapshots קיימים פשוט חסרים את indices 40-45 (הקוד הקיים כבר טופל ב-undefined כ-null).',
+],
 '10.61.0':[
 '🐛 תיקון קריטי — Topic Mastery Heatmap הציג mastery גבוהה על נושאים שזה עתה ענית עליהם, גם אם רוב התשובות היו שגויות. השורש: הנוסחה ב-getTopicMastery() השתמשה ב-FSRS R בלבד, שהוא דעיכת זמן (R≈1 מיד אחרי כל ביקורת — נכונה או שגויה). חישוב חדש: per-card mastery = (ok/tot) × R. תשובה שגויה מורידה מאסטרי ל-0 מיידית; תשובות נכונות ישנות דועכות עם R. Fallback ל-hit-rate גולמי כשמצב FSRS חסר (legacy SM-2). Mirror של Pnimit v9.92.0 + Mishpacha v1.17.0.',
 '🐛 תיקון — Est. Score החזיר 60% מטעה כשרק נושאים בודדים נבחנו. השורש: הנוסחה הניחה 60% (neutral default) לכל נושא עם <3 תשובות, אז המשקל הכולל קרס סביב 60% גם אחרי 26 שאלות. תיקון: נושאים עם <3 תשובות מודרים מהסכימה. מחזיר null כשפחות מ-3 נושאים יש להם נתונים — UI מציג "—" עד שיש מספיק כיסוי.',
@@ -6890,7 +6893,7 @@ function takeWeeklySnapshot(){
     if(snapshots[weekKey])return; // already taken this week
     const tSt=getTopicStats();
     const snap={};
-    for(let i=0;i<40;i++){const s=tSt[i]||{ok:0,no:0,tot:0};snap[i]=s.tot>=3?Math.round(s.ok/s.tot*100):null;}
+    for(let i=0;i<TOPICS.length;i++){const s=tSt[i]||{ok:0,no:0,tot:0};snap[i]=s.tot>=3?Math.round(s.ok/s.tot*100):null;}
     snapshots[weekKey]={date:now.toISOString(),acc:snap};
     const keys=Object.keys(snapshots).sort();
     if(keys.length>52)delete snapshots[keys[0]];

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.61.1';
+const CACHE='shlav-a-v10.61.2';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 const FONT_URLS=['fonts/heebo-hebrew-400-normal.woff2','fonts/heebo-hebrew-500-normal.woff2','fonts/heebo-hebrew-600-normal.woff2','fonts/heebo-hebrew-700-normal.woff2','fonts/heebo-latin-400-normal.woff2','fonts/heebo-latin-500-normal.woff2','fonts/heebo-latin-600-normal.woff2','fonts/heebo-latin-700-normal.woff2','fonts/inter-latin-400-normal.woff2','fonts/inter-latin-500-normal.woff2','fonts/inter-latin-600-normal.woff2','fonts/inter-latin-700-normal.woff2'];
 const JSON_DATA_URLS=['data/questions.json','data/topics.json','data/notes.json','data/drugs.json','data/flashcards.json','harrison_chapters.json','data/hazzard_chapters.json','data/grs8_chapters.json','data/grs8_question_pages.json','data/tabs.json','data/question_chapters.json','data/distractors.json','data/regulatory.json','data/syllabus_data.json'];

--- a/tests/honestStats.test.js
+++ b/tests/honestStats.test.js
@@ -75,6 +75,19 @@ describe("honest stats — source-level guards", () => {
     expect(takeFn[0]).not.toMatch(/s\.tot>0\s*\?\s*Math\.round/);
     expect(takeFn[0]).toMatch(/s\.tot\s*>=\s*[3-9]/);
   });
+
+  it("takeWeeklySnapshot iterates over TOPICS.length, not hardcoded 40", () => {
+    // Bug (v10.61.2 fix): hardcoded `i<40` silently dropped topics 40-45
+    // (Parkinson's, Arrhythmia, Dysphagia, Andropause, Prevention,
+    // Interdisciplinary Care) added in v10.41 (TOPICS expanded 40→46).
+    // getTopicTrend(ti) for those indices stayed null forever.
+    const takeFn = html.match(/function takeWeeklySnapshot\(\)\{[\s\S]*?\n\}/);
+    expect(takeFn, 'takeWeeklySnapshot not found').not.toBeNull();
+    // Negative marker: hardcoded i<40 is the bug.
+    expect(takeFn[0]).not.toMatch(/for\s*\(\s*let\s+i\s*=\s*0\s*;\s*i\s*<\s*40\s*;/);
+    // Positive marker: must use TOPICS.length so newly-added topics are tracked.
+    expect(takeFn[0]).toMatch(/i\s*<\s*TOPICS\.length/);
+  });
 });
 
 // ─── Behavioural test: extract & eval the inline functions ────────────────


### PR DESCRIPTION
## Summary

Real bug fix: `takeWeeklySnapshot()` was iterating with hardcoded `i<40`, silently dropping the six topics added in v10.41 (Parkinson's, Arrhythmia, Dysphagia, Andropause, Prevention, Interdisciplinary Care — indices 40-45).

Result: `getTopicTrend(ti)` for those indices always returned `null` because `snapshot[weekKey].acc[ti]` was never populated, so trend arrows in the Topic Mastery Heatmap never showed week-over-week change for these topics.

The v10.41 changelog mentioned updating "regressionGuards ti range [0,39] → [0,42], dataIntegrity+expandedDataIntegrity topics.length 40→43. hardcoded 40 ב-diag stats הוחלף ל-TOPICS.length" — the diag-stats spot was caught, but `takeWeeklySnapshot` slipped through.

## Fix

`shlav-a-mega.html:6893`:
```diff
- for(let i=0;i<40;i++){const s=tSt[i]||{ok:0,no:0,tot:0};snap[i]=s.tot>=3?Math.round(s.ok/s.tot*100):null;}
+ for(let i=0;i<TOPICS.length;i++){const s=tSt[i]||{ok:0,no:0,tot:0};snap[i]=s.tot>=3?Math.round(s.ok/s.tot*100):null;}
```

## Compatibility

- **No data migration required.** Existing snapshots are keyed by week; old weeks just silently lack acc[40..45]. `getTopicTrend()` already treats `acc[ti]===undefined` the same as `null` (the existing guard checks `prev===null||curr===null`), so legacy data degrades gracefully.
- Sibling repos (FamilyMedicine, InternalMedicine) already use `TOPICS.length` in their own `takeWeeklySnapshot` — Geri was the outlier.

## Regression test

`tests/honestStats.test.js` gains a new case alongside the existing ≥3-answers guard:

```js
it("takeWeeklySnapshot iterates over TOPICS.length, not hardcoded 40", () => {
  ...
  expect(takeFn[0]).not.toMatch(/for\s*\(\s*let\s+i\s*=\s*0\s*;\s*i\s*<\s*40\s*;/);
  expect(takeFn[0]).toMatch(/i\s*<\s*TOPICS\.length/);
});
```

## Version trinity

- `APP_VERSION`: 10.61.1 → 10.61.2
- `sw.js` CACHE: `shlav-a-v10.61.1` → `shlav-a-v10.61.2`
- `package.json` version: 10.61.1 → 10.61.2

CHANGELOG entry added under v10.61.2 (Hebrew, matching house style).

## Verification

```
$ python3 scripts/check-version-sync.py
OK: All versions aligned (v10.61.2)

$ python3 scripts/check-innerhtml.py
OK: No unsanitized innerHTML interpolation

$ python3 scripts/check-innerhtml-pieces.py
OK: 11 innerHTML sites with interpolation, all pieces sanitized or annotated

$ python3 scripts/check-brace-balance.py
OK: Brace balance (3340 pairs)
```

## Test plan

- [x] Version-sync, innerHTML, brace-balance scripts pass locally
- [x] Test pattern verified to still match the function via the existing regex
- [ ] CI green (vitest + integrity-guard)
- [ ] Manual: answer ≥3 questions on a topic-40+ subject (e.g. Parkinson's), wait for next-week boundary, verify trend arrow appears

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEivo9j1mcfNH4v7uAtEg9)_