### PR TITLE
v10.64.35: Track H — broken=true entries are duplicates of canonicals

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.34",
+  "version": "10.64.35",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -6658,7 +6658,7 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.34';
+const APP_VERSION='10.64.35';
 const CHANGELOG={
 '10.64.31':[
 '☁️ Cloud backup 401/403 now actionable — when Supabase rejects the upsert because the caller isn\'t logged in, surface a Hebrew login-required toast and route to More → Settings with the auth username field focused, instead of toast-less silence (or a generic English "Backup failed: 401" with no path forward). Mirror of IM v10.4.12 / FM v1.21.10. Also fixes a stale `slice(0,200,\'info\')` typo in the generic error branch so the toast tone is now passed correctly.',

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.34';
+const CACHE='shlav-a-v10.64.35';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 // CRITICAL_URLS = the bare-minimum app shell required for offline boot.
 // Anything else (data/*.json, fonts, icons) is best-effort in the install

--- a/tests/regressionGuards.test.js
+++ b/tests/regressionGuards.test.js
@@ -522,22 +522,32 @@ describe('multi-select exam-year filter — Task 3 contract', () => {
 });
 
 // ─────────────────────────────────────────────────────────────
-// Broken-question filter (v10.64.33 regression guard)
+// Broken-question filter (v10.64.33 / v10.64.35 regression guard)
 // ─────────────────────────────────────────────────────────────
 //
-// Track D (chaos-audit 2026-05-03): 22 questions tagged 2023-Sep are
-// problematic — 6 are tag-collision duplicates of 2023-Jun-Basic, 16 are
-// multi-part stem fragments that lost their parent context during ingestion.
-// All 22 are flagged with `broken: true` and `broken_reason`.
+// Track D (chaos-audit 2026-05-03): 22 questions tagged 2023-Sep flagged
+// broken — initially classified as 6 tag-duplicates + 16 stem-fragments.
 //
-// The buildPool wrapper at line 1857 of shlav-a-mega.html filters them out
-// of every pool path. This guard locks both the data-side flag and the
-// filter wrapper.
-describe('broken-question filter — v10.64.33', () => {
+// Track H (v10.64.35, 2026-05-03): cross-PDF search against the 56-PDF
+// IMA exam corpus discovered that 13 of the 22 are EXACT DUPLICATES of
+// existing dataset entries already correctly tagged (2020 / 2021-Dec /
+// 2021-Jun / 2023-Jun-Basic). The original "stem-fragment with missing
+// parent" classification was wrong — the parent context exists in the
+// dataset at the canonical idx. broken_reason now points each one at
+// its canonical match. The 9 unmatched (idx 63, 66, 81, 85, 126, 128,
+// 139, 140, 179, 183 minus matched) keep their stem-fragment reason.
+//
+// Net effect: same 22 questions broken-flagged (filtered from pool), but
+// reasons are now medically accurate. Floor stays at 22.
+//
+// The buildPool wrapper at line 1857 of shlav-a-mega.html filters them
+// out of every pool path. This guard locks both the data-side flag and
+// the filter wrapper.
+describe('broken-question filter — v10.64.33 / v10.64.35', () => {
   let questions;
   beforeAll(() => { questions = loadJSON('data/questions.json'); });
 
-  test('there are at least 22 questions flagged broken (Track D D-1 baseline)', () => {
+  test('there are at least 22 questions flagged broken (Track D baseline)', () => {
     const broken = questions.filter(q => q.broken === true);
     expect(broken.length).toBeGreaterThanOrEqual(22);
   });


### PR DESCRIPTION
## Summary

- **Track H discovery**: 13 of the 22 broken=true 2023-Sep entries are EXACT duplicates of existing canonicals already tagged 2020 / 2021-Dec / 2021-Jun / 2023-Jun-Basic — not stem-orphans-with-missing-parent as originally classified in Track D.
- **No content changes** — broken_reason metadata only, plus version trinity bump (10.64.34 → 10.64.35) and regression test docstring update.
- **4 c-conflicts surfaced** for future answer-key audit: idx 14↔2391, 50↔2393, 97↔2400, 132↔2404, 2415↔2726 have same q+options but differing c.

## Why this is metadata-only

The buildPool wrapper at line 1857 already filters broken=true from every pool path. Users see only canonical entries. This commit just makes broken_reason accurately point at the canonical idx instead of the (incorrect) "missing parent" framing.

## Test plan
- [x] vitest: 1110/1110 pass
- [x] check-version-sync: trinity aligned at 10.64.35
- [ ] Live deploy verification post-merge (`bash scripts/verify-deploy.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)