### PR TITLE
v10.64.14: Q-bleed ref cleanup + v3 mapping augmentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.13",
+  "version": "10.64.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -6625,8 +6625,12 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.13';
+const APP_VERSION='10.64.14';
 const CHANGELOG={
+'10.64.14':[
+'🧹 Q-bleed ref cleanup — 6 questions had `ref` fields polluted with PDF table-cell merge artifacts (e.g., "הזארד עמ \' | 695-696 | 24 | GRS- SYNCOPE | 25 | ..."). Cleaned to the per-question portion only ("הזארד עמ \' | 695-696"). Idxs: 2484, 2495, 2929, 3161, 3172, 3490. 1 case (idx=2694) deferred — too many embedded valid pages mixed with bleed.',
+'🗺️ Mapping v3 — augmented v2 dataset→IMA-PDF mapping with 16 new high-confidence entries from the 2026-05-03 cross-specialty bundle parser (which reads 2021-Dec PDF text far better than v2\'s PyMuPDF pass). Net: 1245→1261 mapped, 89→73 unmapped (v3 mapping at .audit_logs/dataset_to_qnum_mapping_v3.json). Cross-check: 13 AGREE with IMA, 1 already-known multi-accept (idx=361 c_accept=[2,3]), 1 medical disagreement flagged for review (idx=346), 1 NO_KEY.',
+],
 '10.64.13':[
 '🛡️ Defensive revert — 15 of v10.64.12\'s 501 canonical Hebrew refs came from ambiguous v2 mappings (multiple PDF Q-N candidates with conflicting canonical refs). Reverted to the topic-correct English chapter ref to avoid potentially-wrong page pointers. Net: 486 page-specific Hebrew refs (still applied), 15 reverted to chapter-only English refs. Spot-check showed at least one revert was right (idx=2810 knee OA had Hazzard ch 80 applied but content is Ch 52 osteoarthritis).',
 '📋 Audit closure: 94 c_wrong_single candidates classified as deliberate curator overrides (NOT bugs). 0 in appeals CSV, 0 explanations support IMA letter, 11 explanations explicitly support dataset letter. Per-session evidence sheets at `.audit_logs/review/{tag}.md` for user reference. NOT auto-applying any flips.',

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.13';
+const CACHE='shlav-a-v10.64.14';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 const FONT_URLS=['fonts/heebo-hebrew-400-normal.woff2','fonts/heebo-hebrew-500-normal.woff2','fonts/heebo-hebrew-600-normal.woff2','fonts/heebo-hebrew-700-normal.woff2','fonts/heebo-latin-400-normal.woff2','fonts/heebo-latin-500-normal.woff2','fonts/heebo-latin-600-normal.woff2','fonts/heebo-latin-700-normal.woff2','fonts/inter-latin-400-normal.woff2','fonts/inter-latin-500-normal.woff2','fonts/inter-latin-600-normal.woff2','fonts/inter-latin-700-normal.woff2'];
 const JSON_DATA_URLS=['data/questions.json','data/topics.json','data/notes.json','data/drugs.json','data/flashcards.json','harrison_chapters.json','data/hazzard_chapters.json','data/grs8_chapters.json','data/grs8_question_pages.json','data/tabs.json','data/question_chapters.json','data/distractors.json','data/regulatory.json','data/syllabus_data.json'];


### PR DESCRIPTION
## Summary

Two workstreams against the Geri-audit queue from `.audit_logs/NEXT_SESSION_BRIEF.md`:

**Mapping augmentation (Workstream 1)** — Replaced the planned Tesseract+OCR approach with the 2026-05-03 cross-specialty bundle's parser, which reads the 2021-Dec PDF far better than v2's PyMuPDF pass (95/100 Qs cleanly extracted with Q-numbers, vs. v2's 42% mapping rate). Built v3 mapping using token-overlap scoring with age-numeric and option-substring weighting. Tuned through false-positive iteration:
- v1 (SequenceMatcher): 1/60 — too strict on paraphrased Hebrew
- v2 (token overlap): 16/60 — surfaced 1 false positive
- v3 (Hebrew-floor + age-anchor + Latin-3-floor): 16 final accepts across all sessions, 0 false positives
- Net: 1245 → 1261 mapped, 89 → 73 unmapped

Cross-check vs IMA final-answer-keys for the 16 augmentations: **13 AGREE, 1 already-known multi-accept** (idx=361 already had `c_accept=[2,3]` set by the curator — confirms the v3 pipeline rediscovers known-good mappings), **1 medical disagreement** flagged (idx=346, candidate curator override per memory rule, NOT auto-flipped), **1 NO_KEY**. No `questions.json` answer changes needed.

**Q-bleed ref cleanup (Workstream 2 — partial closure)** — 145 questions had multi-pipe `ref` fields. Disambiguated into:
- **7 truly Q-bleed corrupted** (PDF table-cell extraction merged adjacent rows): 6 high-quality cleanups applied (idxs 2484, 2495, 2929, 3161, 3172, 3490), 1 deferred (idx=2694 — embedded valid pages mixed with bleed, hand-review needed).
- **138 structured-but-ugly** (legitimate refs like `הזארד49 | 734 | 49-3` = Hazzard ch 49, p. 734, ref idx 49-3): NOT touched — these are beautification candidates, not corruption.

## Verification

- `npm run verify` ✅ all gates pass (trinity, brace balance, innerHTML safety, harrison hebrew baseline)
- 1088/1088 vitest pass
- Round-trip `json.dumps(qs, indent=0)` confirmed byte-identical to source format before applying

## Test plan

- [ ] CI green on this PR
- [ ] After merge: live URL shows v10.64.14 string (per `verify-deploy.sh`)
- [ ] Spot-check 2 of the 6 cleaned refs render correctly in the question-detail UI (idx 2484 and 2929)
- [ ] (Optional) Compare v3 mapping output against `c_wrong_classified.json` to see if any of the 16 newly-mapped Qs land in the curator-override pile

🤖 Generated with [Claude Code](https://claude.com/claude-code)