### PR TITLE
v10.64.22: remapExplanationLetters fix — bare label refs (the "אקו (תשובה ב')" bug)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.21",
+  "version": "10.64.22",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -2742,18 +2742,30 @@ function isMetaOption(text){
 function remapExplanationLetters(text,shuf){
   // shuf[displayPos]=origIdx → build inverse: origIdx→displayPos
   const inv={};shuf.forEach((orig,disp)=>{inv[orig]=disp;});
-  const letters=['A','B','C','D','E'];
+  const latin=['A','B','C','D','E'];
   const heb=['א','ב','ג','ד','ה'];
-  // Replace patterns like "התשובה הנכונה היא C" or "תשובה A" or "Answer B"
-  return text.replace(/\b([A-E])\b/g,(m,letter)=>{
-    const origIdx=letters.indexOf(letter);
-    if(origIdx===-1||inv[origIdx]===undefined)return m;
-    return letters[inv[origIdx]];
-  }).replace(/(תשובה\s*)([א-ה])\b/g,(m,prefix,letter)=>{
-    const origIdx=heb.indexOf(letter);
-    if(origIdx===-1||inv[origIdx]===undefined)return m;
-    return prefix+heb[inv[origIdx]];
-  });
+  const remap=(orig,arr)=>{
+    const i=arr.indexOf(orig);
+    if(i===-1||inv[i]===undefined)return orig;
+    return arr[inv[i]];
+  };
+  // (1) Latin "B"/"Answer C" — ASCII word boundaries work fine here.
+  // (2) Hebrew "תשובה ב'" form — letter directly after "תשובה" + optional whitespace.
+  // (3) Hebrew bare label "א'/ג'/ד' שגויה" — letter+geresh used as bullet label.
+  //     Lookbehind (?<![א-ת]) excludes mid-word gershayim like "מג'ורי" (Major)
+  //     where Hebrew letters precede the apostrophe. Lookahead requires geresh
+  //     followed by whitespace/punct/EOL so foreign-sound markers like
+  //     "ג'נטיקה" (genetics — letter+geresh+more Hebrew) are also rejected.
+  // Single regex with alternation prevents double-remap of the same letter.
+  // v10.64.22 — was missing form (3), making explanations show wrong letter
+  //   refs whenever the option-shuffle moved labels (e.g., "אקו (תשובה ב')"
+  //   stayed as ב' even after echo got shuffled to display position ד').
+  return text
+    .replace(/\b([A-E])\b/g,(m,l)=>remap(l,latin))
+    .replace(
+      /(?:(תשובה\s*)([א-ה])(?=['׳’]|[\s.,;:!?)]|$)|(?<![א-ת])([א-ה])(['׳’])(?=[\s.,;:!?)]|$))/g,
+      (m,p,l1,l2,ger)=>p?p+remap(l1,heb):remap(l2,heb)+ger
+    );
 }
 function getOptShuffle(qIdx,q){
   // Return stable shuffle for this question in this session
@@ -6629,8 +6641,11 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.21';
+const APP_VERSION='10.64.22';
 const CHANGELOG={
+'10.64.22':[
+'🔤 Major fix — `remapExplanationLetters` now remaps BARE label forms ("**א\' שגויה**", "ב\' נכונה") in addition to the "תשובה X\'" form. Before this, when option-shuffle moved the correct answer to a different display position (e.g. orig ב=echo → display ד=echo), the explanation still said "תשובה ב\'" and "א\'/ג\'/ד\' שגויה" referring to ORIGINAL positions — users saw wrong letter cross-references everywhere. Repro: 2024-May-Basic Q1 (idx=2841 stroke / MCA / cardio-embolic). Affected ~1779 explanations using bare label form across the bank. Lookbehind excludes mid-word gershayim ("מג\'ורי", "ג\'נטיקה") so foreign-sound markers are untouched. 8 new regression tests in tests/remapExplanationLetters.test.js. Same bug exists in IM + FM (porting separately).',
+],
 '10.64.21':[
 '🧹 Final 2 multi-pipe ref hand-cleans — idx=2694 (DKA vs HHS in elderly, the 59-pipe parser nightmare): set to `הזארד פרק 99 (Diabetes Mellitus)`. idx=2758 (COVID-19): cleaned `הזארד108 | 1737-1738 | גריאטריה בסיס( | )` → `הזארד פרק 108, עמ\' 1737-1738 (גריאטריה בסיס)`. Multi-pipe ref count now 0 (was 484 at session start).',
 ],

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.21';
+const CACHE='shlav-a-v10.64.22';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 // CRITICAL_URLS = the bare-minimum app shell required for offline boot.
 // Anything else (data/*.json, fonts, icons) is best-effort in the install

--- a/tests/remapExplanationLetters.test.js
+++ b/tests/remapExplanationLetters.test.js
@@ -1,0 +1,113 @@
+/**
+ * v10.64.22 regression: remapExplanationLetters must remap option-letter
+ * references in explanations after option shuffle, including BARE LABEL
+ * forms like "א' שגויה" / "ב' נכונה" (not just the "תשובה X" form).
+ *
+ * Original bug: the regex only caught (תשובה\s*)([א-ה])\b which misses:
+ *   - bare bullet labels: "**א' שגויה** — ..."
+ *   - JS \b after Hebrew is unreliable (Hebrew chars not in ASCII \w)
+ *
+ * Real-world impact: explanations showed wrong option letter references
+ * whenever options got shuffled. Example from idx=2841 (2024-May-Basic
+ * stroke Q): the dataset's correct answer is "echo" at orig position ב=1.
+ * After display shuffle, echo lands at display position ד=3. The
+ * explanation said "אקו (תשובה ב')" but the user sees ECHO under ד —
+ * mismatch, confusing.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+let remapExplanationLetters;
+
+beforeAll(() => {
+  // Extract the function from the monolith via a function-string snapshot.
+  const html = readFileSync(resolve(import.meta.dirname, "..", "shlav-a-mega.html"), "utf-8");
+  const m = html.match(/function remapExplanationLetters\(text,shuf\)\{[\s\S]+?\n\}/);
+  if (!m) throw new Error("remapExplanationLetters not found in shlav-a-mega.html");
+  // eslint-disable-next-line no-new-func
+  remapExplanationLetters = new Function(`${m[0]}\nreturn remapExplanationLetters;`)();
+});
+
+describe("remapExplanationLetters — v10.64.22 fix", () => {
+  // identity shuffle: orig 0,1,2,3 → display 0,1,2,3 — no remap should occur
+  const identity = [0, 1, 2, 3];
+
+  it("identity shuffle leaves text unchanged", () => {
+    const text = "התשובה הנכונה היא ב'. א' שגויה. Answer C.";
+    expect(remapExplanationLetters(text, identity)).toBe(text);
+  });
+
+  it("does not remap mid-word gershayim like \"מג'ורי\" (Major)", () => {
+    const swap = [1, 0, 2, 3]; // א<>ב swap
+    const text = "מאופיין על ידי דיכאון מג'ורי (Major Depression)";
+    expect(remapExplanationLetters(text, swap)).toBe(text);
+  });
+
+  it("does not remap foreign-sound-at-word-start like \"ג'נטיקה\" (genetics)", () => {
+    const swap = [1, 0, 2, 3];
+    const text = "ג'נטיקה היא חשובה";
+    expect(remapExplanationLetters(text, swap)).toBe(text);
+  });
+
+  it("remaps \"תשובה ב'\" form when option shuffled", () => {
+    // shuf[disp]=orig: display position 3 holds original ב (idx=1). So inv[1]=3.
+    const shuf = [3, 2, 0, 1];
+    const text = "האפשרות הנכונה היא תשובה ב'.";
+    const result = remapExplanationLetters(text, shuf);
+    expect(result).toContain("תשובה ד'");
+    expect(result).not.toContain("תשובה ב'");
+  });
+
+  it("remaps bare label \"א' שגויה\" form when option shuffled", () => {
+    // shuf[0]=3 → inv[3]=0; shuf[2]=0 → inv[0]=2
+    const shuf = [3, 2, 0, 1];
+    const text = "- **א' שגויה** — דופלר צוואר רלוונטי\n- **ד' שגויה** — אנטיקואגולציה";
+    const result = remapExplanationLetters(text, shuf);
+    // א (orig 0) → display 2 = ג; ד (orig 3) → display 0 = א
+    expect(result).toContain("ג' שגויה");
+    expect(result).toContain("א' שגויה");
+    expect(result).not.toMatch(/^- \*\*א' שגויה\*\* — דופלר/m);
+  });
+
+  it("remaps Latin standalone letters: \"Answer A\" / \"B is correct\"", () => {
+    // shuf[disp]=orig: [2,0,1,3] → display 0 holds C, display 1 holds A, etc.
+    // So inv[origA=0]=1=B, inv[origB=1]=2=C, inv[origC=2]=0=A.
+    const shuf = [2, 0, 1, 3];
+    expect(remapExplanationLetters("The answer is A.", shuf)).toBe("The answer is B.");
+    expect(remapExplanationLetters("Choice B is correct.", shuf)).toBe("Choice C is correct.");
+    expect(remapExplanationLetters("Option C is wrong.", shuf)).toBe("Option A is wrong.");
+  });
+
+  it("does not double-remap a letter in alternated patterns", () => {
+    // "תשובה ב'" — first branch matches "תשובה ב", consumes through ב.
+    // The trailing geresh + lookbehind keeps the second branch from firing.
+    const swap = [1, 0, 2, 3]; // א<>ב swap
+    const text = "תשובה ב' היא הנכונה";
+    const result = remapExplanationLetters(text, swap);
+    expect(result).toBe("תשובה א' היא הנכונה");
+  });
+
+  it("end-to-end on the v10.64.22 bug case (idx=2841 stroke explanation)", () => {
+    // Dataset original order: [doppler, echo*, no-CT, anticoag] (c=1=echo)
+    // Display shuffle puts: [anticoag, no-CT, doppler, echo] (echo at pos 3)
+    // shuf[disp]=orig: [3, 2, 0, 1]
+    const shuf = [3, 2, 0, 1];
+    const e = `
+לכן **אקו-לב (תשובה ב')** היא הבדיקה החשובה ביותר.
+
+- **א' שגויה** — דופלר צוואר רלוונטי לאתרוסקלרוזיס.
+- **ג' שגויה** — חובה לשלול דימום ב-CT.
+- **ד' שגויה** — אנטיקואגולציה לא מתחילים אוטומטית.
+`.trim();
+    const result = remapExplanationLetters(e, shuf);
+    // The correct answer (echo) was orig ב=1 → display ד=3
+    expect(result).toContain("תשובה ד'");
+    // Doppler (orig א=0) → display ג=2
+    expect(result).toContain("ג' שגויה");
+    // No-CT (orig ג=2) → display ב=1
+    expect(result).toContain("ב' שגויה");
+    // Anticoag (orig ד=3) → display א=0
+    expect(result).toContain("א' שגויה");
+  });
+});


### PR DESCRIPTION
User reported a discrepancy in 2024-May-Basic Q1 (idx=2841 stroke / MCA / cardio-embolic): the explanation said "אקו (תשובה ב')" but display shows echo at position ד. Bullet refs ("א' שגויה — דופלר", "ד' שגויה — anticoag") also pointed to ORIGINAL positions, confusing users.

## Root cause

`remapExplanationLetters` regex `/(תשובה\s*)([א-ה])\b/` caught only the explicit **"תשובה X"** form. Two big misses:

1. **Bare bullet labels** like `**א' שגויה**` (~1,779 hits across Geri's explanations) — letter+geresh form used in option breakdown lists. Never matched the old regex.
2. **JS \b after Hebrew chars** is unreliable since Hebrew letters aren't in ASCII `\w`.

## Fix

Single-pass regex with two-branch alternation:

```js
.replace(
  /(?:(תשובה\s*)([א-ה])(?=['’׳]|[\s.,;:!?)]|$)|(?<![א-ת])([א-ה])(['’׳])(?=[\s.,;:!?)]|$))/g,
  (m, p, l1, l2, ger) => p ? p + remap(l1, heb) : remap(l2, heb) + ger
)
```

Lookbehind `(?<![א-ת])` excludes mid-word gershayim — `מג'ורי` (Major), `ג'נטיקה` (genetics) and similar foreign-sound markers stay untouched. Single-pass with alternation prevents double-remap of the same letter.

## Verified end-to-end on the user's bug case

Original explanation:
```
לכן **אקו-לב (תשובה ב')** היא הבדיקה החשובה ביותר.
- **א' שגויה** — דופלר צוואר רלוונטי לאתרוסקלרוזיס.
- **ג' שגויה** — חובה לשלול דימום ב-CT.
- **ד' שגויה** — אנטיקואגולציה לא מתחילים אוטומטית.
```

After display shuffle (orig ב=echo → display ד), now correctly reads:
```
לכן **אקו-לב (תשובה ד')** היא הבדיקה החשובה ביותר.
- **ג' שגויה** — דופלר צוואר רלוונטי לאתרוסקלרוזיס.   (orig א → display ג)
- **ב' שגויה** — חובה לשלול דימום ב-CT.                 (orig ג → display ב)
- **א' שגויה** — אנטיקואגולציה לא מתחילים אוטומטית.    (orig ד → display א)
```

## 8 new regression tests

- identity shuffle (no-op)
- mid-word gershayim `מג'ורי` (must NOT touch)
- foreign-sound at word start `ג'נטיקה` (must NOT touch)
- `תשובה ב'` form remap
- bare `א' שגויה` label remap
- Latin `Answer A` / `Choice B` / `Option C`
- no double-remap in alternated patterns
- end-to-end on the actual idx=2841 explanation

## Sibling repos

Same bug exists in:
- `InternalMedicine/src/core/utils.js:55`
- `FamilyMedicine/src/core/utils.js:55`

Porting fix in separate PRs (next).

## Verification

- `npm run verify` ✅
- 1099/1099 vitest pass (1091 + 8 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)