### PR TITLE
chore(scripts): commit staged auto-audit tooling drafts

### DIFF
--- a/scripts/auto_fix/auto_fix_regenerate_misaligned_distractors.sh
+++ b/scripts/auto_fix/auto_fix_regenerate_misaligned_distractors.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# auto_fix_regenerate_misaligned_distractors.sh — auto-audit Tier 2 template
+#
+# Repairs data/distractors.json content corruption in Eiasash/Geriatrics
+# by dropping misaligned entries and regenerating them via the Toranot
+# proxy. Always opens a PR; never pushes to main.
+#
+# Triggered by: auto-fix.yml workflow_dispatch with
+#   template = "regenerate_misaligned_distractors"
+#
+# Drop into: scripts/auto_fix/regenerate_misaligned_distractors.sh
+# (chmod +x)
+#
+# Required env (provided by auto-fix.yml):
+#   GITHUB_TOKEN — needs contents:write + pull-requests:write on Eiasash/Geriatrics
+#   REPO         — "Eiasash/Geriatrics"
+#   ISSUE_NUMBER — originating auto-audit issue (for PR cross-link)
+#
+# Wall time: 30-60 min (the regeneration loop dominates).
+# Cost: ~$10 on the Toranot proxy (Haiku 4.5).
+
+set -euo pipefail
+
+REPO="${REPO:-Eiasash/Geriatrics}"
+ISSUE_NUMBER="${ISSUE_NUMBER:-}"
+TS="$(date -u +%Y%m%d-%H%M%S)"
+BRANCH="auto-fix/distractor-realign-${TS}"
+
+red()    { printf '\033[31m%s\033[0m\n' "$*"; }
+green()  { printf '\033[32m%s\033[0m\n' "$*"; }
+blue()   { printf '\033[34m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
+
+# ─── 0. Setup ──────────────────────────────────────────────────────────────
+WORK="$(mktemp -d)"
+cd "$WORK"
+
+git config --global user.email "auto-audit@noreply"
+git config --global user.name  "auto-audit-bot"
+
+blue "Cloning $REPO..."
+git clone --depth 50 "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git" geri
+cd geri
+git checkout main
+git pull --rebase origin main
+
+git checkout -b "$BRANCH"
+
+# ─── 1. Audit current state ────────────────────────────────────────────────
+blue "[1/6] Auditing current alignment..."
+node -e '
+  const fs=require("fs");
+  const Q=JSON.parse(fs.readFileSync("data/questions.json"));
+  const D=JSON.parse(fs.readFileSync("data/distractors.json"));
+  let aligned=0,misaligned=0;
+  for(const[k,v] of Object.entries(D)){
+    const i=+k,q=Q[i];
+    if(!q||!Array.isArray(q.o)||typeof q.c!=="number") continue;
+    if(!Array.isArray(v)||v.length!==q.o.length) continue;
+    const e=v.findIndex(s=>!s||!String(s).trim());
+    if(e===-1) continue;
+    if(e===q.c) aligned++; else misaligned++;
+  }
+  console.log("Aligned:",aligned,"Misaligned:",misaligned);
+  if(misaligned===0){ console.error("Nothing to fix — bailing."); process.exit(42); }
+'
+AUDIT_RC=$?
+if [[ $AUDIT_RC -eq 42 ]]; then
+  yellow "No misalignment found — closing the issue as already-fixed and exiting."
+  if [[ -n "$ISSUE_NUMBER" ]]; then
+    curl -sS -X POST \
+      -H "Authorization: Bearer $GITHUB_TOKEN" \
+      -H "Accept: application/vnd.github+json" \
+      "https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/comments" \
+      -d '{"body":"✅ Auto-fix `regenerate_misaligned_distractors` ran but found no misalignment — likely already fixed in a prior commit. Closing."}'
+    curl -sS -X PATCH \
+      -H "Authorization: Bearer $GITHUB_TOKEN" \
+      -H "Accept: application/vnd.github+json" \
+      "https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER" \
+      -d '{"state":"closed"}'
+  fi
+  exit 0
+fi
+
+# ─── 2. Drop misaligned entries ────────────────────────────────────────────
+blue "[2/6] Dropping misaligned entries..."
+node -e '
+  const fs=require("fs");
+  const Q=JSON.parse(fs.readFileSync("data/questions.json"));
+  const D=JSON.parse(fs.readFileSync("data/distractors.json"));
+  const out={};
+  for(const[k,v] of Object.entries(D)){
+    const i=+k,q=Q[i];
+    if(!q||!Array.isArray(q.o)||typeof q.c!=="number") continue;
+    if(!Array.isArray(v)||v.length!==q.o.length) continue;
+    const e=v.findIndex(s=>!s||!String(s).trim());
+    if(e===-1||e!==q.c) continue;
+    out[k]=v;
+  }
+  fs.writeFileSync("data/distractors.json",JSON.stringify(out));
+  console.log("Kept aligned:",Object.keys(out).length);
+'
+
+# ─── 3. Regenerate via Toranot proxy ───────────────────────────────────────
+blue "[3/6] Regenerating distractors via Toranot proxy (this is the long step)..."
+yellow "      ~30-60 min wall, ~\$10 spend, Haiku 4.5, 6 workers..."
+
+# The script is resumable. If it dies mid-run we re-run; default mode skips
+# entries already present.
+ATTEMPTS=0
+MAX_ATTEMPTS=3
+while [[ $ATTEMPTS -lt $MAX_ATTEMPTS ]]; do
+  ATTEMPTS=$((ATTEMPTS+1))
+  blue "  Generator attempt $ATTEMPTS/$MAX_ATTEMPTS"
+  if node scripts/generate_distractors.cjs --batch 6 --delay 250 --model haiku; then
+    break
+  fi
+  yellow "  Generator exited non-zero, retrying in 30s..."
+  sleep 30
+done
+
+# Verify completeness
+node -e '
+  const fs=require("fs");
+  const Q=JSON.parse(fs.readFileSync("data/questions.json"));
+  const D=JSON.parse(fs.readFileSync("data/distractors.json"));
+  let missing=0,misaligned=0;
+  for(let i=0;i<Q.length;i++){
+    const q=Q[i],v=D[i];
+    if(!q||!Array.isArray(q.o)||typeof q.c!=="number") continue;
+    if(!v){ missing++; continue; }
+    if(!Array.isArray(v)||v.length!==q.o.length){ missing++; continue; }
+    const e=v.findIndex(s=>!s||!String(s).trim());
+    if(e===-1||e!==q.c){ misaligned++; continue; }
+  }
+  console.log("Missing:",missing,"Misaligned:",misaligned);
+  if(missing>0||misaligned>0){
+    console.error("FAIL: regen left holes; manual intervention needed.");
+    process.exit(1);
+  }
+'
+
+# ─── 4. Run tests ──────────────────────────────────────────────────────────
+blue "[4/6] Installing deps + running test suite..."
+npm install --no-audit --no-fund --silent
+npx vitest run tests/distractorsDrift.test.js
+# Don't run the whole suite here — the alignment guard is the only thing
+# affected by this change; full suite runs in CI on the PR.
+
+# ─── 5. Bump version trinity ───────────────────────────────────────────────
+blue "[5/6] Bumping version trinity..."
+CURR=$(node -p "require('./package.json').version")
+# Patch bump (e.g. 10.44.0 -> 10.44.1). Auto-fix never bumps minor/major.
+NEW=$(node -p "
+  const [maj,min,pat]=require('./package.json').version.split('.').map(Number);
+  [maj,min,pat+1].join('.')
+")
+echo "  $CURR → $NEW"
+
+# package.json
+node -e "
+  const fs=require('fs');
+  const p=JSON.parse(fs.readFileSync('package.json'));
+  p.version='$NEW';
+  fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n');
+"
+
+# shlav-a-mega.html APP_VERSION
+sed -i "s/const APP_VERSION='${CURR}';/const APP_VERSION='${NEW}';/" shlav-a-mega.html
+# shlav-a-mega.html CHANGELOG entry — insert just after the CHANGELOG opening
+node -e "
+  const fs=require('fs');
+  const f='shlav-a-mega.html';
+  let html=fs.readFileSync(f,'utf8');
+  const entry=\`'${NEW}':[
+'🤖 Auto-fix: distractor autopsy data corruption detected by auto-audit probe and repaired automatically. \${process.env.MISALIGNED_COUNT||'?'} misaligned entries dropped and regenerated against current questions.json. Originating issue: #${ISSUE_NUMBER}.',
+],
+\`;
+  html=html.replace(/const CHANGELOG=\\{\\n/, 'const CHANGELOG={\\n'+entry);
+  fs.writeFileSync(f,html);
+"
+
+# sw.js cache name (assumes pattern 'shlav-a-vX.Y.Z')
+sed -i "s/const CACHE='shlav-a-v${CURR}';/const CACHE='shlav-a-v${NEW}';/" sw.js
+
+# ─── 6. Commit + push + PR ─────────────────────────────────────────────────
+blue "[6/6] Committing + opening PR..."
+git add -A
+git commit -m "v${NEW} — auto-fix distractor autopsy data corruption
+
+Auto-audit probe \`probe_distractor_alignment\` detected misaligned
+entries in data/distractors.json. This commit:
+
+- drops misaligned entries (where DIS[k] empty slot != Q[k].c)
+- regenerates them via Toranot proxy / Haiku 4.5 / 6 workers
+- bumps version trinity to ${NEW}
+- adds changelog entry
+
+Originating issue: #${ISSUE_NUMBER}
+
+Co-Authored-By: auto-audit-bot <auto-audit@noreply>"
+
+git push origin "$BRANCH"
+
+PR_BODY="Automated repair of distractor autopsy corruption detected by \`probe_distractor_alignment\`.
+
+Originating issue: #${ISSUE_NUMBER}
+
+**Verify before merging:**
+- [ ] CI green
+- [ ] Spot-check 2-3 questions: open the live preview, answer wrong, confirm Distractor Autopsy block shows correct content for all 3 wrong options and a green-label on the correct one
+- [ ] No 'Wrong because:' rationale on any green-checked answer
+
+After merge, the alignment probe will re-run on the next health-check cycle and (should) report clean."
+
+PR_RESPONSE=$(curl -sS -X POST \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/$REPO/pulls" \
+  -d "$(jq -n --arg title "v${NEW} — auto-fix distractor autopsy data corruption" \
+              --arg body "$PR_BODY" \
+              --arg head "$BRANCH" \
+              --arg base "main" \
+              '{title:$title, body:$body, head:$head, base:$base}')")
+
+PR_NUMBER=$(echo "$PR_RESPONSE" | jq -r '.number // empty')
+PR_URL=$(echo "$PR_RESPONSE" | jq -r '.html_url // empty')
+
+if [[ -z "$PR_NUMBER" ]]; then
+  red "PR creation failed: $PR_RESPONSE"
+  exit 1
+fi
+
+# Cross-link to the originating issue
+if [[ -n "$ISSUE_NUMBER" ]]; then
+  curl -sS -X POST \
+    -H "Authorization: Bearer $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/comments" \
+    -d "$(jq -n --arg body "✅ Auto-fix \`regenerate_misaligned_distractors\` opened PR #${PR_NUMBER}: ${PR_URL}\n\nMerge after CI green + manual spot-check on the preview deploy." '{body:$body}')"
+fi
+
+green "✅ Done. PR opened: $PR_URL"

--- a/scripts/auto_fix/auto_fix_repair_workflow_branch.py
+++ b/scripts/auto_fix/auto_fix_repair_workflow_branch.py
@@ -1,0 +1,233 @@
+"""
+auto_fix_repair_workflow_branch.py — auto-audit Tier 2 template
+
+Repairs a workflow that's failing because its checkout step references
+a branch that no longer exists (deleted, force-pushed away, or never
+created in the first place).
+
+Real-world precedent: Geriatrics `Distractor Autopsy Generator` workflow
+failed 14+ consecutive times at the `Checkout distractor-autopsy branch`
+step. This template handles that exact class of failure.
+
+Drop into: scripts/auto_fix/repair_workflow_branch.py
+
+Triggered by: auto-fix.yml workflow_dispatch with template="repair_workflow_branch"
+and inputs from the originating Finding's template_args.
+
+Inputs (from template_args):
+    workflow_file: e.g. "distractor-autopsy.yml"
+    expected_branch: e.g. "cowork/distractor-autopsy"  (best-effort guess
+                     from probe; this template re-parses to confirm)
+
+Side effects (all gated):
+    - Pushes a new ref to origin (creates the missing branch from main)
+      OR fast-forwards it if behind
+    - Comments on the originating issue
+    - Re-triggers the failing workflow once
+
+Will NOT:
+    - Modify main
+    - Force-push existing branches with diverged history (escalates instead)
+    - Touch any branch outside the one named by the workflow file
+
+Required env:
+    GITHUB_TOKEN — needs `contents: write` on the target repo, plus
+                   `actions: write` to re-trigger the workflow
+    REPO         — e.g. "Eiasash/Geriatrics"
+    ISSUE_NUMBER — the originating auto-audit issue (for the resolution comment)
+
+Exit codes:
+    0 — repair succeeded, branch in expected state, workflow re-triggered
+    1 — branch had diverged history; escalated, no action taken
+    2 — could not determine expected branch from workflow file
+    3 — GH API error; partial state, see logs
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from typing import Any, Dict, Optional, Tuple
+
+GH_API = "https://api.github.com"
+
+
+def gh(method: str, path: str, token: str, body: Optional[Dict[str, Any]] = None) -> Any:
+    data = json.dumps(body).encode() if body else None
+    req = urllib.request.Request(
+        f"{GH_API}{path}",
+        data=data,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "Content-Type": "application/json",
+            "User-Agent": "auto-audit-fix",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            raw = r.read()
+            return json.loads(raw) if raw else None
+    except urllib.error.HTTPError as e:
+        return {"_error": True, "status": e.code, "body": e.read().decode("utf-8", errors="replace")}
+
+
+def parse_branch_from_workflow(text: str) -> Optional[str]:
+    """Pull the branch name out of a workflow YAML."""
+    # Match `ref: <branch>` (most common)
+    m = re.search(r"\bref:\s*([^\s'\"#]+)", text)
+    if m:
+        return m.group(1)
+    # Match `git checkout -B <branch>` or `git checkout <branch>`
+    m = re.search(r"\bgit checkout (?:-B\s+)?([^\s'\"`#]+)", text)
+    if m:
+        return m.group(1)
+    # Match `branches: [<branch>]` or `branches: - <branch>` (less reliable)
+    m = re.search(r"branches:\s*\[\s*([^\]\s,]+)", text)
+    if m:
+        return m.group(1)
+    return None
+
+
+def get_branch_sha(repo: str, branch: str, token: str) -> Optional[str]:
+    """Returns commit SHA at HEAD of branch, or None if branch doesn't exist."""
+    res = gh("GET", f"/repos/{repo}/git/refs/heads/{branch}", token)
+    if isinstance(res, dict) and res.get("_error"):
+        return None
+    if isinstance(res, dict) and res.get("object", {}).get("sha"):
+        return res["object"]["sha"]
+    return None
+
+
+def is_ancestor(repo: str, ancestor_sha: str, descendant_sha: str, token: str) -> bool:
+    """True if ancestor is reachable from descendant (i.e. fast-forward is possible)."""
+    res = gh("GET", f"/repos/{repo}/compare/{ancestor_sha}...{descendant_sha}", token)
+    if isinstance(res, dict) and res.get("_error"):
+        return False
+    return res.get("status") in ("identical", "ahead")
+
+
+def comment_on_issue(repo: str, issue: int, msg: str, token: str) -> None:
+    if not issue:
+        return
+    gh("POST", f"/repos/{repo}/issues/{issue}/comments", token, {"body": msg})
+
+
+def main() -> int:
+    token = os.environ["GITHUB_TOKEN"]
+    repo = os.environ["REPO"]
+    issue = int(os.environ.get("ISSUE_NUMBER", "0"))
+
+    args_raw = os.environ.get("TEMPLATE_ARGS", "{}")
+    args = json.loads(args_raw)
+    wf_file = args.get("workflow_file")
+    expected = args.get("expected_branch")
+
+    if not wf_file:
+        print("ERROR: workflow_file missing from template_args", file=sys.stderr)
+        return 2
+
+    # Re-fetch the workflow file and re-parse, in case the probe's guess was wrong
+    wf_path = f".github/workflows/{wf_file}"
+    contents = gh("GET", f"/repos/{repo}/contents/{wf_path}", token)
+    if isinstance(contents, dict) and contents.get("_error"):
+        print(f"ERROR: cannot read workflow file: {contents}", file=sys.stderr)
+        return 3
+    text = base64.b64decode(contents["content"]).decode("utf-8", errors="replace")
+    parsed = parse_branch_from_workflow(text)
+    branch = parsed or expected
+    if not branch:
+        comment_on_issue(repo, issue,
+            f"❌ Auto-fix `repair_workflow_branch` could not determine the expected "
+            f"branch from `{wf_path}`. Manual intervention needed.",
+            token)
+        return 2
+
+    print(f"Target workflow: {wf_file}")
+    print(f"Expected branch: {branch}")
+
+    # State of main + state of expected branch
+    main_sha = get_branch_sha(repo, "main", token)
+    branch_sha = get_branch_sha(repo, branch, token)
+
+    if not main_sha:
+        print("ERROR: cannot read main SHA", file=sys.stderr)
+        return 3
+
+    print(f"main HEAD:   {main_sha}")
+    print(f"{branch} HEAD: {branch_sha or '(branch missing)'}")
+
+    # Case A: branch missing entirely → recreate from main
+    if branch_sha is None:
+        res = gh("POST", f"/repos/{repo}/git/refs", token, {
+            "ref": f"refs/heads/{branch}",
+            "sha": main_sha,
+        })
+        if isinstance(res, dict) and res.get("_error"):
+            comment_on_issue(repo, issue,
+                f"❌ Auto-fix failed to create `{branch}` from main: {res}", token)
+            return 3
+        comment_on_issue(repo, issue,
+            f"✅ Auto-fix `repair_workflow_branch` created missing branch "
+            f"`{branch}` from `main` ({main_sha[:7]}). Re-triggering "
+            f"`{wf_file}`.", token)
+        rerun_workflow(repo, wf_file, branch, token, issue)
+        return 0
+
+    # Case B: branch exists. Is it an ancestor of main? (i.e. just behind?)
+    if branch_sha == main_sha:
+        # Branch is already at main — workflow is failing for a different reason
+        comment_on_issue(repo, issue,
+            f"⚠️ Auto-fix `repair_workflow_branch`: branch `{branch}` is already "
+            f"at `main` ({main_sha[:7]}). The checkout step is failing for a "
+            f"different reason (token scope? path? deleted file?). Escalating to "
+            f"`investigate`.", token)
+        return 1
+
+    # If branch is behind main → fast-forward
+    if is_ancestor(repo, branch_sha, main_sha, token):
+        res = gh("PATCH", f"/repos/{repo}/git/refs/heads/{branch}", token, {
+            "sha": main_sha,
+            "force": False,
+        })
+        if isinstance(res, dict) and res.get("_error"):
+            comment_on_issue(repo, issue,
+                f"❌ Auto-fix failed to fast-forward `{branch}` to main: {res}", token)
+            return 3
+        comment_on_issue(repo, issue,
+            f"✅ Auto-fix `repair_workflow_branch` fast-forwarded `{branch}` "
+            f"from `{branch_sha[:7]}` to `main` ({main_sha[:7]}). Re-triggering "
+            f"`{wf_file}`.", token)
+        rerun_workflow(repo, wf_file, branch, token, issue)
+        return 0
+
+    # Case C: branch has diverged from main → REFUSE to force-push
+    comment_on_issue(repo, issue,
+        f"⚠️ Auto-fix `repair_workflow_branch` will not force-push `{branch}` — "
+        f"it has diverged from main ({branch_sha[:7]} vs {main_sha[:7]}). "
+        f"This may contain in-progress work (e.g. cron-driven WIP commits on "
+        f"a worker branch). Escalating for manual review.\n\n"
+        f"To fix manually: either merge `{branch}` into main if the work matters, "
+        f"or `git push origin --force main:refs/heads/{branch}` to discard it.",
+        token)
+    return 1
+
+
+def rerun_workflow(repo: str, wf_file: str, branch: str, token: str, issue: int) -> None:
+    """Trigger one fresh run of the failing workflow on the now-repaired branch."""
+    res = gh("POST", f"/repos/{repo}/actions/workflows/{wf_file}/dispatches",
+             token, {"ref": branch})
+    if isinstance(res, dict) and res.get("_error"):
+        comment_on_issue(repo, issue,
+            f"⚠️ Branch repaired but workflow re-trigger failed: {res}", token)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/probes/probe_distractor_alignment.py
+++ b/scripts/probes/probe_distractor_alignment.py
@@ -1,0 +1,176 @@
+"""
+probe_distractor_alignment.py — auto-audit Tier 1 probe addition
+
+Detects content-misalignment between data/distractors.json and
+data/questions.json in the Geriatrics repo (Shlav A Mega). The existing
+distractorsDrift.test.js only checks structural invariants (key types,
+array lengths) — it does NOT catch the case where every entry has the
+right shape but points at the wrong question's options. This probe
+fills that gap from the production side.
+
+Real-world precedent: caught 2,729 of 3,795 entries (72%) silently
+misaligned in v10.44.x after the v9.58 answer-key sweep + question
+insertions. By design, this probe will fire on the SAME corruption
+again.
+
+Drop into: scripts/probes/probe_distractor_alignment.py
+
+Wire into probe.py (Geri-specific check):
+
+    from probes.probe_distractor_alignment import check_distractor_alignment
+    if repo == "Eiasash/Geriatrics":
+        findings.extend(check_distractor_alignment(repo))
+
+No GH token needed — pulls from raw.githubusercontent.
+
+Threshold: any misalignment is CRITICAL. The generator invariant is
+absolute — empty slot in DIS[k] MUST equal Q[k].c. There is no
+tolerable rate of drift.
+"""
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any, Dict, List
+
+RAW_BASE = "https://raw.githubusercontent.com"
+
+
+def _fetch_json(repo: str, branch: str, path: str) -> Any:
+    url = f"{RAW_BASE}/{repo}/{branch}/{path}"
+    req = urllib.request.Request(url, headers={"User-Agent": "auto-audit-probe"})
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return json.loads(r.read())
+
+
+def check_distractor_alignment(
+    repo: str = "Eiasash/Geriatrics", branch: str = "main"
+) -> List[Dict[str, Any]]:
+    """
+    Returns at most one finding (the corruption is binary: clean or rotten).
+
+    The check:
+        For every key k in DIS, the empty slot in DIS[k] must equal Q[k].c.
+        This is the generator's output invariant. If it breaks, the UI
+        shows "Wrong because:" rationales on the correct answer.
+
+    Performance: fetches ~6.8MB + ~2MB once per probe run. ~3s.
+    Acceptable for a 30-min cron.
+    """
+    try:
+        Q = _fetch_json(repo, branch, "data/questions.json")
+        D = _fetch_json(repo, branch, "data/distractors.json")
+    except urllib.error.HTTPError as e:
+        return [{
+            "severity": "WARN",
+            "repo": repo,
+            "title": "Cannot fetch questions/distractors for alignment probe",
+            "body": f"HTTP {e.code} fetching from {branch}.",
+            "labels": ["auto-audit"],
+            "template": None,
+            "template_args": {},
+        }]
+
+    aligned = 0
+    misaligned = 0
+    no_empty = 0
+    samples: List[Dict[str, Any]] = []
+
+    for k, v in D.items():
+        try:
+            i = int(k)
+        except (TypeError, ValueError):
+            continue
+        if not (0 <= i < len(Q)):
+            continue
+        q = Q[i]
+        if not isinstance(q, dict):
+            continue
+        opts = q.get("o")
+        c = q.get("c")
+        if not isinstance(opts, list) or not isinstance(c, int):
+            continue
+        if not isinstance(v, list) or len(v) != len(opts):
+            continue
+        empty_idx = next(
+            (j for j, s in enumerate(v) if not s or not str(s).strip()), -1
+        )
+        if empty_idx == -1:
+            no_empty += 1
+            continue
+        if empty_idx == c:
+            aligned += 1
+        else:
+            misaligned += 1
+            if len(samples) < 5:
+                stem = (q.get("q") or "")[:80].replace("\n", " ")
+                samples.append({
+                    "qIdx": i,
+                    "qC": c,
+                    "emptyIdx": empty_idx,
+                    "stem": stem,
+                })
+
+    total = aligned + misaligned + no_empty
+    if total == 0:
+        return [{
+            "severity": "WARN",
+            "repo": repo,
+            "title": "Distractor alignment probe: no data to check",
+            "body": "Both files loaded but no comparable entries were found.",
+            "labels": ["auto-audit"],
+            "template": None,
+            "template_args": {},
+        }]
+
+    if misaligned == 0 and no_empty == 0:
+        # Healthy. Don't emit a finding.
+        return []
+
+    pct = (misaligned / total) * 100.0 if total else 0.0
+    body_lines = [
+        f"**{misaligned} of {total} entries misaligned** ({pct:.1f}%).",
+        "",
+        f"- aligned (empty slot == q.c): {aligned}",
+        f"- misaligned (empty slot != q.c): {misaligned}",
+        f"- no empty slot at all: {no_empty}",
+        "",
+        "**What this means:** the UI renders 'Wrong because:' rationales on "
+        "the correct (green ✓) answer, and silently swallows real "
+        "wrong-option rationales. Users see distractor explanations that "
+        "don't match the question.",
+        "",
+        "**Auto-fix:** run the `regenerate_misaligned_distractors` template — "
+        "it drops misaligned entries, regenerates via the Toranot proxy, and "
+        "opens a PR with a version-trinity bump.",
+        "",
+        "**Sample misaligned entries:**",
+        "```json",
+        json.dumps(samples, indent=2, ensure_ascii=False),
+        "```",
+    ]
+
+    return [{
+        "severity": "CRITICAL",
+        "repo": repo,
+        "title": (
+            f"Distractor autopsy data corruption: "
+            f"{misaligned}/{total} entries misaligned ({pct:.0f}%)"
+        ),
+        "body": "\n".join(body_lines),
+        "labels": ["auto-audit", "auto-fix-eligible", "data-corruption"],
+        "template": "regenerate_misaligned_distractors",
+        "template_args": {
+            "branch": branch,
+            "misaligned_count": misaligned,
+            "total": total,
+        },
+    }]
+
+
+if __name__ == "__main__":
+    import sys
+    repo = sys.argv[1] if len(sys.argv) > 1 else "Eiasash/Geriatrics"
+    branch = sys.argv[2] if len(sys.argv) > 2 else "main"
+    print(json.dumps(check_distractor_alignment(repo, branch), indent=2))

--- a/scripts/probes/probe_workflow_staleness.py
+++ b/scripts/probes/probe_workflow_staleness.py
@@ -1,0 +1,250 @@
+"""
+probe_workflow_staleness.py — auto-audit Tier 1 probe addition
+
+Detects workflows whose latest run failed or stopped running on schedule,
+and emits a CRITICAL finding with a template hint so the auto-fix layer
+can repair common breakages without human authoring.
+
+Integration point: import and call from scripts/probe.py inside the
+per-repo loop. Returns a list of Finding dicts in whatever shape your
+existing probe.py uses; adjust the dict keys to match.
+
+Drop into: scripts/probes/probe_workflow_staleness.py
+
+Wire into probe.py:
+
+    from probes.probe_workflow_staleness import check_workflow_staleness
+    findings.extend(check_workflow_staleness(repo, gh_token))
+
+Required env:
+    GITHUB_TOKEN — read access to the target repo's Actions
+
+Thresholds (edit to taste):
+    FAIL_AGE_HOURS  — how long a failing workflow can sit before CRITICAL
+    STALE_AGE_HOURS — how long a cron workflow can be silent before CRITICAL
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+GH_API = "https://api.github.com"
+FAIL_AGE_HOURS = 4    # Failing workflow blocks for this long → CRITICAL
+STALE_AGE_HOURS = 12  # Cron workflow silent for this long → CRITICAL
+
+
+def _gh(path: str, token: str) -> Any:
+    """Minimal GH API client. Returns parsed JSON or raises."""
+    req = urllib.request.Request(
+        f"{GH_API}{path}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "auto-audit-probe",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=15) as r:
+        return json.loads(r.read())
+
+
+def _hours_since(iso: str) -> float:
+    """ISO8601 with 'Z' → hours from now."""
+    dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+    return (datetime.now(timezone.utc) - dt).total_seconds() / 3600.0
+
+
+def _classify_failure(jobs_data: Dict[str, Any]) -> str:
+    """
+    Look at the failed steps across jobs, pick the template that matches.
+    Returns a template name the auto-fix layer knows about.
+    """
+    for job in jobs_data.get("jobs", []):
+        if job.get("conclusion") != "failure":
+            continue
+        for step in job.get("steps", []):
+            if step.get("conclusion") != "failure":
+                continue
+            name = (step.get("name") or "").lower()
+            # Pattern: "Checkout <branch>-branch" → repair_workflow_branch
+            if "checkout" in name and "branch" in name:
+                return "repair_workflow_branch"
+            if name in ("set up job", "post run actions/checkout"):
+                # GH-side or runner issue; won't fix itself, needs investigation
+                return "investigate"
+    return "investigate"
+
+
+def check_workflow_staleness(
+    repo: str, gh_token: str, target_workflows: Optional[List[str]] = None
+) -> List[Dict[str, Any]]:
+    """
+    Returns a list of findings. Each finding is a dict shaped:
+        {
+            "severity": "CRITICAL" | "WARN",
+            "repo": "Eiasash/Geriatrics",
+            "title": "...",
+            "body": "...",
+            "labels": ["auto-audit", "auto-fix-eligible"],
+            "template": "repair_workflow_branch" | "investigate" | None,
+            "template_args": { ... },
+        }
+
+    `target_workflows`: optional allowlist of workflow file basenames
+        (e.g. ["distractor-autopsy.yml"]). If None, checks all workflows.
+    """
+    findings: List[Dict[str, Any]] = []
+
+    try:
+        wf_list = _gh(f"/repos/{repo}/actions/workflows?per_page=100", gh_token)
+    except urllib.error.HTTPError as e:
+        return [_finding(
+            "WARN", repo, f"Cannot list workflows: HTTP {e.code}",
+            f"GET /actions/workflows returned {e.code}. Check token scope.",
+            template=None,
+        )]
+
+    for wf in wf_list.get("workflows", []):
+        if wf.get("state") != "active":
+            continue
+        wf_name = wf.get("name") or wf.get("path", "?")
+        wf_file = (wf.get("path", "") or "").split("/")[-1]
+        if target_workflows and wf_file not in target_workflows:
+            continue
+        wf_id = wf["id"]
+
+        try:
+            runs = _gh(
+                f"/repos/{repo}/actions/workflows/{wf_id}/runs?per_page=10",
+                gh_token,
+            )
+        except urllib.error.HTTPError:
+            continue
+
+        run_list = runs.get("workflow_runs", [])
+        if not run_list:
+            continue
+
+        latest = run_list[0]
+        conclusion = latest.get("conclusion")  # success | failure | cancelled | skipped | None
+        status = latest.get("status")  # queued | in_progress | completed
+        updated = latest.get("updated_at")
+        run_id = latest.get("id")
+
+        # CASE 1 — latest run failed, and we've been failing for FAIL_AGE_HOURS
+        if conclusion == "failure" and updated:
+            age_h = _hours_since(updated)
+            consec_fail = sum(
+                1 for r in run_list if r.get("conclusion") == "failure"
+            )
+            if age_h >= FAIL_AGE_HOURS:
+                template = "investigate"
+                template_args: Dict[str, Any] = {
+                    "workflow_file": wf_file,
+                    "run_id": run_id,
+                    "branch": latest.get("head_branch"),
+                }
+                # Ask the run for its job/step detail to classify
+                try:
+                    jobs = _gh(
+                        f"/repos/{repo}/actions/runs/{run_id}/jobs", gh_token
+                    )
+                    template = _classify_failure(jobs)
+                    if template == "repair_workflow_branch":
+                        # Try to extract the branch name from the workflow file
+                        # (best effort; auto-fix template will re-parse)
+                        template_args["expected_branch"] = _guess_branch_from_workflow(
+                            repo, wf.get("path", ""), gh_token
+                        )
+                except urllib.error.HTTPError:
+                    pass
+
+                findings.append(_finding(
+                    "CRITICAL", repo,
+                    f"Workflow `{wf_name}` has been failing for {age_h:.1f}h "
+                    f"({consec_fail} consecutive failures)",
+                    f"Last successful run was before {updated}.\n\n"
+                    f"Latest run: https://github.com/{repo}/actions/runs/{run_id}\n\n"
+                    f"Auto-fix template: `{template}`",
+                    template=template,
+                    template_args=template_args,
+                ))
+                continue
+
+        # CASE 2 — workflow is on cron AND last successful run is too old
+        # (we don't know the cron schedule from the API, so use a heuristic:
+        # if the latest run is "completed" and "success" but old, AND the
+        # workflow file mentions schedule/cron, alarm on staleness)
+        if conclusion == "success" and updated:
+            age_h = _hours_since(updated)
+            if age_h >= STALE_AGE_HOURS:
+                # Only alarm if the workflow file declares a schedule
+                if _workflow_has_schedule(repo, wf.get("path", ""), gh_token):
+                    findings.append(_finding(
+                        "CRITICAL", repo,
+                        f"Cron workflow `{wf_name}` last ran {age_h:.1f}h ago — "
+                        f"scheduler likely stopped firing",
+                        f"Latest run was successful but old: {updated}\n"
+                        f"https://github.com/{repo}/actions/runs/{run_id}",
+                        template="investigate",
+                        template_args={"workflow_file": wf_file},
+                    ))
+
+    return findings
+
+
+def _guess_branch_from_workflow(repo: str, wf_path: str, token: str) -> Optional[str]:
+    """Best-effort: pull the workflow file and grep for the branch name."""
+    try:
+        contents = _gh(f"/repos/{repo}/contents/{wf_path}", token)
+        import base64
+        text = base64.b64decode(contents["content"]).decode("utf-8", errors="replace")
+        # Look for `ref: <branch>` or `git checkout <branch>` patterns
+        import re
+        m = re.search(r"\bref:\s*([^\s'\"]+)", text)
+        if m:
+            return m.group(1)
+        m = re.search(r"\bgit checkout (?:-B\s+)?([^\s'\"`]+)", text)
+        if m:
+            return m.group(1)
+    except Exception:
+        pass
+    return None
+
+
+def _workflow_has_schedule(repo: str, wf_path: str, token: str) -> bool:
+    try:
+        contents = _gh(f"/repos/{repo}/contents/{wf_path}", token)
+        import base64
+        text = base64.b64decode(contents["content"]).decode("utf-8", errors="replace")
+        return "schedule:" in text and "cron:" in text
+    except Exception:
+        return False
+
+
+def _finding(
+    severity: str, repo: str, title: str, body: str,
+    template: Optional[str] = None, template_args: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    return {
+        "severity": severity,
+        "repo": repo,
+        "title": title,
+        "body": body,
+        "labels": ["auto-audit", "auto-fix-eligible"] if template else ["auto-audit"],
+        "template": template,
+        "template_args": template_args or {},
+    }
+
+
+if __name__ == "__main__":
+    # Standalone test: probe a single repo, print findings as JSON
+    import sys
+    token = os.environ["GITHUB_TOKEN"]
+    repo = sys.argv[1] if len(sys.argv) > 1 else "Eiasash/Geriatrics"
+    targets = sys.argv[2:] if len(sys.argv) > 2 else None
+    print(json.dumps(check_workflow_staleness(repo, token, targets), indent=2))

--- a/scripts/probes/test_alignment_dispatch.py
+++ b/scripts/probes/test_alignment_dispatch.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+test_alignment_dispatch.py — positive-path verifier for the alignment probe.
+
+Drop in: scripts/probes/test_alignment_dispatch.py
+Run:     python scripts/probes/test_alignment_dispatch.py
+
+What it does:
+  1. Calls probe_distractor_alignment against a known-corrupted SHA
+     (7e893eb — TIS reclassify, pre-v10.45.0, pre-recovery).
+  2. Calls it against current main (known-clean post-v10.45.0).
+  3. Confirms shape, severity, template, label routing, args.
+  4. Confirms the new→old schema adapter inside probe.py produces a
+     finding shape your dispatcher will actually route.
+
+NEVER opens a real issue. NEVER posts to the GH API. Pure in-memory.
+
+Exit code:
+  0 — both paths verified, dispatcher mapping correct, ship it
+  1 — something is wrong, do not push the probe commit
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# Make the probes package importable when this file is run from the repo root
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+try:
+    from probe_distractor_alignment import check_distractor_alignment
+except ImportError as e:
+    print(f"FAIL: cannot import probe — {e}", file=sys.stderr)
+    sys.exit(1)
+
+
+# ─── The schema adapter as wired into probe.py ────────────────────────────
+# Mirror it here so we test the exact mapping. If you edit the adapter in
+# probe.py, edit it here too — keep them in lockstep.
+SEV_MAP = {"CRITICAL": "critical", "WARN": "warning", "ERROR": "error"}
+
+
+def adapt(finding: dict) -> dict:
+    """new→old schema adapter (must match the one in probe.py)."""
+    out = {
+        "severity": SEV_MAP.get(finding["severity"], finding["severity"].lower()),
+        "msg": finding["title"],
+        "body": finding.get("body", ""),
+        "labels": finding.get("labels", []),
+        "kind": finding.get("template"),
+    }
+    if finding.get("template"):
+        out["auto_fix"] = {
+            "template": finding["template"],
+            "args": finding.get("template_args", {}),
+        }
+        out["url"] = (
+            f"https://github.com/{finding['repo']}/blob/main/"
+            "data/distractors.json"
+        )
+    return out
+
+
+# ─── Assertions ───────────────────────────────────────────────────────────
+def expect(cond: bool, label: str, detail: str = "") -> None:
+    """Pretty-printed assertion. Doesn't bail — collects all failures."""
+    mark = "✓" if cond else "✗"
+    line = f"  {mark} {label}"
+    if not cond and detail:
+        line += f"\n      {detail}"
+    print(line)
+    if not cond:
+        FAILURES.append(label)
+
+
+FAILURES: list[str] = []
+
+
+# ─── 1. Negative path — clean main returns no findings ────────────────────
+print("[1/3] Negative path: clean main (post-v10.45.0)")
+clean = check_distractor_alignment("Eiasash/Geriatrics", "main")
+expect(
+    isinstance(clean, list),
+    "returns a list",
+    f"got {type(clean).__name__}",
+)
+expect(
+    len(clean) == 0,
+    "clean main returns []",
+    f"got {len(clean)} findings: "
+    f"{[f.get('title', '?') for f in clean[:3]]}",
+)
+
+
+# ─── 2. Positive path — corrupted SHA returns CRITICAL ────────────────────
+# 7e893eb is the TIS reclassify commit, pre-v10.45.0. Known-corrupted state.
+# If this SHA ever rotates out of the repo (e.g. after a force-push / squash
+# of TIS work), substitute another pre-v10.45.0 commit hash.
+print("\n[2/3] Positive path: known-corrupted SHA (7e893eb / TIS reclassify)")
+corrupt = check_distractor_alignment("Eiasash/Geriatrics", "7e893eb")
+expect(
+    isinstance(corrupt, list) and len(corrupt) == 1,
+    "returns exactly 1 finding",
+    f"got {len(corrupt) if isinstance(corrupt, list) else type(corrupt).__name__}",
+)
+
+if len(corrupt) == 1:
+    f = corrupt[0]
+    expect(f.get("severity") == "CRITICAL", "severity is CRITICAL",
+           f"got {f.get('severity')!r}")
+    expect(f.get("repo") == "Eiasash/Geriatrics", "repo is Geriatrics",
+           f"got {f.get('repo')!r}")
+    expect(
+        f.get("template") == "regenerate_misaligned_distractors",
+        "template is regenerate_misaligned_distractors",
+        f"got {f.get('template')!r}",
+    )
+    expect(
+        "auto-fix-eligible" in f.get("labels", []),
+        "labels include auto-fix-eligible",
+        f"got {f.get('labels')!r}",
+    )
+    expect(
+        "data-corruption" in f.get("labels", []),
+        "labels include data-corruption",
+        f"got {f.get('labels')!r}",
+    )
+    args = f.get("template_args", {})
+    expect(
+        isinstance(args.get("misaligned_count"), int)
+        and args["misaligned_count"] > 1000,
+        "template_args.misaligned_count is a sane integer (>1000)",
+        f"got {args.get('misaligned_count')!r}",
+    )
+    expect(
+        args.get("branch") == "7e893eb",
+        "template_args.branch echoes the input ref",
+        f"got {args.get('branch')!r}",
+    )
+    expect(
+        "Russian" not in f.get("body", "") or len(f.get("body", "")) > 200,
+        "body contains diagnostic detail (samples + counts)",
+        f"body length={len(f.get('body', ''))}",
+    )
+
+
+# ─── 3. Adapter — verify the new→old schema mapping ───────────────────────
+print("\n[3/3] Schema adapter: new probe shape → old probe.py shape")
+if len(corrupt) == 1:
+    adapted = adapt(corrupt[0])
+    expect(
+        adapted.get("severity") == "critical",
+        "adapter lowercases severity",
+        f"got {adapted.get('severity')!r}",
+    )
+    expect(
+        adapted.get("msg") == corrupt[0].get("title"),
+        "adapter renames title→msg",
+    )
+    expect(
+        adapted.get("kind") == "regenerate_misaligned_distractors",
+        "adapter renames template→kind",
+        f"got {adapted.get('kind')!r}",
+    )
+    expect(
+        isinstance(adapted.get("auto_fix"), dict)
+        and adapted["auto_fix"].get("template")
+        == "regenerate_misaligned_distractors",
+        "adapter populates auto_fix.template",
+    )
+    expect(
+        adapted.get("auto_fix", {}).get("args", {}).get("misaligned_count")
+        == corrupt[0]["template_args"]["misaligned_count"],
+        "adapter preserves template_args under auto_fix.args",
+    )
+    expect(
+        adapted.get("url", "").startswith(
+            "https://github.com/Eiasash/Geriatrics/"
+        ) and "data/distractors.json" in adapted.get("url", ""),
+        "adapter attaches debug URL pointing at distractors.json",
+        f"got {adapted.get('url')!r}",
+    )
+
+    # Show the adapted finding so the dispatcher contract is visually obvious
+    print("\n  adapted finding (what probe.py emits to the dispatcher):")
+    print(
+        "\n".join("    " + l for l in json.dumps(
+            adapted, indent=2, ensure_ascii=False
+        ).splitlines()[:20])
+    )
+    if len(json.dumps(adapted)) > 600:
+        print("    ... (truncated)")
+
+
+# ─── Verdict ──────────────────────────────────────────────────────────────
+print()
+if FAILURES:
+    print(f"✗ {len(FAILURES)} check(s) failed:")
+    for f in FAILURES:
+        print(f"    - {f}")
+    print("\nDO NOT push the probe commit until these are resolved.")
+    sys.exit(1)
+else:
+    print("✓ All checks passed. End-to-end positive + negative paths verified.")
+    print("  Probe ready to ship.")
+    sys.exit(0)


### PR DESCRIPTION
Five files (2 auto-fix templates + 2 probes + 1 probe-test) authored as auto-audit additions but staged in this repo's working tree. Committing here to get them out of untracked state.

**The longer-term move:** these belong in `auto-audit/scripts/probes/` and `auto-audit/scripts/auto_fix/` — every file's docstring identifies as an auto-audit Tier 1 or Tier 2 contribution. A follow-up issue should track relocation and wiring into auto-audit's `probe.py` and `auto-fix.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)