### PR TITLE
v10.64.28: Supabase upsert + chaos diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.27",
+  "version": "10.64.28",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/chaos-live-bot.mjs
+++ b/scripts/chaos-live-bot.mjs
@@ -143,6 +143,29 @@ async function runWorker(browser, workerId, stopAt, report) {
     timezoneId: 'Asia/Jerusalem',
   });
   context.setDefaultTimeout(CONFIG.actionTimeoutMs);
+  // Instrument JSON.parse + Response.prototype.json to attribute parse errors
+  // to a real stack — Playwright's `pageerror` handler returns null `stack` for
+  // these because the error is rethrown at the V8 internal layer.
+  await context.addInitScript(() => {
+    const origJsonParse = JSON.parse;
+    JSON.parse = function (...args) {
+      try { return origJsonParse.apply(JSON, args); }
+      catch (e) {
+        const stack = new Error('JSON.parse failure attribution').stack;
+        console.error('[chaos-instrument] JSON.parse error:', e.message, 'inputPreview=', String(args[0] ?? '').slice(0, 60), 'stack=', stack);
+        throw e;
+      }
+    };
+    const origRespJson = Response.prototype.json;
+    Response.prototype.json = function (...args) {
+      const url = this.url, status = this.status;
+      return origRespJson.apply(this, args).catch((e) => {
+        const stack = new Error('Response.json failure attribution').stack;
+        console.error('[chaos-instrument] Response.json error:', e.message, 'url=', url, 'status=', status, 'stack=', stack);
+        throw e;
+      });
+    };
+  });
   const page = await context.newPage();
   const log = { workerId, actions: [], bugs: [], timings: [] };
 
@@ -152,7 +175,13 @@ async function runWorker(browser, workerId, stopAt, report) {
     }
   });
   page.on('pageerror', async (error) => {
-    log.bugs.push({ at: nowIso(), type: 'pageerror', message: error.message, screenshot: await screenshot(page, workerId, 'pageerror') });
+    log.bugs.push({
+      at: nowIso(),
+      type: 'pageerror',
+      message: error.message,
+      stack: error.stack ? String(error.stack).split('\n').slice(0, 8).join('\n') : null,
+      screenshot: await screenshot(page, workerId, 'pageerror'),
+    });
   });
   page.on('requestfailed', (request) => {
     log.bugs.push({
@@ -197,6 +226,16 @@ async function runWorker(browser, workerId, stopAt, report) {
       await sleep(rand(CONFIG.minDelayMs, CONFIG.maxDelayMs));
     }
   } finally {
+    // Snapshot the app's in-page debug buffer (window.__debug.buffer) before
+    // closing — it captures unhandledrejection stacks the Playwright pageerror
+    // event drops as null. See shlav-a-mega.html line 725.
+    try {
+      const buffer = await page.evaluate(() => {
+        const b = window.__debug && window.__debug.buffer;
+        return b ? { errors: b.errors.slice(-50), network: b.network.slice(-50) } : null;
+      });
+      if (buffer) log.appDebugBuffer = buffer;
+    } catch (_) { /* page may already be closed */ }
     report.workers.push(log);
     await context.close().catch(() => {});
   }

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -6274,21 +6274,14 @@ async function cloudBackup(){
     try{_sessions=JSON.parse(localStorage.getItem('samega_sessions')||'[]');}catch(e){}
     const _bundled={...S,_mockHist,_sessions};
     const payload={id:_sbDeviceId(),data:_bundled,updated_at:new Date().toISOString()};
+    // Native upsert via PostgREST Prefer header — single round-trip, no 409 noise
+    // on duplicate-PK retries (vs prior POST→409→PATCH dance).
     const res=await fetch(SUPA_URL+'/rest/v1/samega_backups',{
       method:'POST',
-      headers:{'apikey':_SB_KEY,'Authorization':'Bearer '+_SB_KEY,'Content-Type':'application/json'},
+      headers:{'apikey':_SB_KEY,'Authorization':'Bearer '+_SB_KEY,'Content-Type':'application/json','Prefer':'resolution=merge-duplicates'},
       body:JSON.stringify(payload)
     });
-    if(res.ok||res.status===409){
-      // If 409, try upsert
-      if(res.status===409){
-        const patchRes=await fetch(SUPA_URL+'/rest/v1/samega_backups?id=eq.'+_sbDeviceId(),{
-          method:'PATCH',
-          headers:{'apikey':_SB_KEY,'Authorization':'Bearer '+_SB_KEY,'Content-Type':'application/json'},
-          body:JSON.stringify({data:_bundled,updated_at:new Date().toISOString()})
-        });
-        if(!patchRes.ok){const pe=await patchRes.text();toast('❌ Backup update failed: '+patchRes.status+'\n'+pe.slice(0,200),'info');return;}
-      }
+    if(res.ok){
       ok=true;
       S._lastCloudSync=new Date().toISOString();save();
       toast('✅ Progress backed up to cloud!\nDevice ID: '+_sbDeviceId().slice(0,12)+'...','success');
@@ -6646,7 +6639,7 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.27';
+const APP_VERSION='10.64.28';
 const CHANGELOG={
 '10.64.23':[
 '🔤 remapExplanationLetters lookahead generalized — v10.64.22 used a narrower char class `[\\s.,;:!?)]` for the post-letter context, missing "תשובה אcorrect" (Hebrew letter directly followed by ASCII letter, no separator). FM\'s existing utilsExtras tests caught this; backporting the broader `(?=[^א-ת]|$)` lookahead here. Same semantic intent — accept anything-not-Hebrew (or EOL) — just covers more cases. 2 new tests added.',

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.27';
+const CACHE='shlav-a-v10.64.28';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 // CRITICAL_URLS = the bare-minimum app shell required for offline boot.
 // Anything else (data/*.json, fonts, icons) is best-effort in the install


### PR DESCRIPTION
## Summary
Follow-up to PR #148 (the multi-pass Harrison + chaos bug fix train). Substantive change is the Supabase backup upsert; the rest is diagnostic infrastructure for the next chaos audit pass.

### cloudBackup → native PostgREST upsert
\`Prefer: resolution=merge-duplicates\` header tells Supabase to do \`INSERT … ON CONFLICT (PK) DO UPDATE\` atomically. Replaces the prior optimistic POST → 409 → PATCH retry pattern. One round-trip instead of two; clean network log; ~8× phantom 409s per chaos run eliminated.

### chaos-live-bot.mjs diagnostic upgrades (no prod impact)
- pageerror handler captures \`error.stack\` (was message-only)
- \`addInitScript\` wraps \`JSON.parse\` + \`Response.prototype.json\` to attribute parse failures to a real stack via console.error
- Worker teardown snapshots \`window.__debug.buffer\` so the in-page unhandledrejection stacks already captured by the app land in the chaos JSON report

## Outstanding deferred
- 13× → 3× → 2× "Unexpected end of input" pageerrors across three chaos runs. Investigation: this is V8's wording for eval/Function compilation failures, **not** JSON.parse (which says "Unexpected end of JSON input"). No \`eval\`, \`new Function\`, \`setTimeout('string')\`, \`DOMParser\`, \`new Worker\` in the codebase. Likely a CSP-related or SW-cached compile error in a UI feature exercised by specific click sequences. The new \`__debug.buffer\` hook in chaos-live-bot.mjs is the wedge for next-pass attribution. 0.25% rate (2/811 actions); not user-facing.

## Test plan
- [x] \`npm run verify\` — 1106/1106 pass
- [x] Trinity 10.64.28 aligned
- [ ] verify-deploy.sh after Pages rebuilds

🤖 Generated with [Claude Code](https://claude.com/claude-code)