### PR TITLE
v10.64.29: ?validate=1 onclick syntax validator (chaos diagnostic wedge)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.28",
+  "version": "10.64.29",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -6527,6 +6527,19 @@ if(sv.srchi!==undefined&&document.getElementById('srchi'))document.getElementByI
 if(sv.nfilt!==undefined&&document.getElementById('nfilt'))document.getElementById('nfilt').value=sv.nfilt;
 if(focused){const fe=document.getElementById(focused);if(fe){fe.focus();if(fe.value){try{fe.setSelectionRange(fe.value.length,fe.value.length);}catch(_){/* range/date/etc inputs reject setSelectionRange */}}}}
 updateAccountChip();
+// Diagnostic wedge for the "Unexpected end of input" pageerror class — this is
+// V8's wording for inline event-handler compilation failures at click-dispatch
+// time. Gated by ?validate=1 URL param so it never runs in production.
+// Audit run with `?validate=1` and watch console for `[onclick-validate]`
+// entries — they pinpoint dynamically-built onclick strings whose ${var}
+// interpolation broke JS syntax. See .audit_logs/NEXT_AUDIT_NOTES.md.
+if(typeof window!=='undefined'&&/[?&]validate=1\b/.test(location.search||'')){
+  document.querySelectorAll('[onclick]').forEach(function(elt){
+    var src=elt.getAttribute('onclick')||'';
+    try{new Function('event',src);}
+    catch(e){console.error('[onclick-validate]',e.message,'tag=',elt.tagName,'onclick=',src.slice(0,200));}
+  });
+}
 }
 
 // v10.49.0: Header account chip — shows initial when logged in, 👤 when guest.
@@ -6639,7 +6652,7 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.28';
+const APP_VERSION='10.64.29';
 const CHANGELOG={
 '10.64.23':[
 '🔤 remapExplanationLetters lookahead generalized — v10.64.22 used a narrower char class `[\\s.,;:!?)]` for the post-letter context, missing "תשובה אcorrect" (Hebrew letter directly followed by ASCII letter, no separator). FM\'s existing utilsExtras tests caught this; backporting the broader `(?=[^א-ת]|$)` lookahead here. Same semantic intent — accept anything-not-Hebrew (or EOL) — just covers more cases. 2 new tests added.',

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.28';
+const CACHE='shlav-a-v10.64.29';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 // CRITICAL_URLS = the bare-minimum app shell required for offline boot.
 // Anything else (data/*.json, fonts, icons) is best-effort in the install


### PR DESCRIPTION
## Summary
After 4 chaos audit passes triangulated the "Unexpected end of input" pageerror class to V8's wording for **inline event-handler compilation at click-dispatch time** (not JSON.parse, not Promise rejection — both ruled out by instrumented runs), this PR ships the next-pass diagnostic wedge.

## Mechanism
Render-time hook calls \`new Function('event', onclickAttr)\` against every \`[onclick]\` attribute after each render. Compile failures console.error a \`[onclick-validate]\` tagged entry with the failing tag + first 200 chars of the broken source.

\`\`\`js
if (/[?&]validate=1\b/.test(location.search||'')) {
  document.querySelectorAll('[onclick]').forEach(elt => {
    var src = elt.getAttribute('onclick') || '';
    try { new Function('event', src); }
    catch (e) { console.error('[onclick-validate]', e.message, 'tag=', elt.tagName, 'onclick=', src.slice(0,200)); }
  });
}
\`\`\`

## Production safety
Gated by \`?validate=1\` URL param. Never runs without the flag. Zero overhead for normal users.

## Next-pass usage
\`\`\`bash
CHAOS_URL='https://eiasash.github.io/Geriatrics/shlav-a-mega.html?validate=1' npm run chaos
\`\`\`

The chaos bot already captures \`console:error\` events. Each \`[onclick-validate]\` entry surfaces the broken onclick strings end-to-end. With 6932 dynamically-built onclick handlers in the file (per a quick grep), one of them is producing a malformed JS expression for some specific render state.

## Background — investigation rule-outs
| Pass | Method | Result |
|---|---|---|
| 1 | Baseline 30-min, 4 workers | 13× pageerrors |
| 2 | + \`error.stack\` capture | All stacks **null** |
| 3 | + \`addInitScript\` JSON.parse + Response.json wrappers | **0 \`[chaos-instrument]\` console hits** → not JSON parsing |
| 4 | + \`window.__debug.buffer\` snapshot | **buffer empty** → not caught by app's \`error\`/\`unhandledrejection\` listeners |

Logged in \`.audit_logs/NEXT_AUDIT_NOTES.md\`.

## Test plan
- [x] \`npm run verify\` — 1106/1106 pass
- [x] Trinity 10.64.29 aligned
- [ ] verify-deploy.sh after Pages rebuilds

🤖 Generated with [Claude Code](https://claude.com/claude-code)