### PR TITLE
v10.64.17: GPT audit response — 6 fixes (imgs/SW/CSP/storage/meta)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.16",
+  "version": "10.64.17",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -6,10 +6,8 @@
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <meta name="mobile-web-app-capable" content="yes">
-<meta name="apple-mobile-web-app-capable" content="yes">
-<meta name="mobile-web-app-capable" content="yes">
 <meta name="theme-color" content="#0f172a">
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: blob: https://*.supabase.co https://ima-contentfiles.s3.amazonaws.com https://ima-files.s3.amazonaws.com; connect-src 'self' https://*.supabase.co https://api.anthropic.com https://toranot.netlify.app; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self';">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: blob: https://krmlzwwelqvlfslwltol.supabase.co https://ima-contentfiles.s3.amazonaws.com https://ima-files.s3.amazonaws.com; connect-src 'self' https://krmlzwwelqvlfslwltol.supabase.co https://api.anthropic.com https://toranot.netlify.app; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self';">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🩺</text></svg>">
 <link rel="manifest" href="manifest.json">
 <!-- v10.63.7 LCP fix: kick off the 7MB questions.json fetch at HTML-parse time
@@ -6625,8 +6623,15 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.16';
+const APP_VERSION='10.64.17';
 const CHANGELOG={
+'10.64.17':[
+'🖼️ Image rendering fix — 16 questions had `imgs:[url]` (Supabase-hosted exam figures) but no `q.img`, and the render path only checked `q.img`. They displayed text-only — diagnose-the-invisible-lesion. Normalized: all 16 now have `q.img` set. Affects subspecialty image questions: wounds, X-rays, neuro images, ECGs.',
+'🛡️ Service worker robustness — `cache.addAll(ALL_URLS)` was all-or-nothing; one missing optional asset (font/icon/JSON) aborted the entire SW install. Split into CRITICAL_URLS (app shell — must succeed) + best-effort `Promise.allSettled` for optional assets. Plus the IDB open in background-sync no longer pins version=1 (would `VersionError` on schema migration), and there\'s an objectStore guard.',
+'🔒 Supabase origin pinning — both CSP (`img-src` + `connect-src`) and the SW background-sync allowlist now require the exact project origin `krmlzwwelqvlfslwltol.supabase.co`, not the wildcard `*.supabase.co`. Closes a potential exfiltration path: a compromised same-origin script could have queued a POST to an attacker-controlled Supabase project (still has the apikey header attached).',
+'💾 Corrupt-LS quarantine — `lsGet()` previously deleted any key whose JSON failed to parse, which meant one bad write could permanently destroy user study progress (`samega`, `samega_ex`, `shlav_q_images`). Now copies the corrupt value to `<key>.corrupt.<ts>` before clearing — recoverable.',
+'🧹 Mobile meta cleanup — `apple-mobile-web-app-capable` and `mobile-web-app-capable` were each declared twice. Dedup\'d.',
+],
 '10.64.16':[
 '✨ Ref readability finishing pass — 91 of the 93 multi-pipe refs left from v10.64.15 (the complex multi-chapter / Tab-Fig-trailer / glued-Hebrew cases) beautified. Patterns added: multi-chapter `+`/comma forms (e.g. "הזארד58 + 15 | 884 + 211" → "הזארד פרק 58 עמ\' 884 + פרק 15 עמ\' 211"), trailing Tab/Fig/p./תמונה/גרף segments preserved as parenthetical (e.g. "Tab 60-9"), context tags ("גריאטריה בסיס/על"), pages glued to Hebrew law names ("151חוק..." → "עמ\' 151 (חוק...)"). Only 2 truly hand-clean cases left (idx=2694 = 59-pipe nightmare, idx=2758 = parser-bracket artifact). Total beautified across v10.64.15+16: 482/484 multi-pipe refs.',
 ],

--- a/src/storage.js
+++ b/src/storage.js
@@ -10,7 +10,17 @@
  */
 function lsGet(key, fallback) {
   try { return JSON.parse(localStorage.getItem(key)) ?? fallback; }
-  catch(e) { localStorage.removeItem(key); return fallback; }
+  catch(e) {
+    // Quarantine corrupt data under a timestamped key instead of deleting it —
+    // sacred keys (`samega`, `samega_ex`, `shlav_q_images`) carry user study
+    // progress; one bad write should not become permanent data loss.
+    try {
+      const raw = localStorage.getItem(key);
+      if (raw != null) localStorage.setItem(`${key}.corrupt.${Date.now()}`, raw);
+      localStorage.removeItem(key);
+    } catch (_) { /* quota or read-blocked — give up gracefully */ }
+    return fallback;
+  }
 }
 
 /**

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,9 @@
-const CACHE='shlav-a-v10.64.16';
+const CACHE='shlav-a-v10.64.17';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
+// CRITICAL_URLS = the bare-minimum app shell required for offline boot.
+// Anything else (data/*.json, fonts, icons, study-plan helpers) is best-effort
+// in the install handler — a missing optional asset must not abort install.
+const CRITICAL_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','src/storage.js','src/sw-update.js'];
 const FONT_URLS=['fonts/heebo-hebrew-400-normal.woff2','fonts/heebo-hebrew-500-normal.woff2','fonts/heebo-hebrew-600-normal.woff2','fonts/heebo-hebrew-700-normal.woff2','fonts/heebo-latin-400-normal.woff2','fonts/heebo-latin-500-normal.woff2','fonts/heebo-latin-600-normal.woff2','fonts/heebo-latin-700-normal.woff2','fonts/inter-latin-400-normal.woff2','fonts/inter-latin-500-normal.woff2','fonts/inter-latin-600-normal.woff2','fonts/inter-latin-700-normal.woff2'];
 const JSON_DATA_URLS=['data/questions.json','data/topics.json','data/notes.json','data/drugs.json','data/flashcards.json','harrison_chapters.json','data/hazzard_chapters.json','data/grs8_chapters.json','data/grs8_question_pages.json','data/tabs.json','data/question_chapters.json','data/distractors.json','data/regulatory.json','data/syllabus_data.json'];
 const ALL_URLS=[...HTML_URLS,...JSON_DATA_URLS,...FONT_URLS];
@@ -22,7 +26,18 @@ function trimCache(cacheName,max){
   }));
 }
 
-self.addEventListener('install',e=>e.waitUntil(caches.open(CACHE).then(c=>c.addAll(ALL_URLS)).then(()=>self.skipWaiting())));
+// Install: critical shell must succeed; everything else is best-effort.
+// Previously a single missing icon/font/data file aborted the whole install
+// (cache.addAll is all-or-nothing per spec).
+const OPTIONAL_URLS=ALL_URLS.filter(u=>!CRITICAL_URLS.includes(u));
+self.addEventListener('install',e=>e.waitUntil(
+  caches.open(CACHE).then(async cache=>{
+    await cache.addAll(CRITICAL_URLS);
+    await Promise.allSettled(OPTIONAL_URLS.map(async url=>{
+      try{const res=await fetch(url);if(res.ok)await cache.put(url,res);}catch(_){}
+    }));
+  }).then(()=>self.skipWaiting())
+));
 self.addEventListener('activate',e=>e.waitUntil(
   caches.keys().then(ks=>Promise.all(
     // Preserve IMG_CACHE + PDF_CACHE across version bumps (on-demand LRU caches,
@@ -120,19 +135,24 @@ if(e.tag==='supabase-backup'){
 e.waitUntil(
 (async()=>{
 try{
+// Open IDB without a version — the SW shouldn't trigger an upgrade and
+// shouldn't fail with VersionError if the main thread bumps schema version.
 const db=await new Promise((resolve,reject)=>{
-const req=indexedDB.open('shlav_mega_db',1);
+const req=indexedDB.open('shlav_mega_db');
 req.onsuccess=ev=>resolve(ev.target.result);
 req.onerror=ev=>reject(ev.target.error);
 });
+if(!db.objectStoreNames.contains('state')){db.close();return;}
 const tx=db.transaction('state','readonly');
 const req=tx.objectStore('state').get('pending_sync');
 const data=await new Promise(r=>{req.onsuccess=()=>r(req.result);req.onerror=()=>r(null);});
 if(data&&data.url&&data.body){
-// Whitelist Supabase REST hosts — IDB is writable by any same-origin script,
-// so a compromised tab could otherwise redirect the queued POST (with the
-// apikey header attached) to an attacker-controlled URL.
-const _supaOk=/^https:\/\/[a-z0-9-]+\.supabase\.co\/rest\/v1\//i.test(data.url);
+// Pin to the actual project origin — wildcard *.supabase.co would still allow
+// exfiltration to an attacker-controlled Supabase project if a compromised
+// same-origin script poisoned pending_sync.
+const SUPABASE_ORIGIN='https://krmlzwwelqvlfslwltol.supabase.co';
+let _supaOk=false;
+try{const u=new URL(data.url);_supaOk=(u.origin===SUPABASE_ORIGIN&&u.pathname.startsWith('/rest/v1/'));}catch(_){}
 if(!_supaOk){console.warn('Background sync: refusing non-Supabase url',data.url);return;}
 const res=await fetch(data.url,{method:'POST',headers:{'Content-Type':'application/json','apikey':data.apikey||''},body:JSON.stringify(data.body)});
 if(res.ok){

--- a/tests/coverageGaps.test.js
+++ b/tests/coverageGaps.test.js
@@ -158,8 +158,11 @@ describe('SRS / FSRS Edge Cases', () => {
 });
 
 describe('Content Security Policy', () => {
-  it('CSP allows Supabase connections', () => {
-    expect(html).toContain('https://*.supabase.co');
+  it('CSP allows Supabase connections (origin-pinned to project, v10.64.17)', () => {
+    // Was wildcard `*.supabase.co` until v10.64.17; pinned to the actual project
+    // origin to close exfiltration paths via attacker-controlled Supabase projects.
+    expect(html).toContain('https://krmlzwwelqvlfslwltol.supabase.co');
+    expect(html).not.toContain('https://*.supabase.co');
   });
 
   it('CSP allows Anthropic API', () => {

--- a/tests/expandedDataIntegrity.test.js
+++ b/tests/expandedDataIntegrity.test.js
@@ -382,6 +382,16 @@ describe("questions/image_map.json — integrity", () => {
 describe("questions.json — image field (img) validation", () => {
   const SUPA_IMG_PREFIX = "https://krmlzwwelqvlfslwltol.supabase.co/storage/v1/object/public/question-images/";
 
+  it("no question has q.imgs[] without q.img (renderer reads q.img only — v10.64.17)", () => {
+    const offenders = [];
+    questions.forEach((q, i) => {
+      if (Array.isArray(q.imgs) && q.imgs.length > 0 && !q.img) {
+        offenders.push({ index: i, imgs0: String(q.imgs[0]).slice(0, 80) });
+      }
+    });
+    expect(offenders, `Questions with imgs[] but no img — renderer will skip image: ${JSON.stringify(offenders.slice(0, 5))}`).toEqual([]);
+  });
+
   it("img field, when present, is a valid URL string (https or data:image/svg+xml)", () => {
     const invalid = [];
     questions.forEach((q, i) => {


### PR DESCRIPTION
## Summary

Responding to a fresh external audit (GPT) of the v10.64.16 state. **6 of 7 verified findings fixed** in this PR; 1 deferred for cross-repo coordination.

## Fixes

| Severity | Finding | Fix |
|---|---|---|
| **HIGH** | 16 questions with `imgs:[url]` rendered text-only | Normalized: set `q.img = imgs[0]`; added regression test |
| **MED** | SW install was all-or-nothing on missing optional assets | Split into `CRITICAL_URLS` + `Promise.allSettled` for rest |
| **MED** | SW IDB open pinned to version=1 | Removed version arg; added objectStore guard |
| **MED** | CSP + SW allowlist wildcard `*.supabase.co` | Pinned to project origin `krmlzwwelqvlfslwltol.supabase.co` |
| **LOW** | `lsGet()` deleted corrupt data permanently | Quarantine to `<key>.corrupt.<ts>` before clearing |
| **LOW** | Duplicate mobile-web-app meta tags | Dedup'd |

## Deferred (NOT in this PR)

| Finding | Reason |
|---|---|
| `syllabus_data.json` stale (3833 vs 3743 + per-topic counts) | The JS↔Python fixture in `tests/studyPlanAlgorithm.test.js` asserts specific freq/hour vectors derived from a Python reference (`auto-audit/scripts/generate_study_plan.py`). Updating syllabus alone breaks 3 fixture tests; coordinated cross-repo Python regen needed. Recorded in `NEXT_SESSION_BRIEF.md`. |

## Findings I pushed back on

- GPT's HIGH#3 ("audit ZIP missing icons + image_map.json") was about my local audit-bundle script, not the repo. Repo has all those files; my `.audit_logs/build_audit_bundle.py` excluded `icons/` and `questions/` dirs. Will fix the bundler separately.
- `audit_tis_picks.py` noise (1990 false positives) — internal tooling not user-facing; out of scope for this PR.
- 5-option GRS8 schema doc drift — no user impact (`isOk(q,i)` already handles dynamic option counts); doc-only, deferred.

## Verification

- `npm run verify` ✅
- 1089/1089 vitest pass (added 1 new test for `q.imgs` regression)
- Trinity at 10.64.17

## Test plan

- [ ] CI green
- [ ] After merge: live URL shows v10.64.17
- [ ] Spot-check: open one of idxs [3246, 3263, 3264, 3266, 3280] in the UI and confirm the image renders
- [ ] Open DevTools → Application → Service Workers → confirm SW activates without `cache.addAll` failure
- [ ] DevTools → Application → Local Storage → manually corrupt `samega` JSON, reload, confirm `samega.corrupt.<ts>` appears + app boots from fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)