### PR TITLE
ci: add verify-deploy.sh post-deploy live verification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,12 @@ No build step needed. Edit and refresh.
 - Update all three when making changes to ensure users get cache-busted (see workspace CLAUDE.md "version-trinity invariant")
 - The trinity guard lives in two places: strict pairwise alignment in `tests/appIntegrity.test.js`, and a version-agnostic re-derivation from `package.json` in `tests/visualOverhaul2026.test.js` (refactored v10.60 — used to hard-code the literal version string and went stale every release)
 
+### Release Invariants (run before declaring "shipped")
+1. **Local trinity** — `python3 scripts/check-version-sync.py` (HTML APP_VERSION + sw.js CACHE + package.json all aligned). Already part of `npm run verify`.
+2. **Tests + guards** — `npm run verify` (vitest + innerHTML safety + brace balance + Harrison hebrew baseline).
+3. **Live witness** — after `git push` lands and Pages rebuilds (~60–90s), `bash scripts/verify-deploy.sh` curls the live URL and asserts the new version actually appears in deployed `shlav-a-mega.html` and `sw.js`. **Don't claim "deployed" until this passes** — local trinity match ≠ live deploy match (Pages can silently fail to publish, or CDN can serve stale).
+4. **Question content edits** — any change to `data/questions.json` `o[]` text, `c` index, or `e` explanation must quote the source PDF (Hazzard 8e / Harrison 22e / GRS8) in the chat or commit message before the edit lands. Never paraphrase or fabricate option text — the v9.81 idx 510 incident was caught only by manual sanity check and required a v9.82 hotfix.
+
 ### Testing
 ```bash
 npm test             # Run all tests (vitest, 1,047 tests across 45 files)

--- a/scripts/verify-deploy.sh
+++ b/scripts/verify-deploy.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# verify-deploy.sh — Post-deploy live verification.
+#
+# Curls the live GitHub Pages URLs and confirms the expected version string
+# appears in the deployed HTML and sw.js. Polls with backoff because Pages
+# takes ~60–90s to publish after push.
+#
+# Why: existing scripts/check-version-sync.py validates LOCAL files match.
+# This validates the LIVE site actually shipped the new version — catches
+# the "cache masking shipped fixes" + "Pages build silently failed" cases.
+#
+# Usage:
+#   ./scripts/verify-deploy.sh                # uses package.json version
+#   ./scripts/verify-deploy.sh 10.63.2        # explicit version
+#   ./scripts/verify-deploy.sh --wait 180     # max wait seconds (default 120)
+#   ./scripts/verify-deploy.sh --no-wait      # one-shot check, no polling
+#
+# Exit codes:
+#   0 — both HTML and sw.js show the expected version
+#   1 — version mismatch after wait window
+#   2 — usage error or network failure
+
+set -u
+
+LIVE_HTML='https://eiasash.github.io/Geriatrics/shlav-a-mega.html'
+LIVE_SW='https://eiasash.github.io/Geriatrics/sw.js'
+WAIT_MAX=120
+INTERVAL=10
+ONESHOT=0
+VERSION=''
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --wait) WAIT_MAX="$2"; shift 2;;
+    --no-wait) ONESHOT=1; shift;;
+    -h|--help) sed -n '1,30p' "$0"; exit 0;;
+    -*) echo "verify-deploy: unknown flag $1" >&2; exit 2;;
+    *) VERSION="$1"; shift;;
+  esac
+done
+
+if [[ -z "$VERSION" ]]; then
+  if ! VERSION=$(node -p "require('./package.json').version" 2>/dev/null); then
+    echo "verify-deploy: cannot read package.json version" >&2
+    exit 2
+  fi
+fi
+
+echo "verify-deploy: expecting v${VERSION}"
+echo "  HTML: ${LIVE_HTML}"
+echo "  SW:   ${LIVE_SW}"
+
+start=$(date +%s)
+while true; do
+  html_ok=0
+  sw_ok=0
+
+  html_body=$(curl -sf -A 'Mozilla/5.0 verify-deploy' --max-time 15 "${LIVE_HTML}" || true)
+  sw_body=$(curl -sf -A 'Mozilla/5.0 verify-deploy' --max-time 15 "${LIVE_SW}" || true)
+
+  if printf '%s' "$html_body" | grep -qE "APP_VERSION[[:space:]]*=[[:space:]]*['\"]${VERSION}['\"]"; then
+    html_ok=1
+  fi
+  if printf '%s' "$sw_body" | grep -qF "shlav-a-v${VERSION}"; then
+    sw_ok=1
+  fi
+
+  if [[ "$html_ok" = 1 && "$sw_ok" = 1 ]]; then
+    elapsed=$(( $(date +%s) - start ))
+    echo "  HTML APP_VERSION=${VERSION}    PASS"
+    echo "  SW   CACHE=shlav-a-v${VERSION}  PASS"
+    echo "verify-deploy: PASS (after ${elapsed}s)"
+    exit 0
+  fi
+
+  elapsed=$(( $(date +%s) - start ))
+  if [[ "$ONESHOT" = 1 ]] || (( elapsed >= WAIT_MAX )); then
+    echo ""
+    echo "verify-deploy: FAIL after ${elapsed}s"
+    [[ "$html_ok" = 0 ]] && echo "  ✗ live HTML missing APP_VERSION='${VERSION}'"
+    [[ "$sw_ok" = 0 ]] && echo "  ✗ live sw.js missing 'shlav-a-v${VERSION}'"
+    echo ""
+    echo "Possible causes:"
+    echo "  - GitHub Pages still building — wait 30s, retry"
+    echo "  - Push didn't land on main"
+    echo "  - Trinity drift — run: python3 scripts/check-version-sync.py"
+    echo "  - CDN cache — try cache-busted URL: ${LIVE_HTML}?v=${VERSION}"
+    exit 1
+  fi
+
+  echo "  ...polling (html=${html_ok} sw=${sw_ok}, ${elapsed}s/${WAIT_MAX}s) — sleeping ${INTERVAL}s"
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
## Summary
- Adds `scripts/verify-deploy.sh`: curls the live URL after deploy and asserts the new version actually appears in deployed `shlav-a-mega.html` and `sw.js`. Catches "Pages silently fails" / "CDN serves stale" failures that local trinity checks can't see.
- Adds **Release Invariants** section to `CLAUDE.md` codifying the four-step gate: local trinity → tests + guards → live witness → question-content source-citation.

## Why
Local `scripts/check-version-sync.py` validates that local files match — it cannot tell whether the deployed page actually updated. Three sessions of "shipped fix wasn't visible" turned out to be cache/Pages issues rather than code issues. `verify-deploy.sh` is the canonical post-deploy gate the audit-fix-deploy skill now requires.

## Test plan
- [x] `bash scripts/verify-deploy.sh --no-wait` → PASS at v10.63.2 (local + live aligned)
- [x] `bash scripts/verify-deploy.sh --no-wait 99.99.99` → exit 1 with diagnostic table
- [x] No changes to runtime code / question data / build pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)