### PR TITLE
v10.64.32: fix Cover-Options onclick syntax error (5-pass mystery solved)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.31",
+  "version": "10.64.32",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -2870,7 +2870,7 @@ if(ans){cls+=' lk';if(!examMode){if(isOk(q,origI))cls+=' ok';else if(origI===sel
 else if(origI===sel)cls+=' sel';
 const blurCls=blindRecall&&!ans&&origI!==sel?' qo-blur':'';
 const autopsyCls=(autopsyMode&&ans&&!examMode&&!isOk(q,origI)&&origI===autopsyDistractor)?' distractor-highlight':'';
-h+=`<button class="${cls}${blurCls}${autopsyCls}" onclick="${blindRecall&&!ans&&origI!==sel?'this.classList.remove(\"qo-blur\");':''}pick(${origI})" aria-label="Option ${origI+1}" dir="${heDir(o)}"><span>${sanitize(o)}</span>${q.oi&&q.oi[origI]?'<img src="'+sanitize(q.oi[origI])+'" style="max-width:100%;max-height:120px;margin-top:6px;border-radius:6px" loading="lazy">':''}</button>`;
+h+=`<button class="${cls}${blurCls}${autopsyCls}" onclick="${blindRecall&&!ans&&origI!==sel?'this.classList.remove(\'qo-blur\');':''}pick(${origI})" aria-label="Option ${origI+1}" dir="${heDir(o)}"><span>${sanitize(o)}</span>${q.oi&&q.oi[origI]?'<img src="'+sanitize(q.oi[origI])+'" style="max-width:100%;max-height:120px;margin-top:6px;border-radius:6px" loading="lazy">':''}</button>`;
 });
 return h;
 }
@@ -6643,7 +6643,7 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.31';
+const APP_VERSION='10.64.32';
 const CHANGELOG={
 '10.64.31':[
 '☁️ Cloud backup 401/403 now actionable — when Supabase rejects the upsert because the caller isn\'t logged in, surface a Hebrew login-required toast and route to More → Settings with the auth username field focused, instead of toast-less silence (or a generic English "Backup failed: 401" with no path forward). Mirror of IM v10.4.12 / FM v1.21.10. Also fixes a stale `slice(0,200,\'info\')` typo in the generic error branch so the toast tone is now passed correctly.',

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.31';
+const CACHE='shlav-a-v10.64.32';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 // CRITICAL_URLS = the bare-minimum app shell required for offline boot.
 // Anything else (data/*.json, fonts, icons) is best-effort in the install

--- a/tests/regressionGuards.test.js
+++ b/tests/regressionGuards.test.js
@@ -520,3 +520,53 @@ describe('multi-select exam-year filter — Task 3 contract', () => {
     expect(missing).toEqual([]);
   });
 });
+
+// ─────────────────────────────────────────────────────────────
+// Inline onclick attribute integrity (v10.64.32 regression guard)
+// ─────────────────────────────────────────────────────────────
+//
+// 3-hour chaos run (2026-05-03) found 48× "Uncaught SyntaxError: Unexpected
+// end of input" pageerrors traced to a template literal at line 2873 that
+// produced:
+//
+//   onclick="this.classList.remove(\"qo-blur\");pick(2)"
+//
+// Inside a backtick template literal, `\"` is consumed as an escape →
+// becomes a literal `"`. The resulting HTML attribute had unescaped
+// double-quotes inside its `"`-delimited value. The HTML parser
+// terminated the attribute at the first inner `"`, leaving the browser
+// to compile only `this.classList.remove(` as the onclick body — V8
+// throws "Unexpected end of input" at click-dispatch time.
+//
+// Fix: use single-quoted JS string literals (`'qo-blur'`) inside the
+// attribute, so single quotes don't conflict with the outer `"`
+// delimiter. This guard scans the source for the broken pattern.
+describe('inline onclick attribute integrity', () => {
+  test('no onclick template literal contains unescaped double-quotes after backslash escape consumption', () => {
+    const html = readFile('shlav-a-mega.html');
+    // Match: onclick="..." attribute values that, after \"  is consumed as an
+    // escape (template-literal semantics), would contain literal " inside
+    // the HTML attribute. The source-level smoking gun is `\"` appearing
+    // INSIDE an `onclick="..."` attribute value within a backtick template.
+    //
+    // We grep for the pattern that survived through render() in the bug:
+    //   onclick="${...?'...remove(\"qo-blur\")...':...}..."
+    //
+    // The unsafe fingerprint: any backslash-quote pair inside `onclick="..."`
+    // delimited by backticks. Since the file is a single-monolith template,
+    // we look for `onclick="` followed by content containing `\"` before
+    // the next `"`. Note: `&quot;` is the SAFE encoded alternative; `\'`
+    // (backslash-single-quote) is the SAFE single-quote escape we shipped.
+    const re = /onclick="[^"]*\\"[^"]*"/g;
+    const matches = [...html.matchAll(re)];
+    if (matches.length > 0) {
+      // Return helpful context for triage
+      const offenders = matches.map(m => ({
+        idx: m.index,
+        snippet: html.slice(Math.max(0, m.index), m.index + 200),
+      }));
+      console.error('Unsafe onclick patterns found:', JSON.stringify(offenders, null, 2));
+    }
+    expect(matches).toEqual([]);
+  });
+});


### PR DESCRIPTION
## The 5-pass mystery, solved

48× "Uncaught SyntaxError: Unexpected end of input" pageerrors that triggered chaos investigations across PRs #146-#151 — root cause finally pinned via the 3-hour chaos run completed at 22:58.

## The bug

\`shlav-a-mega.html\` line 2873 rendered option buttons with this template literal:

\`\`\`js
onclick="\${blindRecall && !ans && origI !== sel
  ? 'this.classList.remove(\\"qo-blur\\");'
  : ''}pick(\${origI})"
\`\`\`

Inside a backtick template literal, \`\\\"\` is consumed as a JS escape sequence and evaluates to a literal \`"\`. The HTML attribute the user got was:

\`\`\`html
onclick="this.classList.remove("qo-blur");pick(2)"
\`\`\`

The HTML parser terminated the \`"\`-delimited attribute at the first inner \`"\`, leaving the browser to compile only \`this.classList.remove(\` as the onclick body. V8 threw "Uncaught SyntaxError: Unexpected end of input" at click-dispatch time.

## Why it survived 5 audit passes

- Fires only when \`blindRecall = true\` (Cover Options enabled OR mid-Mock-Exam with blur applied) AND user clicks an unselected option
- Random walks rarely toggle Cover Options on; once on, every unselected-option click crashes
- Worker 4 of the 3-hour run had **0 pageerrors over 1785 actions** because its random walk never enabled Cover Options. Workers 1/3 hit it 46 times combined.
- Pure parser SyntaxError → no JS frames → neither Playwright \`pageerror\` handler nor in-page \`window.error\` listener could attribute source
- Only **visual analysis of 5 sampled pageerror screenshots** pinned the trigger: 3 of 5 showed Cover-Options-blurred options at the moment of error

## The fix

Change \`\\"qo-blur\\"\` to \`\'qo-blur\'\`. Single quotes inside the HTML \`"\` attribute don't conflict with the outer delimiter, so:
- Template literal evaluates the inner JS string to \`this.classList.remove('qo-blur');\`
- HTML parser keeps the entire \`onclick="..."\` body intact (single quotes are valid inside double-quoted HTML attrs)
- V8 at click time sees \`this.classList.remove('qo-blur');pick(2)\` — valid JS

## Regression guard

\`tests/regressionGuards.test.js\` now scans for \`/onclick="[^"]*\\\\"[^"]*"/\` — any unescaped backslash-quote inside an onclick attribute fails the test with the offending snippet for triage.

## Test plan
- [x] \`npm run verify\` — 1107/1107 pass (+1 new regression guard)
- [x] Trinity 10.64.32 aligned (package.json + sw.js + APP_VERSION)
- [x] Template render simulation confirms valid HTML in all 3 branches (no blindRecall, blindRecall+unselected, blindRecall+selected)
- [ ] verify-deploy.sh after Pages rebuilds
- [ ] **Real-world validation**: next chaos run should show pageerror count drop from ~24/hr to near-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)