### PR TITLE
v10.64.16: ref beautification finishing pass (91 of 93)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.15",
+  "version": "10.64.16",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -6625,8 +6625,11 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.15';
+const APP_VERSION='10.64.16';
 const CHANGELOG={
+'10.64.16':[
+'✨ Ref readability finishing pass — 91 of the 93 multi-pipe refs left from v10.64.15 (the complex multi-chapter / Tab-Fig-trailer / glued-Hebrew cases) beautified. Patterns added: multi-chapter `+`/comma forms (e.g. "הזארד58 + 15 | 884 + 211" → "הזארד פרק 58 עמ\' 884 + פרק 15 עמ\' 211"), trailing Tab/Fig/p./תמונה/גרף segments preserved as parenthetical (e.g. "Tab 60-9"), context tags ("גריאטריה בסיס/על"), pages glued to Hebrew law names ("151חוק..." → "עמ\' 151 (חוק...)"). Only 2 truly hand-clean cases left (idx=2694 = 59-pipe nightmare, idx=2758 = parser-bracket artifact). Total beautified across v10.64.15+16: 482/484 multi-pipe refs.',
+],
 '10.64.15':[
 '✨ Ref readability — 391 questions had pipe-delimited canonical refs (e.g. "הזארד88 | 1263, 1391") that displayed as cryptic strings to users. Beautified to natural Hebrew form: "הזארד פרק 88, עמ\' 1263, 1391". Patterns covered: הזארד<N> | <pages>, הריסון<N> | <pages>, with optional source-extractor index dropped (e.g. "| 49-3"), and image refs preserved as "(תמונה X-Y)" suffix. 93 complex multi-chapter forms (e.g. "הזארד58 + 15 | 884 + 211") left as-is to preserve cross-chapter info. No content changes — only display formatting of the existing canonical refs.',
 ],

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.15';
+const CACHE='shlav-a-v10.64.16';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 const FONT_URLS=['fonts/heebo-hebrew-400-normal.woff2','fonts/heebo-hebrew-500-normal.woff2','fonts/heebo-hebrew-600-normal.woff2','fonts/heebo-hebrew-700-normal.woff2','fonts/heebo-latin-400-normal.woff2','fonts/heebo-latin-500-normal.woff2','fonts/heebo-latin-600-normal.woff2','fonts/heebo-latin-700-normal.woff2','fonts/inter-latin-400-normal.woff2','fonts/inter-latin-500-normal.woff2','fonts/inter-latin-600-normal.woff2','fonts/inter-latin-700-normal.woff2'];
 const JSON_DATA_URLS=['data/questions.json','data/topics.json','data/notes.json','data/drugs.json','data/flashcards.json','harrison_chapters.json','data/hazzard_chapters.json','data/grs8_chapters.json','data/grs8_question_pages.json','data/tabs.json','data/question_chapters.json','data/distractors.json','data/regulatory.json','data/syllabus_data.json'];


### PR DESCRIPTION
## Summary

Final pass on the v10.64.15 multi-pipe ref work. Of the 93 untouched complex forms, **91 are now beautified**; only **2 truly-hand-clean cases** remain (idx=2694 = 59-pipe parser nightmare, idx=2758 = parser-bracket artifact).

Cumulative across v10.64.15 + v10.64.16: **482 of 484 multi-pipe refs upgraded (99.6%)**.

## New patterns handled

| Pattern | Before | After |
|---|---|---|
| Multi-chapter `+` | `הזארד58 + 15 \| 884 + 211` | `הזארד פרק 58 עמ' 884 + פרק 15 עמ' 211` |
| Multi-chapter `,` | `הזארד57, 63 \| 873, 933` | `הזארד פרק 57 עמ' 873 + פרק 63 עמ' 933` |
| Trailing Tab | `הזארד60 \| 929 \| Tab 60-9` | `הזארד פרק 60, עמ' 929 (Tab 60-9)` |
| Trailing Fig | `הריסון48 \| 314 \| Fig 48-2` | `הריסון פרק 48, עמ' 314 (Fig 48-2)` |
| Trailing תמונה | `הריסון63 \| 439 \| תמונה63-18` | `הריסון פרק 63, עמ' 439 (תמונה63-18)` |
| Same-chap multi-page `+` | `הזארד43 \| 638 + 641` | `הזארד פרק 43, עמ' 638, 641` |
| Page-glued Hebrew | `הזארד10 \| 151חוק הכשירות...` | `הזארד פרק 10, עמ' 151 (חוק הכשירות...)` |
| Context tag | `הזארד99 \| 1566 \| -גריאטריה בסיס` | `הזארד פרק 99, עמ' 1566 (גריאטריה בסיס)` |
| Year suffix dropped | `הזארד42 \| 620 \| Tab 42-2 \| 2025` | `הזארד פרק 42, עמ' 620 (Tab 42-2)` |
| Tab list | `הריסון128 \| 1033-4 \| 128-8, 128-9` | `הריסון פרק 128, עמ' 1033-4 (Tab 128-8, 128-9)` |

## What's left

| Case | Why deferred |
|---|---|
| idx=2694 | 59-pipe ref bleeds across multiple Q's data — needs hand-review against PDF |
| idx=2758 | `הזארד108 \| 1737-1738 \| גריאטריה בסיס( \| )` — stray parser bracket in middle |

Both are now isolated single-question cases vs. the 484-ref bulk problem we started with.

## Verification

- `npm run verify` ✅
- 1088/1088 vitest pass
- 91 of 91 proposals applied with no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)