### PR TITLE
v10.64.10: 6 more c_accept from rebuilt v2 mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.9",
+  "version": "10.64.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -6625,8 +6625,13 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.9';
+const APP_VERSION='10.64.10';
 const CHANGELOG={
+'10.64.10':[
+'✅ 6 more c_accept additions from v2-mapping audit (mapping rebuilt with stem+all-4-options 4-corner predicate as primary builder, not just verifier; 1162/1334 unique high-confidence mappings, up from 477 strict-verified in v1). Multi-accept expansions: CLL questions idx=2855/3460 [3]→[1,2,3] (IMA accepted Coombs+/leukostasis/AIHA), ABCD2-TIA idx=3271 [1]→[1,3]. Voided post-appeal: 2020 Q97 idx=152/153, 2022-Jun-Subspec Q42 anticholinergic idx=3227.',
+'🔧 Mapping v2 builder hardened — anchor regex `(?:^|[\\s\\n])(\\d{1,3})\\s*[.?]+\\s+` excludes lab-value decimals (no whitespace after dot) and clinical-numeric commas like "40 , סטורציה 85%". Section bounding falls back to next-any-anchor when sequential successor (n+1..n+5) is missing — prevents "section runs to EOF" overmatching. 2024-May-Subspec hits 100% mapping; only 2021-Dec lags at 42% (image-heavy PDF with broken text extraction).',
+'🛡️ Held back 95 c_wrong_single candidates and 593 ref-replacement candidates pending per-question medical review and a separate release. Mapping reliability is high but answer-key disagreements still need expert eyes — IMA keys do contain real errors (see geriatrics_answer_key_changes.csv for 82 appeals) but so does any post-hoc audit.',
+],
 '10.64.9':[
 '✅ 4 c_accept additions confirmed against IMA final answer keys via 4-corner verification (stem + all 4 options match PDF Q-section): idx=2506 (2021-Dec Q1 stroke pathophysiology) [2,3]; idx=3221 (2022-Jun-Subspec Q36 dementia case) [1,2]; idx=3249 (2022-Jun-Subspec Q66 HF case) [0,1]; idx=29 (2024-Sep-Basic Q134 FeNa<1%) [0,1,2,3] (IMA-voided). Users picking the "other accepted" letter on these 4 will now see ✓ instead of ✗.',
 '🛡️ Audit-tooling honesty — original c-WRONG audit (192 raw cases) was overturned by stem-verification. Mapping had a systematic +1 shift due to BIDI-induced regex bug ("N\\n?.\\n stem" anchors were missed because regex required digit-period without intervening "?"). After fix: 192 raw → 76 multi-accept-verified + 18 voided-verified + 1 single-c-disagreement (held back for manual review). Spot-checked 3 strict-verified candidates were ALL dataset-correct — applying them would have CORRUPTED right answers. Lesson: matcher reliability ≠ option-text-found-in-PDF; always require stem-anchored 4-corner verification before bulk content edits.',

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.9';
+const CACHE='shlav-a-v10.64.10';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 const FONT_URLS=['fonts/heebo-hebrew-400-normal.woff2','fonts/heebo-hebrew-500-normal.woff2','fonts/heebo-hebrew-600-normal.woff2','fonts/heebo-hebrew-700-normal.woff2','fonts/heebo-latin-400-normal.woff2','fonts/heebo-latin-500-normal.woff2','fonts/heebo-latin-600-normal.woff2','fonts/heebo-latin-700-normal.woff2','fonts/inter-latin-400-normal.woff2','fonts/inter-latin-500-normal.woff2','fonts/inter-latin-600-normal.woff2','fonts/inter-latin-700-normal.woff2'];
 const JSON_DATA_URLS=['data/questions.json','data/topics.json','data/notes.json','data/drugs.json','data/flashcards.json','harrison_chapters.json','data/hazzard_chapters.json','data/grs8_chapters.json','data/grs8_question_pages.json','data/tabs.json','data/question_chapters.json','data/distractors.json','data/regulatory.json','data/syllabus_data.json'];


### PR DESCRIPTION
## Summary
- 6 `c_accept` additions confirmed by **rebuilt** dataset→Q-num mapping (v2): 3 multi-accept expansions + 3 voided encodings.
- v2 mapping uses 4-corner predicate (stem + all 4 options) as **primary builder**, not just verifier — 1162/1334 unique high-confidence mappings (87%).
- Trinity bumped 10.64.9 → 10.64.10.

## Why a v2 mapping was needed
The v1 mapping (option-text + back-walk) had a systematic +1 shift caused by Hebrew BIDI artifact `N\n?.\n stem` defeating my anchor regex. After the v3 verifier showed only 477 of 1281 mappings as truly trustworthy (down from "96%"), I rebuilt the mapping from scratch using the 4-corner predicate as the builder.

Two anchor-regex hardening passes were needed:
1. `\s*[.?,]+\s+` (require whitespace after punctuation) — excluded lab-value decimals like `4.0-11.0`
2. `\s*[.?]+\s+` (drop comma) — excluded clinical-numeric commas like `40 , סטורציה 85%`

Plus section bounding falls back to next-any-anchor when sequential successor is missing — prevents the "section runs to EOF" bug that mapped 4 different dataset Qs to PDF Q40.

## Per-tag mapping rates
| Tag | Mapped/Total | Rate |
|---|---|---|
| 2020 | 96/100 | 96% |
| 2021-Dec | 44/104 | 42% (image-heavy PDF — known limitation) |
| 2022-Jun-Basic | 147/150 | 98% |
| 2022-Jun-Subspec | 93/95 | 98% |
| 2023-Jun-Basic | 137/141 | 97% |
| 2023-Jun-Subspec | 96/100 | 96% |
| 2024-May-Basic | 147/150 | 98% |
| 2024-May-Subspec | 96/96 | 100% |
| 2024-Sep-Basic | 145/150 | 97% |
| 2024-Sep-Subspec | 96/98 | 98% |
| 2025-Jun-Basic | 146/150 | 97% |

## Changes
| idx | Tag, Q# | Topic | Existing c_accept | New c_accept |
|---|---|---|---|---|
| 2855 | 2024-May-Basic Q84 | CLL features | absent | `[1,2,3]` |
| 3271 | 2022-Jun-Subspec Q91 | ABCD2-TIA | absent | `[1,3]` |
| 3460 | 2024-May-Subspec Q84 | CLL (dup of 2855) | absent | `[1,2,3]` |
| 152 | 2020 Q97 | Aspiration prevention | `[2,3]` | `[0,1,2,3]` |
| 153 | 2020 Q97 (dataset-dup) | — | absent | `[0,1,2,3]` |
| 3227 | 2022-Jun-Subspec Q42 | Anticholinergic strongest | absent | `[0,1,2,3]` |

## Held back (intentional)
- 95 `c_wrong_single` candidates — needs per-question medical review (each could be IMA-key error vs dataset-side intentional update).
- 593 canonical-ref replacements — separate release, citation hygiene.

## Test plan
- [x] `npm test` — 1088/1088 pass
- [x] `python3 scripts/check-version-sync.py` — trinity aligned at v10.64.10
- [ ] Post-merge: GitHub Pages deploy + live page shows v10.64.10

🤖 Generated with [Claude Code](https://claude.com/claude-code)