### PR TITLE
docs: fix 3,833 → 3,743 stale-count drift + add doc-level guard

### DIFF
--- a/.claude/web-project-instructions.md
+++ b/.claude/web-project-instructions.md
@@ -16,7 +16,7 @@ cost.
 # Shlav A Mega — Israeli Geriatrics Board Exam PWA
 
 Single-file PWA at https://eiasash.github.io/Geriatrics/ — `shlav-a-mega.html`,
-no build. Hebrew-RTL, 3,833 questions, currently v10.64.47.
+no build. Hebrew-RTL, 3,743 questions, currently v10.64.47.
 
 ## Working rules (non-negotiable)
 1. Don't assume. Don't hide confusion. Surface tradeoffs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ These four rules are the floor. They override any conflicting guidance later in 
 
 - **Live URL**: https://eiasash.github.io/Geriatrics/
 - **Main file**: `shlav-a-mega.html` (~524 KB, ~7,150 lines, 210 named functions)
-- **App version**: v10.64.47 (as of 05/05/26) — 3,833 Qs across 46 topics. All 3,833 Qs carry `ref` (Hazzard / Harrison chapter + title) and pre-generated `e` explanation. Recent: v10.64.47 loading-skeleton stale count fix + STALE_COUNTS guard at `const CHANGELOG=` boundary; v10.64.46 Track-I distractor regen — 75 drifted Qs regenerated (0 fail); v10.64.45 Track-R 1547 Hazzard refs realigned to question_chapters.json authority; v10.64.42–44 Track-Q `backup_set` SECURITY DEFINER RPC + TDZ regression test + PDF externalization to GitHub Releases (-85% repo size); v10.64.30s–40 Tracks D/H/I/J/K/L/M/N/O/P — distractor regen + detector v3 + 110 curator overrides triangulated; v10.64.10–16 Q-num matcher v2/v3, 6 c_accept, 48 deletes, 501 canonical refs, 482 ref beautifications.
+- **App version**: v10.64.47 (as of 05/05/26) — 3,743 Qs across 46 topics. All 3,743 Qs carry `ref` (Hazzard / Harrison chapter + title) and pre-generated `e` explanation. Recent: v10.64.47 loading-skeleton stale count fix + STALE_COUNTS guard at `const CHANGELOG=` boundary; v10.64.46 Track-I distractor regen — 75 drifted Qs regenerated (0 fail); v10.64.45 Track-R 1547 Hazzard refs realigned to question_chapters.json authority; v10.64.42–44 Track-Q `backup_set` SECURITY DEFINER RPC + TDZ regression test + PDF externalization to GitHub Releases (-85% repo size); v10.64.30s–40 Tracks D/H/I/J/K/L/M/N/O/P — distractor regen + detector v3 + 110 curator overrides triangulated; v10.64.10–16 Q-num matcher v2/v3, 6 c_accept, 48 deletes, 501 canonical refs, 482 ref beautifications.
 - **Data**: JSON files in `data/` directory, loaded lazily at runtime
 - **Deployment**: Push to `main` → GitHub Actions validates → GitHub Pages live in ~60s
 
@@ -79,7 +79,7 @@ the full decomposition ledger and safe-next-steps list.
 ├── manifest.json            # PWA manifest
 │
 ├── data/                    # Lazy-loaded JSON data — single source of truth
-│   ├── questions.json       # 3,833 MCQs (primary runtime source, all carry `ref` + `e`)
+│   ├── questions.json       # 3,743 MCQs (primary runtime source, all carry `ref` + `e`)
 │   ├── notes.json           # 46 study topic notes
 │   ├── drugs.json           # 113 Beers/ACB drugs database
 │   ├── flashcards.json      # 159 high-yield flashcards
@@ -150,7 +150,7 @@ All runtime data lives in `data/`. The app and service worker load exclusively f
   "t": "2022",  // exam year string
   "ti": 18,     // primary topic index (0–45, see TOPICS below)
   "tis": [18, 19],  // multi-tag topic indices (v10.41+)
-  "e": "...",   // pre-generated AI explanation (populated on all 3,833 Qs)
+  "e": "...",   // pre-generated AI explanation (populated on all 3,743 Qs)
   "ref": "..."  // Hazzard / Harrison chapter + title citation
 }
 ```
@@ -484,7 +484,7 @@ GitHub Actions runs CI → on pass, GitHub Pages updates within ~60 seconds.
 |---|---|
 | Main file | `shlav-a-mega.html` (~7,150 lines, ~524 KB) |
 | Named functions | 210 (213 incl. shared/*.js, the integrity-guard counting basis) |
-| Questions | 3,833 (IMA past exams + Hazzard/Harrison AI-generated + GRS8 imports; all carry `ref` + `e`) |
+| Questions | 3,743 (IMA past exams + Hazzard/Harrison AI-generated + GRS8 imports; all carry `ref` + `e`) |
 | Topics | 46 |
 | Drugs | 113 |
 | Flashcards | 159 |
@@ -519,7 +519,7 @@ GitHub Actions runs CI → on pass, GitHub Pages updates within ~60 seconds.
 ### Recommended Additions (Priority Order)
 
 1. **OSCE station validation** — Currently no OSCE data file; if reintroduced, validate scenario completeness, task arrays, tip arrays, and cross-reference with topic index
-2. **Explanation quality checks** — Test that all 3,833 `e` fields are non-empty, >= 50 chars, contain no HTML injection, and are valid Hebrew/English text
+2. **Explanation quality checks** — Test that all 3,743 `e` fields are non-empty, >= 50 chars, contain no HTML injection, and are valid Hebrew/English text
 3. **Hazzard chapter JSON** — Validate `hazzard_chapters.json` structure, chapter numbering, and cross-reference with notes.json `ch` field
 4. **Exam year tag consistency** — Validate that each `t` field matches known exam sessions, test distribution balance across years
 5. **Topic distribution balance** — Add quantitative tests: no single topic should have >15% or <1% of total questions
@@ -560,8 +560,8 @@ Reach **1,000+ tests** with coverage of every data file, every engine function, 
 - ~~TOPICS expanded 40→46~~ — v10.41 (added Parkinson's, Arrhythmia, Dysphagia, Andropause, Prevention, Interdisciplinary Care)
 - ~~Built-in debug console~~ — v10.38 (5-tap top-right corner activation)
 - ~~GRS8 Book 3 selective import~~ — v10.37 (+77 Qs across 14 high-yield chapters)
-- ~~`ref` field on every Q~~ — Hazzard/Harrison citation populated on all 3,833 Qs
-- ~~Pre-generated `e` explanations~~ — present on all 3,833 Qs
+- ~~`ref` field on every Q~~ — Hazzard/Harrison citation populated on all 3,743 Qs
+- ~~Pre-generated `e` explanations~~ — present on all 3,743 Qs
 - ~~Hazzard chapter JSON tests~~ — `textbookChapters.test.js` covers schemas
 - ~~Add flashcard spaced repetition~~ — FSRS-4.5 wired with Due/Browse mode
 

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -12,7 +12,7 @@ This file is appended to by every `audit-fix-deploy` pipeline run. Each entry re
 |---|---|---|
 | Branch | `main` | clean after `git pull --rebase` |
 | `APP_VERSION` | 10.63.1 | trinity aligned (HTML / sw.js / package.json) |
-| Q corpus | 3833 | data/questions.json |
+| Q corpus | 3743 | data/questions.json |
 | Topics | 46 | ti 0..45 |
 | Function count | 210 | `shlav-a-mega.html` (was ~270 in stale CLAUDE.md, was ~219 in audit-fix-deploy skill text — both pre-decomposition figures; current actual is 210) |
 | Helper prefixes | 27 distinct | `_rl*`, `_rt*`, `_rqm*`, `_rq*`, `_restore*`, `_run*`, `_rpc` |
@@ -27,7 +27,7 @@ This file is appended to by every `audit-fix-deploy` pipeline run. Each entry re
 | Severity | Finding | Action |
 |---|---|---|
 | Info | All 7 verify checks green pre-audit (version sync, brace balance, two innerHTML audits, Harrison Hebrew baseline, vitest, sw-update.js syntax). No active issue. | None — pipeline confirmed healthy. |
-| Info | Skill-text Q-count drift: skill says 3326 / 4 exam dirs / 219 functions / 693 tests. Repo is at 3833 Qs / 7 exam dirs / 210 functions / 938 tests. | Recorded — central skill is reference text, not enforced. The geriatrics-dev local skill mirror should reflect real numbers (see "skill update" below). |
+| Info | Skill-text Q-count drift: skill says 3326 / 4 exam dirs / 219 functions / 693 tests. Repo is at 3743 Qs / 7 exam dirs / 210 functions / 938 tests. | Recorded — central skill is reference text, not enforced. The geriatrics-dev local skill mirror should reflect real numbers (see "skill update" below). |
 | Low | 2 ungated `console.log` lines at `shlav-a-mega.html:1254-1255` (data-load logs). | Pre-existing, intentional load-time diagnostics. No action; recorded. |
 | Low | Within-session stem duplicates in past-exam corpus (2 known cases — v10.63.1 baseline): `2025-Jun-Basic` paired vignette, `2023-Jun-Subspec` paper-cited Q×2. | New `pastExamCoverage` test pins ceiling at 10 / max 3 per stem — bumps an alarm if a future ingest doubles the corpus. |
 | Info | RLS sanity pass NOT executed this session — Supabase MCP requires interactive OAuth. `progress_state` schema-known-good per CLAUDE.md (lives in `public`, RLS on). | **Open follow-up**: run the 4 RLS queries on `krmlzwwelqvlfslwltol` next time the OAuth flow is alive. Schema has been stable since v10.59 (RPC-mediated reads, public SELECT dropped). |
@@ -91,7 +91,7 @@ Topics under 5 Qs are weak — flagged for next content pass.
 |---|---|---|
 | Topic coverage | All 46 topics have ≥9 Qs. Weakest: ti=45 (Interdisciplinary Care, n=9), ti=43 (Andropause, n=21). **Zero topics under the 5-Q threshold.** | None — content team can target ti=43-45 next, but no audit gap. |
 | Past-exam tag taxonomy | All 7 exam dirs (`2020_al`, `2021_dec_al`, `2022_jun_al`, `2023_jun_al`, `2024_may_al`, `2024_sep_al`, `2025_jun_al`) have matching tagged Qs. 1,549 Qs with year tags across 17 distinct tag values (Basic / Subspec / orphan splits). | None. |
-| Harrison/Hazzard chapter mapping | `data/question_chapters.json` has **3,833 entries** mapping every Q-index → `{haz: N, grs: N}`. **0 orphaned haz refs** (haz keys all in 1-108) and **0 orphaned har refs**. Hazzard 108 chapters / Harrison 69 chapters available. | None — clean. |
+| Harrison/Hazzard chapter mapping | `data/question_chapters.json` has **3,743 entries** mapping every Q-index → `{haz: N, grs: N}`. **0 orphaned haz refs** (haz keys all in 1-108) and **0 orphaned har refs**. Hazzard 108 chapters / Harrison 69 chapters available. | None — clean. |
 | Function-count trajectory | Current 210. History: ~270 (early v9.x) → 219 (v10.46+ decomposition) → 210 (v10.62.0 dropped renderDrugs + renderCalc shim). The drop is intentional. | Documented here so future auditors don't panic at the delta. |
 | Coverage gaps (uncalled functions) | Cross-ref `tests/*.test.js` calls vs 210 named functions in HTML: ~165 not directly invoked from any test. Most are render helpers (`_rc*` / `_rl*` / `_rqm*`) that return HTML strings — single-file PWA prevents direct unit testing. Indirect coverage via integration tests (`migrationWiring`, `trackViewMarkup`, `appLogic`). | No action — known architectural limit. |
 | `npm outdated` / `npm audit` | Skipped this pass (devDeps only — `vitest`, `acorn`, `cross-env`, `@vitest/coverage-v8`). Last audit pass cleared all known vulns. | Recheck at R3. |
@@ -134,7 +134,7 @@ Last updated: 2026-05-01 (Round 2 audit, v10.63.2).
 
 ## Codebase metrics
 - shlav-a-mega.html: 7,322 lines / 524 KB / **210 named functions**
-- Questions: **3,833** in data/questions.json (all carry ref + e)
+- Questions: **3,743** in data/questions.json (all carry ref + e)
 - Topics: 46 (ti 0..45)
 - Tests: **1,077** across **46** files
 - Brace pairs: 3,386

--- a/tests/dataIntegrity.test.js
+++ b/tests/dataIntegrity.test.js
@@ -474,6 +474,72 @@ describe("cross-file referential integrity", () => {
     ).toEqual([]);
   });
 
+  /**
+   * STALE-COUNT GUARD — repo-root documentation (v10.64.48 / 2026-05-05).
+   *
+   * The same staleness class hit CLAUDE.md, IMPROVEMENTS.md, and
+   * .claude/web-project-instructions.md when terminal Claude refreshed
+   * versions to v10.64.47 but missed the `3,833 → 3,743` count drift in
+   * docs. Existing guards (above) only scan src/study_plan.js + the live
+   * prefix of shlav-a-mega.html, so docs went unprotected.
+   *
+   * Per-line allow-list: a line containing a stale number is permitted ONLY
+   * when it ALSO contains an explicit historical-context marker (`stale`,
+   * `obsolete`, `legacy`, `historical`, `pre-v10`, `(was`, `was ~`, `was 88`,
+   * `CHANGELOG`). Anything else is flagged.
+   *
+   * To add a legitimate new historical reference: include one of those
+   * markers in the same line. To declare a new "current" total: update
+   * STALE_COUNTS below to leave only obsolete numbers.
+   */
+  it("repo docs have no current-state stale count claims", () => {
+    const fs = require("fs");
+    const path = require("path");
+    const repoRoot = path.resolve(import.meta.dirname, "..");
+    const DOC_FILES = [
+      "CLAUDE.md",
+      "IMPROVEMENTS.md",
+      ".claude/web-project-instructions.md",
+    ];
+    const STALE_COUNTS = ["3,833", "3833", "3,791", "3791", "3,795", "3795"];
+    const HISTORICAL_MARKERS = [
+      "stale",
+      "Stale",
+      "STALE",
+      "obsolete",
+      "legacy",
+      "historical",
+      "pre-v10",
+      "(was",
+      "was ~",
+      "was 88",
+      "CHANGELOG",
+      "v10.64.18",
+      "v10.64.41",
+      "v10.64.47",
+    ];
+    const violations = [];
+    for (const rel of DOC_FILES) {
+      const abs = path.join(repoRoot, rel);
+      if (!fs.existsSync(abs)) continue;
+      const lines = fs.readFileSync(abs, "utf-8").split("\n");
+      lines.forEach((line, i) => {
+        const hits = STALE_COUNTS.filter((s) => line.includes(s));
+        if (hits.length === 0) return;
+        const exempt = HISTORICAL_MARKERS.some((m) => line.includes(m));
+        if (!exempt) {
+          violations.push(
+            `${rel}:${i + 1}: stale count [${hits.join(", ")}] without historical marker — line: ${line.trim().slice(0, 120)}`,
+          );
+        }
+      });
+    }
+    expect(
+      violations,
+      `Stale count claims found in docs without historical marker:\n${violations.join("\n")}`,
+    ).toEqual([]);
+  });
+
   it("ref field cites a recognizable textbook source where present", () => {
     // Allowlist of legitimate clinical citation patterns. Add new ones as
     // sources expand; the goal is to catch obviously-broken refs (typos,

--- a/tests/pastExamCoverage.test.js
+++ b/tests/pastExamCoverage.test.js
@@ -196,7 +196,7 @@ describe('cross-file integrity — package.json vs questions corpus', () => {
   });
 
   it('Q count is in the announced ballpark (no >10% drop without intent)', () => {
-    // CLAUDE.md announces ~3,833 Qs. Tolerate growth, block large drop.
+    // CLAUDE.md announces ~3,743 Qs (was ~3,833 pre-v10.64.11 deletes). Tolerate growth, block large drop.
     // If the count drifts down, this test asks for an intentional bump.
     expect(questions.length).toBeGreaterThanOrEqual(3500);
   });


### PR DESCRIPTION
Web Claude audit 2026-05-05 caught 9 stale 3,833 references across CLAUDE.md / IMPROVEMENTS.md / .claude/web-project-instructions.md after the v10.64.47 currency refresh missed updating the question count alongside the version bump.

The existing STALE_COUNTS guards in tests/dataIntegrity.test.js scan src/study_plan.js + the live prefix of shlav-a-mega.html — but not docs. So docs went unprotected and the bug shipped to main as 6349961.

## Fixes
- .claude/web-project-instructions.md:19 — 3,833 → 3,743
- CLAUDE.md (7 lines) — 3,833 → 3,743
- IMPROVEMENTS.md (4 lines) — 3833/3,833 → 3743/3,743
- tests/pastExamCoverage.test.js:199 — comment refreshed

## New guard
tests/dataIntegrity.test.js gets a third STALE_COUNTS test that scans the three doc files. Per-line allow-list permits stale numbers when accompanied by a historical-context marker (stale, obsolete, legacy, historical, pre-v10, (was, CHANGELOG, v10.64.18, v10.64.41, v10.64.47).

## Verify
- npm run verify clean — 1097 passed, 7 skipped, 47 test files
- Authority sources untouched — no q.c, q.o[], q.e mutations
- Lane discipline: branch-based since terminal Claude shipped v10.64.47 ~recently