### PR TITLE
v10.64.33: 2023-Sep broken-flag pass + idx=2377 image rescue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.32",
+  "version": "10.64.33",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -1849,7 +1849,12 @@ function getWrongReviewPool(){
   out.sort((a,b)=>b.score-a.score);
   return out.map(o=>o.i);
 }
-function buildPool(){
+// Global pool filter: questions flagged broken (e.g. 2023-Sep multi-part stem
+// fragments missing parent context, identified by chaos-audit 2026-05-03) are
+// excluded from every pool path. We wrap _buildPoolRaw so all early returns
+// pass through the filter without per-path edits.
+function buildPool(){_buildPoolRaw();if(Array.isArray(pool))pool=pool.filter(i=>!QZ[i]||!QZ[i].broken);}
+function _buildPoolRaw(){
 if(filt==='wrong'){
 pool=getWrongReviewPool();
 qi=0;sel=null;ans=false;return;
@@ -6643,7 +6648,7 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.32';
+const APP_VERSION='10.64.33';
 const CHANGELOG={
 '10.64.31':[
 '☁️ Cloud backup 401/403 now actionable — when Supabase rejects the upsert because the caller isn\'t logged in, surface a Hebrew login-required toast and route to More → Settings with the auth username field focused, instead of toast-less silence (or a generic English "Backup failed: 401" with no path forward). Mirror of IM v10.4.12 / FM v1.21.10. Also fixes a stale `slice(0,200,\'info\')` typo in the generic error branch so the toast tone is now passed correctly.',

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.32';
+const CACHE='shlav-a-v10.64.33';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 // CRITICAL_URLS = the bare-minimum app shell required for offline boot.
 // Anything else (data/*.json, fonts, icons) is best-effort in the install

--- a/tests/expandedDataIntegrity.test.js
+++ b/tests/expandedDataIntegrity.test.js
@@ -432,7 +432,10 @@ describe("questions.json — image field (img) validation", () => {
       }
       const isHttps = q.img.startsWith("https://");
       const isSvgData = q.img.startsWith("data:image/svg+xml");
-      if (!isHttps && !isSvgData) {
+      // v10.64.33: relative `questions/images/*` allowed for one-off Pages-served
+      // fallback (idx=2377 broken-Supabase-image rescue from chaos-audit 2026-05-03)
+      const isRelativeQimg = q.img.startsWith("questions/images/");
+      if (!isHttps && !isSvgData && !isRelativeQimg) {
         invalid.push({ index: i, img: q.img.slice(0, 60) });
       }
     });
@@ -444,6 +447,7 @@ describe("questions.json — image field (img) validation", () => {
     questions.forEach((q, i) => {
       if (!q.img) return;
       if (q.img.startsWith("data:image/svg+xml")) return; // AI-generated schematics OK
+      if (q.img.startsWith("questions/images/")) return; // v10.64.33: Pages-served relative fallback (idx=2377)
       if (!q.img.startsWith(SUPA_IMG_PREFIX)) {
         wrong.push({ index: i, img: q.img.slice(0, 80) });
       }

--- a/tests/regressionGuards.test.js
+++ b/tests/regressionGuards.test.js
@@ -522,6 +522,41 @@ describe('multi-select exam-year filter — Task 3 contract', () => {
 });
 
 // ─────────────────────────────────────────────────────────────
+// Broken-question filter (v10.64.33 regression guard)
+// ─────────────────────────────────────────────────────────────
+//
+// Track D (chaos-audit 2026-05-03): 22 questions tagged 2023-Sep are
+// problematic — 6 are tag-collision duplicates of 2023-Jun-Basic, 16 are
+// multi-part stem fragments that lost their parent context during ingestion.
+// All 22 are flagged with `broken: true` and `broken_reason`.
+//
+// The buildPool wrapper at line 1857 of shlav-a-mega.html filters them out
+// of every pool path. This guard locks both the data-side flag and the
+// filter wrapper.
+describe('broken-question filter — v10.64.33', () => {
+  let questions;
+  beforeAll(() => { questions = loadJSON('data/questions.json'); });
+
+  test('there are at least 22 questions flagged broken (Track D D-1 baseline)', () => {
+    const broken = questions.filter(q => q.broken === true);
+    expect(broken.length).toBeGreaterThanOrEqual(22);
+  });
+
+  test('every question with broken=true has a broken_reason', () => {
+    const broken = questions.filter(q => q.broken === true);
+    const noReason = broken.filter(q => !q.broken_reason || typeof q.broken_reason !== 'string');
+    expect(noReason).toEqual([]);
+  });
+
+  test('shlav-a-mega.html buildPool wrapper applies the broken filter', () => {
+    const html = readFile('shlav-a-mega.html');
+    // Wrapper at line 1857: function buildPool(){_buildPoolRaw();...filter(i=>!QZ[i]||!QZ[i].broken)...}
+    expect(html).toMatch(/function buildPool\(\)\s*\{\s*_buildPoolRaw\(\)/);
+    expect(html).toMatch(/pool=pool\.filter\(i=>!QZ\[i\]\|\|!QZ\[i\]\.broken\)/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
 // Inline onclick attribute integrity (v10.64.32 regression guard)
 // ─────────────────────────────────────────────────────────────
 //


### PR DESCRIPTION
## Summary
Two findings from the audit + chaos session, both shipped here:

### Track D — 22 problematic 2023-Sep questions
Session-end pairing analysis found these split into:
- **6 tag-collision duplicates** of 2023-Jun-Basic (idx 2410-2415) — identical case stems, duplicate entries from ingestion
- **16 multi-part stem fragments** that lost their parent case context — short stems with lab values but no patient story (e.g., idx=14: "5. What's the approach to infection in the case described?" with no case in the stem)

All 22 flagged with \`broken=true\` + \`broken_reason\`. **No deletions** — preserves question indices for FSRS state, \`distractors.json\` keys, \`syllabus_data\` totals. \`shlav-a-mega.html\` \`buildPool\` wrapped to filter \`q.broken\` from every pool path:

\`\`\`js
function buildPool(){_buildPoolRaw();if(Array.isArray(pool))pool=pool.filter(i=>!QZ[i]||!QZ[i].broken);}
function _buildPoolRaw(){...original body...}
\`\`\`

Single-line wrapper covers all 9 early-return paths in the inner function.

### Track E — idx=2377 image rescue
3-hour chaos run captured **11× HTTP 400** on \`geri_Jun22_al_q38_tmuna7.jpg\` from Supabase storage. Local file exists at \`questions/images/jun2022_q38.png\` (188KB, Pages-served, 200 OK). Redirected \`q.img\` to the relative path. \`expandedDataIntegrity.test.js\` updated to allowlist the \`questions/images/\` prefix as a Pages-served fallback alongside the canonical Supabase bucket.

## Regression guards
\`tests/regressionGuards.test.js\` (+3 new):
- ≥22 questions flagged broken (pins the Track D baseline)
- every \`broken=true\` entry has a \`broken_reason\` string
- \`shlav-a-mega.html\` buildPool wrapper structure pinned

## Test plan
- [x] \`npm run verify\` — 1110/1110 pass (was 1107, +3 new guards)
- [x] Trinity 10.64.33 aligned
- [x] LF endings preserved on \`questions.json\` (binary-mode write)
- [x] No idx shifts — distractors.json / syllabus_data.json untouched
- [ ] verify-deploy.sh after Pages rebuilds

## Cumulative session ship train
| PR | Version | Substantive |
|---|---|---|
| #146-#152 | up to 10.64.31 | citation audit + chaos hardening + auth UX |
| #153 | 10.64.32 | Cover-Options onclick syntax fix (5-pass mystery) |
| **#NEW** | **10.64.33** | **22 broken-flag + image rescue from full audit cycle** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)