### PR TITLE
v10.64.15: beautify 391 pipe-delimited canonical refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.14",
+  "version": "10.64.15",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -6625,8 +6625,11 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.14';
+const APP_VERSION='10.64.15';
 const CHANGELOG={
+'10.64.15':[
+'✨ Ref readability — 391 questions had pipe-delimited canonical refs (e.g. "הזארד88 | 1263, 1391") that displayed as cryptic strings to users. Beautified to natural Hebrew form: "הזארד פרק 88, עמ\' 1263, 1391". Patterns covered: הזארד<N> | <pages>, הריסון<N> | <pages>, with optional source-extractor index dropped (e.g. "| 49-3"), and image refs preserved as "(תמונה X-Y)" suffix. 93 complex multi-chapter forms (e.g. "הזארד58 + 15 | 884 + 211") left as-is to preserve cross-chapter info. No content changes — only display formatting of the existing canonical refs.',
+],
 '10.64.14':[
 '🧹 Q-bleed ref cleanup — 6 questions had `ref` fields polluted with PDF table-cell merge artifacts (e.g., "הזארד עמ \' | 695-696 | 24 | GRS- SYNCOPE | 25 | ..."). Cleaned to the per-question portion only ("הזארד עמ \' | 695-696"). Idxs: 2484, 2495, 2929, 3161, 3172, 3490. 1 case (idx=2694) deferred — too many embedded valid pages mixed with bleed.',
 '🗺️ Mapping v3 — augmented v2 dataset→IMA-PDF mapping with 16 new high-confidence entries from the 2026-05-03 cross-specialty bundle parser (which reads 2021-Dec PDF text far better than v2\'s PyMuPDF pass). Net: 1245→1261 mapped, 89→73 unmapped (v3 mapping at .audit_logs/dataset_to_qnum_mapping_v3.json). Cross-check: 13 AGREE with IMA, 1 already-known multi-accept (idx=361 c_accept=[2,3]), 1 medical disagreement flagged for review (idx=346), 1 NO_KEY.',

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.14';
+const CACHE='shlav-a-v10.64.15';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 const FONT_URLS=['fonts/heebo-hebrew-400-normal.woff2','fonts/heebo-hebrew-500-normal.woff2','fonts/heebo-hebrew-600-normal.woff2','fonts/heebo-hebrew-700-normal.woff2','fonts/heebo-latin-400-normal.woff2','fonts/heebo-latin-500-normal.woff2','fonts/heebo-latin-600-normal.woff2','fonts/heebo-latin-700-normal.woff2','fonts/inter-latin-400-normal.woff2','fonts/inter-latin-500-normal.woff2','fonts/inter-latin-600-normal.woff2','fonts/inter-latin-700-normal.woff2'];
 const JSON_DATA_URLS=['data/questions.json','data/topics.json','data/notes.json','data/drugs.json','data/flashcards.json','harrison_chapters.json','data/hazzard_chapters.json','data/grs8_chapters.json','data/grs8_question_pages.json','data/tabs.json','data/question_chapters.json','data/distractors.json','data/regulatory.json','data/syllabus_data.json'];


### PR DESCRIPTION
## Summary

Continuation of the v10.64.14 ref-cleanup workstream. The canonical IMA refs that shipped in v10.64.12 use pipe delimiters as a table-cell artifact (`"הזארד88 | 1263, 1391"`). They render in the UI as cryptic strings. This PR beautifies the 391 simple-pattern cases into natural Hebrew form, leaves 93 complex multi-chapter forms untouched.

| Pattern | Before | After |
|---|---|---|
| Hazzard chapter+pages | `הזארד88 \| 1263, 1391` | `הזארד פרק 88, עמ' 1263, 1391` |
| With source-extractor idx | `הזארד49 \| 734 \| 49-3` | `הזארד פרק 49, עמ' 734` |
| Hazzard amud-only | `הזארד עמ ' \| 695-696` | `הזארד עמ' 695-696` |
| With image ref | `הזארד74 \| 1138-1139 \| תמונה74-5` | `הזארד פרק 74, עמ' 1138-1139 (תמונה74-5)` |
| Harrison chapter+pages | `הריסון39 \| 271 \| 39-1` | `הריסון פרק 39, עמ' 271` |

Source-extractor index segments (e.g., `\| 49-3`) are dropped — they're internal PDF-extraction artifacts, not user-facing references. Image refs preserved as parenthetical suffix.

## What was NOT touched

93 complex multi-chapter forms preserved as-is to avoid info loss:
- `הזארד58 + 15 \| 884 + 211 \| + \| תמונה15-2` (cross-chapter ref)
- `הזארד57, 63 \| 873, 933` (multiple chapters comma-separated)
- `הזארד108 \| 1737-1738 \| גריאטריה בסיס( \| )` (parenthetical context)
- idx=2694 (still the deferred 59-pipe case from v10.64.14)

These need hand-review or richer regex; not worth risk in a bulk pass.

## Verification

- `npm run verify` ✅ all gates pass
- 1088/1088 vitest pass
- 391 of 391 proposals applied with no drift
- Round-trip `json.dumps(qs, indent=0)` byte-identical to source format

## Test plan

- [ ] CI green
- [ ] After merge: live URL shows v10.64.15
- [ ] Spot-check 2 questions render the new form (e.g., open question idx=2 in the UI, see "הזארד פרק 88, עמ' 1263, 1391")

🤖 Generated with [Claude Code](https://claude.com/claude-code)