### PR TITLE
v10.62.0: kill Drug Lookup — sync with Pnimit v9.97.0 (partial)

### DIFF
--- a/.github/workflows/integrity-guard.yml
+++ b/.github/workflows/integrity-guard.yml
@@ -85,10 +85,8 @@ jobs:
               # Tab rendering (all 5 tabs + sub-tabs)
               'renderQuiz',
               'renderStudy',
-              'renderDrugs',
               'renderFlash',
               'renderLibrary',
-              'renderCalc',
               'renderSearch',
               'renderChat',
               'renderFeedback',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.61.2",
+  "version": "10.62.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -4555,29 +4555,6 @@ return h;
 }
 function fcSetMode(mode){S.fcDueMode=(mode==='due');S.fcFlip=false;if(S.fcDueMode)fcRebuildQueue();save();render();}
 
-// ===== DRUG LOOKUP =====
-let drugSearch='';
-function renderDrugs(){
-let h=`<div class="sec-t">💊 Drug Lookup</div><div class="sec-s">Beers Criteria + ACB Score Checker</div>`;
-h+=`<input class="search-box" placeholder="Search drug name..." oninput="drugSearch=this.value;render()" value="${drugSearch}" id="dsrch">`;
-const fv=drugSearch.toLowerCase();
-const filtered=DRUGS.filter(d=>!fv||d.name.toLowerCase().includes(fv)||d.heb.includes(fv)||(d.cat||'').toLowerCase().includes(fv));
-h+=`<div class="card">`;
-if(!filtered.length)h+=`<div style="padding:16px;text-align:center;color:rgb(var(--fg3));font-size:12px">No drugs found</div>`;
-filtered.forEach(d=>{
-h+=`<div class="drug-row"><div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:4px">
-<span style="font-weight:700;font-size:12px">${d.name} ${d.heb?'<span style="color:rgb(var(--fg3))">('+d.heb+')</span>':''}</span>
-<div style="display:flex;gap:4px">
-${d.beers?'<span class="badge badge-r">BEERS</span>':''}
-${d.acb>=3?'<span class="badge badge-r">ACB '+d.acb+'</span>':d.acb>=2?'<span class="badge badge-y">ACB '+d.acb+'</span>':d.acb>=1?'<span class="badge badge-g">ACB '+d.acb+'</span>':''}
-</div></div>
-<div style="font-size:10px;color:rgb(var(--fg2))">${d.cat||''}</div>
-<div style="font-size:10px;color:rgb(var(--fg2));margin-top:2px">${d.risk}</div></div>`;
-});
-h+=`</div>`;
-return h;
-}
-
 // ===== CALCULATORS =====
 
 // ===== CALCULATOR HELPERS (_rc* prefix) =====
@@ -6238,7 +6215,7 @@ async function cloudRestore(){
 function render(){
 const el=document.getElementById('ct');
 const focused=document.activeElement?.id;
-const sv={srchi:document.getElementById('srchi')?.value,nfilt:document.getElementById('nfilt')?.value,dsrch:document.getElementById('dsrch')?.value};
+const sv={srchi:document.getElementById('srchi')?.value,nfilt:document.getElementById('nfilt')?.value};
 if(tab!==lastTab){el.classList.remove('fade-in');void el.offsetWidth;el.classList.add('fade-in');window.scrollTo({top:0});lastTab=tab;}
 switch(tab){
 case'quiz':el.innerHTML=onCallMode?renderOnCall():renderQuiz();break;
@@ -6250,7 +6227,6 @@ case'learn':
   {const _learnPills=[
     {id:'study', mode:'learn', ic:'📝', l:'Notes'},
     {id:'flash', mode:'learn', ic:'🃏', l:'Cards'},
-    {id:'drugs', mode:'learn', ic:'💊', l:'Drugs'},
     {id:'haz-pdf',mode:'lib',  ic:'📕', l:'Hazzard'},
     {id:'harrison',mode:'lib', ic:'📗', l:'Harrison'},
     {id:'grs8',  mode:'lib',   ic:'📙', l:'GRS8'},
@@ -6274,12 +6250,10 @@ case'learn':
   } else {
     if(learnSub==='study')_body=renderStudy();
     else if(learnSub==='flash')_body=renderFlash();
-    else if(learnSub==='drugs')_body=renderDrugs();
   }
   el.innerHTML=_subBar+_body;}break; // safe-innerhtml: _subBar is built from a hardcoded pill array (no user input)
 case'study':tab='learn';learnSub='study';el.innerHTML='';render();break;
 case'flash':tab='learn';learnSub='flash';el.innerHTML='';render();break;
-case'drugs':tab='learn';learnSub='drugs';el.innerHTML='';render();break;
 case'lib':_studyMode='lib';tab='learn';render();break; // v10.54.0: alias to merged Study tab
 case'calc':tab='more';moreSub='calc';el.innerHTML='';render();break;
 case'track':
@@ -6311,7 +6285,6 @@ default:tab='quiz';el.innerHTML=renderQuiz();break;
 // Restore input values and focus
 if(sv.srchi!==undefined&&document.getElementById('srchi'))document.getElementById('srchi').value=sv.srchi;
 if(sv.nfilt!==undefined&&document.getElementById('nfilt'))document.getElementById('nfilt').value=sv.nfilt;
-if(sv.dsrch!==undefined&&document.getElementById('dsrch'))document.getElementById('dsrch').value=sv.dsrch;
 if(focused){const fe=document.getElementById(focused);if(fe){fe.focus();if(fe.value)fe.setSelectionRange(fe.value.length,fe.value.length);}}
 updateAccountChip();
 }
@@ -6426,8 +6399,12 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.61.2';
+const APP_VERSION='10.62.0';
 const CHANGELOG={
+'10.62.0':[
+'UX cleanup: kill Drug Lookup (covered by Med Basket) — mirrors Pnimit v9.97.0',
+'Drop renderDrugs + renderCalc from integrity-guard CRITICAL_FUNCTIONS',
+],
 '10.61.2':[
 '🐛 תיקון — takeWeeklySnapshot איטרציה קבועה ל-i<40 דילגה על 6 הנושאים שנוספו ב-v10.41 (Parkinson\'s, Arrhythmia, Dysphagia, Andropause, Prevention, Interdisciplinary Care, indices 40-45). תיקון: i<TOPICS.length. תוצאה: snapshots שבועיים קולטים את כל 46 הנושאים, getTopicTrend() החזיר null קבוע על הנושאים האלה ועכשיו פעיל. נתונים היסטוריים לא מושפעים — snapshots קיימים פשוט חסרים את indices 40-45 (הקוד הקיים כבר טופל ב-undefined כ-null).',
 ],

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.61.2';
+const CACHE='shlav-a-v10.62.0';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 const FONT_URLS=['fonts/heebo-hebrew-400-normal.woff2','fonts/heebo-hebrew-500-normal.woff2','fonts/heebo-hebrew-600-normal.woff2','fonts/heebo-hebrew-700-normal.woff2','fonts/heebo-latin-400-normal.woff2','fonts/heebo-latin-500-normal.woff2','fonts/heebo-latin-600-normal.woff2','fonts/heebo-latin-700-normal.woff2','fonts/inter-latin-400-normal.woff2','fonts/inter-latin-500-normal.woff2','fonts/inter-latin-600-normal.woff2','fonts/inter-latin-700-normal.woff2'];
 const JSON_DATA_URLS=['data/questions.json','data/topics.json','data/notes.json','data/drugs.json','data/flashcards.json','harrison_chapters.json','data/hazzard_chapters.json','data/grs8_chapters.json','data/grs8_question_pages.json','data/tabs.json','data/question_chapters.json','data/distractors.json','data/regulatory.json','data/syllabus_data.json'];

--- a/tests/migrationWiring.test.js
+++ b/tests/migrationWiring.test.js
@@ -20,7 +20,7 @@ beforeAll(() => {
 describe("render function orchestrators exist", () => {
   const ORCHESTRATORS = [
     "renderQuiz", "renderTrack", "renderCalc", "renderLibrary",
-    "renderStudy", "renderFlash", "renderDrugs", "renderSearch",
+    "renderStudy", "renderFlash", "renderSearch",
     "renderMedBasket", "renderOnCall", "render", "renderTabs",
   ];
   for (const name of ORCHESTRATORS) {


### PR DESCRIPTION
## Summary

UX cleanup, partial sync with Pnimit v9.97.0. Drops the Drug Lookup tab (functionally redundant with Med Basket) but **defers** the Calc-tab kill pending a decision on the Med Basket entry point — see the open question below.

## Spec source
[Tier 1 cleanup brief, 2026-04-30] — three-part request: (1) kill Drug Lookup, (2) kill Calc tab in More, (3) drop both from integrity-guard CRITICAL_FUNCTIONS.

This PR ships **#1 + #3 only**. #2 stays open because investigating the spec surfaced a UX choice the author wanted to make personally:

- The "Calc" sub-tab in More is **already user-labeled `🧺 Meds`** (L6293 of main).
- Only the internal `id:'calc'` and the 1-line `renderCalc()` shim → `renderMedBasket()` are the lie.
- Med Basket has zero other callsites — killing renderCalc with no replacement orphans a real feature (ACB + STOPP polypharmacy clash engine).
- Pnimit v9.97.0 is **not** a clean precedent: Pnimit's calc was real generic CrCl/CHA₂DS₂-VASc/CURB-65 forms (redundant with ward-helper). Geri's "calc" is just a misnamed Med Basket entry.

Three options surfaced for #2; awaiting the call before shipping.

## Changes

- `shlav-a-mega.html`:
  - Delete `// ===== DRUG LOOKUP =====` block + `renderDrugs()` + `let drugSearch=''`.
  - Drop `{id:'drugs', mode:'learn', ic:'💊', l:'Drugs'}` from the Study sub-tab pill array.
  - Drop `else if(learnSub==='drugs')_body=renderDrugs();` from learn-tab dispatcher.
  - Drop `case'drugs':...` history-route alias.
  - Drop orphaned `dsrch` save/restore in `render()` (sole consumer was the deleted input).
  - `DRUGS` data array **stays** — Med Basket consumes it.
- `.github/workflows/integrity-guard.yml`: remove `renderDrugs` + `renderCalc` from CRITICAL_FUNCTIONS (per spec end-state; `renderCalc` still exists but its pin is dropped because #2 will kill the function in a follow-up).
- `tests/migrationWiring.test.js`: drop `renderDrugs` from ORCHESTRATORS. **Test floor moves 922 → 921** in lockstep with the deletion (one fewer function = one fewer test case). Not a regression. NOT a trinity test — the two version-agnostic trinity files (appIntegrity.test.js, visualOverhaul2026.test.js) are untouched.
- Trinity bump 10.61.2 → 10.62.0: `package.json` + `APP_VERSION` + `sw.js` CACHE.
- CHANGELOG entry for 10.62.0 (two bullets — Drug Lookup + integrity-guard).

## Test plan

- [x] `npm test` → 41 files / 921 passing (down 1 from 922 due to ORCHESTRATORS list shrink)
- [x] Trinity verified: `pkg=APP_VERSION=CACHE=10.62.0`
- [x] `grep -c "renderDrugs" shlav-a-mega.html` → 1 (only the new CHANGELOG bullet)
- [x] `grep -E "renderDrugs|renderCalc" .github/workflows/integrity-guard.yml` → 0 matches
- [ ] CI: validate / build / deploy / js-integrity / notify / generate ×7 / report-build-status all green
- [ ] Post-merge: `curl -s https://eiasash.github.io/Geriatrics/sw.js | head -1` → `const CACHE='shlav-a-v10.62.0';`
- [ ] auto-audit health-check stays quiet within ~15s of merge

## Follow-ups

- **v10.62.1 (pending decision):** kill the renderCalc shim, finalize Med Basket entry point per chosen option (rename-in-place / move-to-Quiz-drawer / strict-spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)