### PR TITLE
v10.64.24: fix 3 hallucinated Hazzard chapter citations + CI guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.23",
+  "version": "10.64.24",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -6646,7 +6646,7 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.23';
+const APP_VERSION='10.64.24';
 const CHANGELOG={
 '10.64.23':[
 '🔤 remapExplanationLetters lookahead generalized — v10.64.22 used a narrower char class `[\\s.,;:!?)]` for the post-letter context, missing "תשובה אcorrect" (Hebrew letter directly followed by ASCII letter, no separator). FM\'s existing utilsExtras tests caught this; backporting the broader `(?=[^א-ת]|$)` lookahead here. Same semantic intent — accept anything-not-Hebrew (or EOL) — just covers more cases. 2 new tests added.',
@@ -7269,7 +7269,7 @@ function getTopicTrend(ti){
     return curr-prev; // positive = improving
   }catch(e){return null;}
 }
-const BUILD_HASH=(()=>{const d=new Date('2026-04-11T00:00:00Z');return d.toISOString().slice(0,10).replace(/-/g,'');})();
+const BUILD_HASH=(()=>{const d=new Date('2026-05-03T00:00:00Z');return d.toISOString().slice(0,10).replace(/-/g,'');})();
 
 // ===== SHARED AI PROXY =====
 const AI_PROXY='https://toranot.netlify.app/api/claude';

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.23';
+const CACHE='shlav-a-v10.64.24';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 // CRITICAL_URLS = the bare-minimum app shell required for offline boot.
 // Anything else (data/*.json, fonts, icons) is best-effort in the install

--- a/tests/textbookChapters.test.js
+++ b/tests/textbookChapters.test.js
@@ -203,6 +203,50 @@ describe('Topic distribution balance — quantitative', () => {
   });
 });
 
+describe('Question ref/e chapter citations resolve to real chapters', () => {
+  // Audit 2026-05-03 caught 3 questions citing Hazzard Ch 109/121/124 — none exist
+  // (Hazzard 8e maxes at Ch 108). Hallucinated chapter numbers slip through silently
+  // because the medical content of the explanation is usually fine; only the
+  // attribution is wrong. This guard pins every Hazzard chapter cited in q.ref or
+  // q.e to an existing entry in hazzard_chapters.json.
+  //
+  // Harrison side intentionally not bounded — Harrison 22e has ~480 chapters and
+  // our hazzard_chapters.json holds only a sparse 69 of them, so absence !== bogus.
+  const HZ_CITE_RE = /(?:Hazzard\s*Ch|הזארד\s*(?:פרק\s*)?)\s*(\d+)/gi;
+
+  it('every Hazzard chapter cited in q.ref exists in hazzard_chapters.json', () => {
+    const bad = [];
+    for (let i = 0; i < questions.length; i++) {
+      const ref = questions[i].ref || '';
+      let m;
+      const re = new RegExp(HZ_CITE_RE);
+      while ((m = re.exec(ref))) {
+        const id = String(Number(m[1]));
+        if (!hazzard[id]) bad.push({ i, cited: m[1], ref: ref.slice(0, 80) });
+      }
+    }
+    expect(bad, JSON.stringify(bad.slice(0, 5))).toEqual([]);
+  });
+
+  it('every Hazzard chapter cited in q.e exists in hazzard_chapters.json', () => {
+    const bad = [];
+    for (let i = 0; i < questions.length; i++) {
+      const e = questions[i].e || '';
+      let m;
+      const re = new RegExp(HZ_CITE_RE);
+      while ((m = re.exec(e))) {
+        const id = String(Number(m[1]));
+        if (!hazzard[id]) {
+          // Snippet around the match for triage
+          const snippet = e.slice(Math.max(0, m.index - 30), m.index + 50);
+          bad.push({ i, cited: m[1], snippet });
+        }
+      }
+    }
+    expect(bad, JSON.stringify(bad.slice(0, 5))).toEqual([]);
+  });
+});
+
 describe('Exam-year tag consistency', () => {
   // CLAUDE.md priority 4. `t` is a year-like tag — most are 4-digit years
   // (e.g. "2022"), some are dual-session ("2022-א"/"2022-ב"), some carry


### PR DESCRIPTION
## Summary
- Deep consistency audit of `data/questions.json` caught 3 questions citing Hazzard 8e chapters that don't exist (book maxes at Ch 108):
  - **idx=2490** (CAP in elderly): `ref` Ch 109 → Ch 105 (Bacterial Pneumonia and Tuberculosis)
  - **idx=3130** (UTI/urosepsis): `e` footer Ch 124 → Ch 106 (Urinary Tract Infections); `ref` was already correct
  - **idx=3683** (gout): both `ref` and `e` cited bogus Ch 121 — dropped, Harrison Ch 365 stands
- New CI guard in `tests/textbookChapters.test.js`: every Hazzard chapter cited in `q.ref` or `q.e` must resolve in `hazzard_chapters.json`. Catches the class of hallucinated-chapter regressions going forward.
- Trinity bump → 10.64.24 (`package.json` + `sw.js` CACHE + HTML `APP_VERSION`); BUILD_HASH refreshed to 2026-05-03.

## Audit methodology
Multi-iteration audit script (`.audit_logs/audit_explanation_consistency.py`, retained for posterity in gitignored `.audit_logs/`) checked:
- letter_mismatch (e claims wrong letter is correct) — **0 found** after 5 regex refinements
- bullet_option_mismatch (bullet rationale vs option text) — 23 flagged, all verified false positives (heuristic limitation: bullets explain *why*, don't echo option text)
- ref_chapter_mismatch (ref vs e cite different Hazzard chapters) — **1 found** (idx=3130)
- header_mismatch (lead-in description doesn't match correct option) — 3 flagged, all false positives from Hebrew↔Latin script gap (e.g., `BETA-BLOCKERS` vs `ביתא-בלוקרים`)
- chapter-existence bounds (Hazzard >108) — **3 found**, all real bugs

## Test plan
- [x] `npm run verify` — trinity aligned, brace balance OK, innerHTML safe, Harrison-Hebrew baseline clean, 1103/1103 tests pass
- [x] New tests in `textbookChapters.test.js` (25 → 25, +2 chapter-bound checks) verified passing post-fix
- [x] Diff is surgical: 4 ins / 4 del across `data/questions.json`, LF endings preserved
- [ ] Live witness via `bash scripts/verify-deploy.sh` after Pages rebuilds

🤖 Generated with [Claude Code](https://claude.com/claude-code)