### PR TITLE
v10.64.21: final 2 multi-pipe ref hand-cleans (484→0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.20",
+  "version": "10.64.21",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -6629,8 +6629,11 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.20';
+const APP_VERSION='10.64.21';
 const CHANGELOG={
+'10.64.21':[
+'🧹 Final 2 multi-pipe ref hand-cleans — idx=2694 (DKA vs HHS in elderly, the 59-pipe parser nightmare): set to `הזארד פרק 99 (Diabetes Mellitus)`. idx=2758 (COVID-19): cleaned `הזארד108 | 1737-1738 | גריאטריה בסיס( | )` → `הזארד פרק 108, עמ\' 1737-1738 (גריאטריה בסיס)`. Multi-pipe ref count now 0 (was 484 at session start).',
+],
 '10.64.20':[
 '🧹 lsSet migration completion — 3 remaining bare `localStorage.setItem` calls on sacred keys (samega_ex line 2152, samega_mock_hist + samega_sessions in cloud-restore path lines 6340-6341) migrated to lsSet(). The migration started in v10.64.17 (helper) → v10.64.19 (6 main paths) is now 100% complete; no sacred-key write swallows iOS Safari quota errors silently.',
 ],

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.20';
+const CACHE='shlav-a-v10.64.21';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 // CRITICAL_URLS = the bare-minimum app shell required for offline boot.
 // Anything else (data/*.json, fonts, icons) is best-effort in the install


### PR DESCRIPTION
Hand-fixes the 2 ref cases left from v10.64.16's beautification pass.

| idx | Q | Before | After |
|---:|---|---|---|
| 2694 | DKA vs HHS in elderly | 59-pipe parser nightmare | `הזארד פרק 99 (Diabetes Mellitus)` |
| 2758 | COVID-19 | `הזארד108 \| 1737-1738 \| גריאטריה בסיס( \| )` | `הזארד פרק 108, עמ' 1737-1738 (גריאטריה בסיס)` |

After this PR, **0 multi-pipe refs remain in the bank** (was 484 at session start).

Tests 1091/1091. Trinity v10.64.21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)