### PR TITLE
v10.64.31: cloudBackup 401/403 → Hebrew login-required toast + route

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.30",
+  "version": "10.64.31",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -6285,9 +6285,13 @@ async function cloudBackup(){
       ok=true;
       S._lastCloudSync=new Date().toISOString();save();
       toast('✅ Progress backed up to cloud!\nDevice ID: '+_sbDeviceId().slice(0,12)+'...','success');
+    } else if(res.status===401||res.status===403){
+      toast('❌ נדרשת התחברות לחשבון לגיבוי לענן\nLogin required','info');
+      tab='more';moreSub='settings';renderTabs();render();
+      setTimeout(function(){var el=document.getElementById('auth-li-user');if(el)el.focus();},150);
     } else {
       const err=await res.text();
-      toast('❌ Backup failed: '+res.status+'\n'+err.slice(0,200,'info'));
+      toast('❌ Backup failed: '+res.status+'\n'+err.slice(0,200),'info');
     }
   }catch(e){toast('❌ Backup failed: '+e.message,'info');}
   _syncState=ok?'init':'failed';updateSyncPill();
@@ -6639,8 +6643,11 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.30';
+const APP_VERSION='10.64.31';
 const CHANGELOG={
+'10.64.31':[
+'☁️ Cloud backup 401/403 now actionable — when Supabase rejects the upsert because the caller isn\'t logged in, surface a Hebrew login-required toast and route to More → Settings with the auth username field focused, instead of toast-less silence (or a generic English "Backup failed: 401" with no path forward). Mirror of IM v10.4.12 / FM v1.21.10. Also fixes a stale `slice(0,200,\'info\')` typo in the generic error branch so the toast tone is now passed correctly.',
+],
 '10.64.23':[
 '🔤 remapExplanationLetters lookahead generalized — v10.64.22 used a narrower char class `[\\s.,;:!?)]` for the post-letter context, missing "תשובה אcorrect" (Hebrew letter directly followed by ASCII letter, no separator). FM\'s existing utilsExtras tests caught this; backporting the broader `(?=[^א-ת]|$)` lookahead here. Same semantic intent — accept anything-not-Hebrew (or EOL) — just covers more cases. 2 new tests added.',
 ],

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.30';
+const CACHE='shlav-a-v10.64.31';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 // CRITICAL_URLS = the bare-minimum app shell required for offline boot.
 // Anything else (data/*.json, fonts, icons) is best-effort in the install


### PR DESCRIPTION
## Summary
- Mirror of IM #87 (v10.4.12) / FM #31 (v1.21.10) for Geri's `cloudBackup()`
- 401/403 from Supabase upsert now shows a Hebrew "login required" toast and auto-routes to More → Settings with `#auth-li-user` focused — instead of the previous opaque English toast that left users tapping the button with no path forward
- Fixes a stale `slice(0,200,'info')` typo in the generic error branch (`'info'` was being swallowed as a 3rd arg to `slice` instead of being the toast tone)

## Audit trail (for parity with IM/FM)
- **Bug 2** (settings UX section headers) — already clean: 3 distinct `<div class="card">` blocks at lines 5812 / 5817 / 5833 with 👤 Account · חשבון, 💾 Data Management, and 🔑 Anthropic API Key headers
- **Bug 3** (feedback payload shape) — already clean: line 5937 sends `{type, text, ts, version, uid}` to `shlav_feedback`, the same schema FM verified via Supabase MCP

## Trinity
- `shlav-a-mega.html` `APP_VERSION` 10.64.30 → 10.64.31
- `sw.js` `CACHE` `shlav-a-v10.64.30` → `shlav-a-v10.64.31`
- `package.json` `version` 10.64.30 → 10.64.31

## Test plan
- [x] `npm run verify` green locally (1106 tests pass, version-sync + brace-balance + innerHTML guards all OK)
- [ ] CI green
- [ ] Post-merge: `bash scripts/verify-deploy.sh --wait 180` shows v10.64.31 live at https://eiasash.github.io/Geriatrics/
- [ ] Manual: tap "☁️ Backup to Cloud" while logged out → should see Hebrew "נדרשת התחברות" toast + auto-jump to Settings → username field focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)