### PR TITLE
chore(ci): remove distractor-autopsy schedule trigger (branch deleted)

### DIFF
--- a/.github/workflows/distractor-autopsy.yml
+++ b/.github/workflows/distractor-autopsy.yml
@@ -3,12 +3,20 @@ name: Distractor Autopsy Generator
 # Autonomous bulk-run generator for data/distractors.json.
 # Runs on cowork/distractor-autopsy branch; commits+force-pushes progress each run.
 # Exits no-op if distractors.json is already at 100% coverage.
+#
+# 2026-05-02: schedule trigger REMOVED. The autopsy bulk-gen wave is
+# structurally done (data/distractors.json shipped at 100% coverage in
+# v10.45) and the side branch `cowork/distractor-autopsy` was deleted —
+# every 2h cron fire was failing at the checkout step (HTTP 404), eroding
+# CI signal-to-noise on the Actions UI. The auto-audit
+# `regenerate_misaligned_distractors` template is the modern drift-driven
+# replacement (re-generates only when real misalignment is detected).
+# `workflow_dispatch:` below preserves the option to manually re-arm this
+# workflow if a future structural autopsy is needed (you'd also need to
+# recreate the cowork/distractor-autopsy branch).
 
 on:
   workflow_dispatch:
-  schedule:
-    # Every 2 hours; GHA free tier supports ~6h per job, we cap at 50min
-    - cron: '0 */2 * * *'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Web Claude's read-only health audit caught this on 2026-05-02 — the only red signal across all 5 medical PWAs. Translating the finding into action.

**Problem:** The `Distractor Autopsy Generator` workflow has a 2-hourly cron (\`schedule: '0 */2 * * *'\`) that checks out the side branch \`cowork/distractor-autopsy\`. That branch was deleted after the bulk-gen wave shipped (data/distractors.json reached 100% coverage in v10.45), so every cron fire was failing at the \`actions/checkout\` step with HTTP 404. The same workflow ran green 9 consecutive times today on the identical HEAD SHA before the branch deletion — the SHA didn't change, the branch did.

**Why this matters:** Push CI (CI / Integrity Guard / Pages build & deployment) is all green on HEAD \`0e9e6ec\`. The cron failures are CI noise on the Actions UI, not a product outage — but they erode signal-to-noise and would mask a real failure if one came along.

**Fix:** Remove the \`schedule:\` trigger entirely. \`workflow_dispatch:\` is preserved for manual re-runs if a future structural autopsy is ever needed (which would also require recreating the side branch first).

## Why drop the schedule rather than add a "branch exists?" guard

Web Claude offered both options. Going with the schedule removal because:
1. The autopsy bulk-gen is structurally done — data/distractors.json is at 100% coverage and stable
2. The auto-audit \`regenerate_misaligned_distractors\` template is the modern drift-driven replacement (re-generates only when real misalignment is detected, instead of time-driven bulk-gen on a stable SHA)
3. Time-driven runs on stable code burn Actions minutes for no clinical benefit
4. A guard step would suppress the noise without removing the underlying waste

## Test plan
- [x] YAML parses cleanly (\`python -c "import yaml; yaml.safe_load(open('.github/workflows/distractor-autopsy.yml'))"\`)
- [ ] CI still green after merge
- [ ] No more cron fires every 2h — confirmed via \`gh run list --workflow=distractor-autopsy.yml --limit 5\` after 4-6h
- [ ] Manual \`workflow_dispatch\` still works if needed (smoke-test from Actions UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)