### PR TITLE
v10.64.9: 4 c_accept additions verified by 4-corner audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.8",
+  "version": "10.64.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -6625,8 +6625,12 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.8';
+const APP_VERSION='10.64.9';
 const CHANGELOG={
+'10.64.9':[
+'✅ 4 c_accept additions confirmed against IMA final answer keys via 4-corner verification (stem + all 4 options match PDF Q-section): idx=2506 (2021-Dec Q1 stroke pathophysiology) [2,3]; idx=3221 (2022-Jun-Subspec Q36 dementia case) [1,2]; idx=3249 (2022-Jun-Subspec Q66 HF case) [0,1]; idx=29 (2024-Sep-Basic Q134 FeNa<1%) [0,1,2,3] (IMA-voided). Users picking the "other accepted" letter on these 4 will now see ✓ instead of ✗.',
+'🛡️ Audit-tooling honesty — original c-WRONG audit (192 raw cases) was overturned by stem-verification. Mapping had a systematic +1 shift due to BIDI-induced regex bug ("N\\n?.\\n stem" anchors were missed because regex required digit-period without intervening "?"). After fix: 192 raw → 76 multi-accept-verified + 18 voided-verified + 1 single-c-disagreement (held back for manual review). Spot-checked 3 strict-verified candidates were ALL dataset-correct — applying them would have CORRUPTED right answers. Lesson: matcher reliability ≠ option-text-found-in-PDF; always require stem-anchored 4-corner verification before bulk content edits.',
+],
 '10.64.8':[
 '🩹 4 PDF-confirmed orphan-fragment deletions — labs/calculations without patient stem context. Each was confirmed against the IMA exam PDF the user uploaded; in each case the canonical full version exists in the source PDF but the orphan is just the labs block.',
 '🚀 Major data unlock — user uploaded structured PDF dataset (geriatrics_exam_outputs.zip): 56-PDF inventory mapping each PDF to (track, session, key_version), 1451-row final_answer_keys.csv (post-appeal answers including multi-accept like "א ד"), 712-row sources_extracted.csv (canonical IMA refs), 82-row answer_key_changes.csv (appeal results). Saved to .audit_logs/. Opens up: D phase 3 retags, C v2 ref replacement using IMA-canonical refs, full c-field audit against authoritative key, in-app multi-accept support.',

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.8';
+const CACHE='shlav-a-v10.64.9';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 const FONT_URLS=['fonts/heebo-hebrew-400-normal.woff2','fonts/heebo-hebrew-500-normal.woff2','fonts/heebo-hebrew-600-normal.woff2','fonts/heebo-hebrew-700-normal.woff2','fonts/heebo-latin-400-normal.woff2','fonts/heebo-latin-500-normal.woff2','fonts/heebo-latin-600-normal.woff2','fonts/heebo-latin-700-normal.woff2','fonts/inter-latin-400-normal.woff2','fonts/inter-latin-500-normal.woff2','fonts/inter-latin-600-normal.woff2','fonts/inter-latin-700-normal.woff2'];
 const JSON_DATA_URLS=['data/questions.json','data/topics.json','data/notes.json','data/drugs.json','data/flashcards.json','harrison_chapters.json','data/hazzard_chapters.json','data/grs8_chapters.json','data/grs8_question_pages.json','data/tabs.json','data/question_chapters.json','data/distractors.json','data/regulatory.json','data/syllabus_data.json'];


### PR DESCRIPTION
## Summary
- 4 `c_accept` data updates on questions confirmed by 4-corner verification (stem + all 4 options found in IMA exam PDF Q-section), drawn from `geriatrics_final_answer_keys.csv` post-appeal data.
- Net user impact: users picking the *other* accepted letter on these 4 questions now see ✓ instead of ✗.
- Trinity bumped 10.64.8 → 10.64.9.

## Why so few — important methodology finding
The original answer-key audit produced 192 c-WRONG cases. I built progressively stricter verifiers:
- **v1 (loose, stem-anywhere-in-N→N+1)**: 192 → 18 candidates
- **v2 (strict, anchor-back-walk)**: 192 → 3 candidates
- **Visual PDF check**: All 3 strict candidates were dataset-correct — the matcher had a systematic +1 shift due to a BIDI-induced regex bug (`?\.` followed digit in some Hebrew PDF extractions, defeating my `\d{1,3}\s*\.\s*` anchor pattern). Audit was comparing dataset's Q(N+1) content against IMA's Q(N) answer key.
- **v3 (4-corner: stem + all 4 options + corrected anchor regex)**: 192 → 1 single-c-disagreement (held back for manual review), 76 verified multi-accept, 18 verified voided.

After deduping against existing `c_accept` (already populated on 137 questions in earlier passes): **net 4 changes** (3 new + 1 expansion).

## Changes applied
| idx | Tag, Q# | Topic | Existing c_accept | New c_accept |
|---|---|---|---|---|
| 2506 | 2021-Dec Q1 | Stroke pathophysiology | `[2]` | `[2,3]` |
| 3221 | 2022-Jun-Subspec Q36 | Dementia workup | absent | `[1,2]` |
| 3249 | 2022-Jun-Subspec Q66 | HF management | absent | `[0,1]` |
| 29 | 2024-Sep-Basic Q134 | FeNa<1% (voided) | absent | `[0,1,2,3]` |

App's `isOk(q,i)` already supports `c_accept` — pure data update, no app code changes.

## Test plan
- [x] `npm test` — 1088/1088 pass
- [x] `python3 scripts/check-version-sync.py` — trinity aligned at v10.64.9
- [x] Brace balance + innerHTML safety gates pass
- [ ] Post-merge: GitHub Pages deploy + verify-deploy.sh confirms live page shows v10.64.9

## Memory persistence
Saved `project_geriatrics_qnum_matcher_unreliable.md` to memory documenting the matcher reliability finding so future sessions don't re-attempt bulk c-fixes from the unreliable mapping. Bar for re-attempting: 4-corner verification + per-question manual review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)