### PR TITLE
v10.64.23: remap lookahead generalized — catches "תשובה אcorrect"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.22",
+  "version": "10.64.23",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -2760,10 +2760,15 @@ function remapExplanationLetters(text,shuf){
   // v10.64.22 — was missing form (3), making explanations show wrong letter
   //   refs whenever the option-shuffle moved labels (e.g., "אקו (תשובה ב')"
   //   stayed as ב' even after echo got shuffled to display position ד').
+  // Lookahead `(?=[^א-ת]|$)` = "next char is not a Hebrew letter (or EOL)".
+  // Catches: geresh `'`, whitespace, ASCII letters, punct, EOL.
+  // Excludes: another Hebrew letter (so "תשובה בא" / "ג'נטיקה" stay untouched).
+  // Generalized in v10.64.23 — was a narrower char class missing
+  // "תשובה אcorrect" form (Hebrew letter directly followed by Latin).
   return text
     .replace(/\b([A-E])\b/g,(m,l)=>remap(l,latin))
     .replace(
-      /(?:(תשובה\s*)([א-ה])(?=['׳’]|[\s.,;:!?)]|$)|(?<![א-ת])([א-ה])(['׳’])(?=[\s.,;:!?)]|$))/g,
+      /(?:(תשובה\s*)([א-ה])(?=[^א-ת]|$)|(?<![א-ת])([א-ה])(['׳’])(?=[^א-ת]|$))/g,
       (m,p,l1,l2,ger)=>p?p+remap(l1,heb):remap(l2,heb)+ger
     );
 }
@@ -6641,8 +6646,11 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.22';
+const APP_VERSION='10.64.23';
 const CHANGELOG={
+'10.64.23':[
+'🔤 remapExplanationLetters lookahead generalized — v10.64.22 used a narrower char class `[\\s.,;:!?)]` for the post-letter context, missing "תשובה אcorrect" (Hebrew letter directly followed by ASCII letter, no separator). FM\'s existing utilsExtras tests caught this; backporting the broader `(?=[^א-ת]|$)` lookahead here. Same semantic intent — accept anything-not-Hebrew (or EOL) — just covers more cases. 2 new tests added.',
+],
 '10.64.22':[
 '🔤 Major fix — `remapExplanationLetters` now remaps BARE label forms ("**א\' שגויה**", "ב\' נכונה") in addition to the "תשובה X\'" form. Before this, when option-shuffle moved the correct answer to a different display position (e.g. orig ב=echo → display ד=echo), the explanation still said "תשובה ב\'" and "א\'/ג\'/ד\' שגויה" referring to ORIGINAL positions — users saw wrong letter cross-references everywhere. Repro: 2024-May-Basic Q1 (idx=2841 stroke / MCA / cardio-embolic). Affected ~1779 explanations using bare label form across the bank. Lookbehind excludes mid-word gershayim ("מג\'ורי", "ג\'נטיקה") so foreign-sound markers are untouched. 8 new regression tests in tests/remapExplanationLetters.test.js. Same bug exists in IM + FM (porting separately).',
 ],

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.22';
+const CACHE='shlav-a-v10.64.23';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 // CRITICAL_URLS = the bare-minimum app shell required for offline boot.
 // Anything else (data/*.json, fonts, icons) is best-effort in the install

--- a/tests/remapExplanationLetters.test.js
+++ b/tests/remapExplanationLetters.test.js
@@ -79,6 +79,18 @@ describe("remapExplanationLetters — v10.64.22 fix", () => {
     expect(remapExplanationLetters("Option C is wrong.", shuf)).toBe("Option A is wrong.");
   });
 
+  it("remaps Hebrew letter directly followed by ASCII letter (v10.64.23)", () => {
+    // "תשובה אcorrect" form — caught by FM's existing utilsExtras.test.js;
+    // earlier v10.64.22 narrower lookahead missed it.
+    const shuf = [1, 2, 0, 3];
+    expect(remapExplanationLetters("תשובה אcorrect", shuf)).toBe("תשובה גcorrect");
+  });
+
+  it("remaps Hebrew letter directly followed by whitespace (v10.64.23)", () => {
+    const shuf = [1, 2, 0, 3];
+    expect(remapExplanationLetters("תשובה א נכונה", shuf)).toBe("תשובה ג נכונה");
+  });
+
   it("does not double-remap a letter in alternated patterns", () => {
     // "תשובה ב'" — first branch matches "תשובה ב", consumes through ב.
     // The trailing geresh + lookbehind keeps the second branch from firing.


### PR DESCRIPTION
Backport from FM v1.21.8 — broader lookahead `(?=[^א-ת]|$)` instead of narrower char class. Catches Hebrew-letter-directly-followed-by-ASCII case that v10.64.22 missed.

2 new regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)