### PR TITLE
v10.64.12: 501 canonical IMA refs (page-specific)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.11",
+  "version": "10.64.12",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -6625,8 +6625,12 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.11';
+const APP_VERSION='10.64.12';
 const CHANGELOG={
+'10.64.12':[
+'📚 501 questions get canonical IMA-published source citations (page-specific Hazzard / Harrison page+chapter pointers, e.g. "הזארד88 | 1263, 1391" or "הריסון310 | 2305"). Replaces heuristic English chapter-only refs (e.g. "Hazzard Ch 58 — DELIRIUM") with the actual source IMA based the question on. Source: geriatrics_sources_extracted.csv via v2 4-corner mapping (PR #132 infrastructure).',
+'🛡️ 92 corrupted/placeholder canonical refs filtered (PDF row-merge artifacts like "חוקX | X" or "מאמר... | 11 | HAZZARD | 12 | HAZZARD") — those keep their existing English chapter ref. Apply criterion: ref must start with `הזארד` or `הריסון` and not contain row-merge separator `| HAZZARD | ` or `| GRS |`.',
+],
 '10.64.11':[
 '🧹 Orphan triage complete — all 48 *-orphan questions deleted as fragment-duplicates. 47 had canonical-tagged siblings already in dataset (v2 4-corner predicate uniquely matched their content to a specific exam Q-N where a sibling already lives). 1 was AI-hallucinated (4AT "second question" — not in any exam PDF, fabricated content). Net 3791→3743 (-48). Memory note `project_geriatrics_pdf_dataset.md` D-phase-3 task complete.',
 '🔁 Index-coupled JSON files re-keyed: distractors.json, regulatory.json, question_chapters.json all filtered + remapped to dense 0..3742. parserBleedGuard whitelist shifted: {2541,3218,2941,3499} → {2493,3170,2893,3451}. regressionGuards thresholds: 2022/2023-Jun-orphan + 2024-orphan all set to 0; total 3791→3743.',

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.11';
+const CACHE='shlav-a-v10.64.12';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 const FONT_URLS=['fonts/heebo-hebrew-400-normal.woff2','fonts/heebo-hebrew-500-normal.woff2','fonts/heebo-hebrew-600-normal.woff2','fonts/heebo-hebrew-700-normal.woff2','fonts/heebo-latin-400-normal.woff2','fonts/heebo-latin-500-normal.woff2','fonts/heebo-latin-600-normal.woff2','fonts/heebo-latin-700-normal.woff2','fonts/inter-latin-400-normal.woff2','fonts/inter-latin-500-normal.woff2','fonts/inter-latin-600-normal.woff2','fonts/inter-latin-700-normal.woff2'];
 const JSON_DATA_URLS=['data/questions.json','data/topics.json','data/notes.json','data/drugs.json','data/flashcards.json','harrison_chapters.json','data/hazzard_chapters.json','data/grs8_chapters.json','data/grs8_question_pages.json','data/tabs.json','data/question_chapters.json','data/distractors.json','data/regulatory.json','data/syllabus_data.json'];


### PR DESCRIPTION
## Summary
- 501 questions get canonical IMA-published source citations from \`geriatrics_sources_extracted.csv\` via the v2 4-corner mapping (PR #132 infra).
- 92 corrupted PDF-extraction artifacts skipped (kept existing English ref).
- Trinity bumped 10.64.11 → 10.64.12.

## Why
Existing refs were heuristic English chapter pointers like \`"Hazzard Ch 58 — DELIRIUM"\`. The IMA's published source-extracts CSV has the actual reference each question was authored against — page-specific. Replacing gives students direct page pointers like \`"הזארד88 | 1263, 1391"\` (Hazzard ch 88, pages 1263 and 1391) instead of just a chapter title.

## Sample replacements
| Question topic | OLD ref | NEW ref |
|---|---|---|
| Cholangiocarcinoma palliation | \`Hazzard Ch 58 — DELIRIUM ...\` | \`הזארד88 \| 1263, 1391\` |
| SARC-F screening | \`Hazzard Ch 88 — CANCER AND AGING\` | \`הזארד49 \| 734 \| 49-3\` |
| FeNa <1% | \`Hazzard Ch 83 — KIDNEY DISEASES\` | \`הריסון310 \| 2305\` |
| MOCA dementia screening | \`Hazzard Ch 8 — GERIATRIC ASSESSMENT\` | \`הזארד63 \| 984\` |

(The OLD English chapter numbers were sometimes wrong — heuristic match by topic keyword. The NEW Hebrew refs are what IMA actually cited.)

## Filter applied (92 skipped)
Skipped any canonical ref that:
- Doesn't start with \`הזארד\` or \`הריסון\` (excludes laws, GRS, articles — sources where the CSV row-merge corruption is most common)
- Contains row-merge separator \`| HAZZARD |\` or \`| GRS |\` (the merged-cell pattern from the source CSV)
- Is a placeholder like \`חוקX | X\`
- Is shorter than 8 chars

Those questions keep their English chapter ref.

## Test plan
- [x] \`npm test\` — 1088/1088 pass
- [x] Trinity sync at v10.64.12
- [ ] Post-merge: live page shows v10.64.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)