### PR TITLE
test: 110-curator-override ratchet (Tracks J+L+O 16 overrides)

### DIFF
--- a/.audit_logs/curator_overrides.json
+++ b/.audit_logs/curator_overrides.json
@@ -1,0 +1,181 @@
+{
+  "_meta": {
+    "purpose": "Machine-readable registry of curator overrides where dataset's q.c is medically correct but disagrees with IMA's published answer key. Pinned by tests/curatorOverridesRatchet.test.js — flips will fail loud.",
+    "created": "2026-05-05",
+    "source_docs": [
+      ".audit_logs/TRACK_J_FINDINGS.md",
+      ".audit_logs/TRACK_L_FINDINGS.md",
+      ".audit_logs/TRACK_O_P_FINDINGS.md"
+    ],
+    "appendable": true,
+    "note_94_prior": "94 prior overrides documented in .audit_logs/review/{tag}.md evidence sheets (per-tag Markdown narratives). Not yet machine-extracted. This file currently pins the 16 fresh overrides from Tracks J+L+O (2026-05-04). Append further entries as they're audited."
+  },
+  "overrides": [
+    {
+      "idx": 2391,
+      "expected_c": 3,
+      "track": "J",
+      "tag": "2020",
+      "qnum": 10,
+      "topic_short": "stage-4 pressure ulcer + sepsis abx",
+      "rationale": "Polymicrobial infection requires broad-spectrum; cefazolin (IMA pick) insufficient. Hazzard Ch 46.",
+      "ima_published_c": 2
+    },
+    {
+      "idx": 2393,
+      "expected_c": 3,
+      "track": "J",
+      "tag": "2020",
+      "qnum": 25,
+      "topic_short": "anemia in MRSA sepsis (ACD pattern)",
+      "rationale": "Low transferrin rules out IDA; iron+transferrin+ferritin pattern is textbook ACD. Treat infection.",
+      "ima_published_c": 1
+    },
+    {
+      "idx": 2400,
+      "expected_c": 3,
+      "track": "J",
+      "tag": "2020",
+      "qnum": 27,
+      "topic_short": "fulminant CDI antibiotic choice",
+      "rationale": "IDSA 2017+ guidelines: fulminant CDI requires PO vanco + IV metronidazole. IMA's PO metronidazole predates update.",
+      "ima_published_c": 0
+    },
+    {
+      "idx": 2404,
+      "expected_c": 1,
+      "track": "J",
+      "tag": "2021-Jun",
+      "qnum": 23,
+      "topic_short": "early amiodarone thyroid pattern",
+      "rationale": "Elevated TSH + Wolff-Chaikoff pattern is expected, not pathologic. Beta-blockers inappropriate.",
+      "ima_published_c": null
+    },
+    {
+      "idx": 2726,
+      "expected_c": 0,
+      "expected_c_accept": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "track": "J",
+      "tag": "2023-Jun-Basic",
+      "qnum": 24,
+      "topic_short": "multi-cause AKI on rehab",
+      "rationale": "IMA appeal accepted all four answers — multi-accept question.",
+      "ima_published_c": 0
+    },
+    {
+      "idx": 2395,
+      "expected_c": 2,
+      "track": "L",
+      "tag": "2020",
+      "qnum": 17,
+      "topic_short": "post-NSTEMI discharge meds (HR 58, LVEF 45%)",
+      "rationale": "RAMIPRIL alone — HR 58 contraindicates BB, controlled BP makes lerc redundant, LVEF 45% needs ACE-I.",
+      "ima_published_c": 1
+    },
+    {
+      "idx": 2402,
+      "expected_c": 0,
+      "track": "L",
+      "tag": "2021-Jun",
+      "qnum": 24,
+      "topic_short": "urgent dialysis indication",
+      "rationale": "AEIOU + severe AS context: pulmonary edema refractory to volume = absolute indication.",
+      "ima_published_c": null
+    },
+    {
+      "idx": 2403,
+      "expected_c": 1,
+      "track": "L",
+      "tag": "2021-Jun",
+      "qnum": 15,
+      "topic_short": "MM bone-event prophylaxis",
+      "rationale": "Pamidronate is IMWG traditional first-line. Denosumab non-inferior but alternative.",
+      "ima_published_c": null
+    },
+    {
+      "idx": 2405,
+      "expected_c": 1,
+      "track": "L",
+      "tag": "2021-Jun",
+      "qnum": 16,
+      "topic_short": "PMR diagnostic feature",
+      "rationale": "ANA- is the only PMR-supportive feature among options. Microcytic anemia + RF+ argue against PMR.",
+      "ima_published_c": null
+    },
+    {
+      "idx": 154,
+      "expected_c": 2,
+      "track": "O",
+      "tag": "2020",
+      "qnum": 58,
+      "topic_short": "OSA workup",
+      "rationale": "Sleep study — classic OSA picture. AI agrees. IMA's anticholinergic pick is wrong.",
+      "ima_published_c": 1
+    },
+    {
+      "idx": 2442,
+      "expected_c": 1,
+      "track": "O",
+      "tag": "2020",
+      "qnum": 84,
+      "topic_short": "Patient Rights Law",
+      "rationale": "Inform patient — Law 1996 §13-15 is absolute. IMA's defer-to-family pick is illegal.",
+      "ima_published_c": 0
+    },
+    {
+      "idx": 2518,
+      "expected_c": 0,
+      "track": "O",
+      "tag": "2022-Jun-Basic",
+      "qnum": 85,
+      "topic_short": "Brookdale demographic statistics",
+      "rationale": "Curator override on uncertain Brookdale figure. 3-way split with no clear winner; canonical preserved.",
+      "ima_published_c": 3
+    },
+    {
+      "idx": 2900,
+      "expected_c": 2,
+      "track": "O",
+      "tag": "2024-May-Basic",
+      "qnum": 103,
+      "topic_short": "RBD precedes Parkinson's",
+      "rationale": "Textbook prodromal synucleinopathy. AI agrees. IMA multi-accept misses the correct answer.",
+      "ima_published_c": null
+    },
+    {
+      "idx": 3509,
+      "expected_c": 0,
+      "track": "O",
+      "tag": "2024-Sep-Subspec",
+      "qnum": 20,
+      "topic_short": "CURB-65 = 1 mortality",
+      "rationale": "<2% mortality at CURB-65=1 → community-treated. AI agrees. IMA's >20% pick is wrong.",
+      "ima_published_c": 2
+    },
+    {
+      "idx": 341,
+      "expected_c": 3,
+      "track": "O",
+      "tag": "2021-Dec",
+      "qnum": 30,
+      "topic_short": "Torsades de pointes culprit drug",
+      "rationale": "Rivaroxaban does not prolong QT; FQs (levofloxacin) do. AI agrees. IMA's pick is wrong.",
+      "ima_published_c": 2
+    },
+    {
+      "idx": 2515,
+      "expected_c": 2,
+      "track": "O",
+      "tag": "2021-Dec",
+      "qnum": 5,
+      "topic_short": "CKD anemia management threshold",
+      "rationale": "KDIGO threshold Hgb 10 — at 11.1, no treatment. 3-way split; canonical is best-defensible.",
+      "ima_published_c": 3
+    }
+  ]
+}

--- a/tests/curatorOverridesRatchet.test.js
+++ b/tests/curatorOverridesRatchet.test.js
@@ -1,0 +1,122 @@
+/**
+ * Curator-override ratchet test.
+ *
+ * Pins the questions where the dataset's `q.c` is medically correct but
+ * disagrees with IMA's published answer key. These are documented in
+ * `.audit_logs/curator_overrides.json` (machine-readable registry) and
+ * narratively in `.audit_logs/TRACK_J_FINDINGS.md`,
+ * `TRACK_L_FINDINGS.md`, `TRACK_O_P_FINDINGS.md`.
+ *
+ * Why this exists: across Tracks J + L + O (2026-05-04), 16 c-disagreements
+ * were triangulated (clinical reasoning + IMA + Track-A AI) and 0 flips
+ * warranted — IMA's published key is medically wrong in ~70% of cases.
+ * A future "helpful" audit could silently flip these back toward IMA's wrong
+ * key, undoing the curator's correction. This test fails loud if any pinned
+ * override no longer matches expectation.
+ *
+ * Coverage: 16 of ~110 documented overrides (Tracks J+L+O). The remaining
+ * 94 prior overrides live in unstructured per-tag evidence sheets at
+ * `.audit_logs/review/{tag}.md`. They can be machine-extracted and appended
+ * to `curator_overrides.json` in a future pass — the ratchet floor today
+ * is the 16 that have clean structured source.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const ROOT = resolve(import.meta.dirname, "..");
+
+function loadJSON(filename) {
+  return JSON.parse(readFileSync(resolve(ROOT, filename), "utf-8"));
+}
+
+let questions, registry;
+
+beforeAll(() => {
+  questions = loadJSON("data/questions.json");
+  registry = loadJSON(".audit_logs/curator_overrides.json");
+});
+
+describe("Curator-override ratchet", () => {
+  it("registry exists and is non-empty", () => {
+    expect(registry).toBeTruthy();
+    expect(registry.overrides).toBeInstanceOf(Array);
+    expect(registry.overrides.length).toBeGreaterThanOrEqual(16);
+  });
+
+  it("registry meta documents purpose + appendability", () => {
+    expect(registry._meta).toBeTruthy();
+    expect(registry._meta.purpose).toMatch(/curator override/i);
+    expect(registry._meta.appendable).toBe(true);
+  });
+
+  // Per-entry: idx exists in questions, q.c matches expected, c_accept
+  // shape matches if specified. This is the actual ratchet — flipping any
+  // pinned q.c will fail this test loudly with the offending idx.
+  it("every override entry's q.c matches expected_c", () => {
+    const failures = [];
+    for (const entry of registry.overrides) {
+      const q = questions[entry.idx];
+      if (!q) {
+        failures.push(
+          `idx=${entry.idx} (${entry.track}/${entry.tag}/q#${entry.qnum}): missing from questions.json`,
+        );
+        continue;
+      }
+      if (q.c !== entry.expected_c) {
+        failures.push(
+          `idx=${entry.idx} (${entry.track}/${entry.tag}/q#${entry.qnum}): expected c=${entry.expected_c}, got c=${q.c} — ${entry.topic_short}`,
+        );
+      }
+    }
+    expect(failures, failures.join("\n  ")).toEqual([]);
+  });
+
+  it("c_accept arrays match registry where pinned", () => {
+    const failures = [];
+    for (const entry of registry.overrides) {
+      if (!entry.expected_c_accept) continue;
+      const q = questions[entry.idx];
+      if (!q) continue; // already failed above
+      const actual = q.c_accept || null;
+      const expected = entry.expected_c_accept;
+      if (
+        !Array.isArray(actual) ||
+        actual.length !== expected.length ||
+        !expected.every((v, i) => v === actual[i])
+      ) {
+        failures.push(
+          `idx=${entry.idx}: expected c_accept=${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+        );
+      }
+    }
+    expect(failures, failures.join("\n  ")).toEqual([]);
+  });
+
+  it("primary c is in c_accept when c_accept is present (registry consistency)", () => {
+    for (const entry of registry.overrides) {
+      if (!entry.expected_c_accept) continue;
+      expect(
+        entry.expected_c_accept,
+        `registry idx=${entry.idx}: expected_c=${entry.expected_c} not in expected_c_accept ${JSON.stringify(entry.expected_c_accept)}`,
+      ).toContain(entry.expected_c);
+    }
+  });
+
+  it("track tags are J / L / O (Tracks H+J+K+L+O+P narrative)", () => {
+    const allowed = new Set(["J", "L", "N", "O", "P"]);
+    for (const entry of registry.overrides) {
+      expect(allowed, `idx=${entry.idx} unexpected track ${entry.track}`).toContain(entry.track);
+    }
+  });
+
+  it("idx + qnum are non-negative integers", () => {
+    for (const entry of registry.overrides) {
+      expect(Number.isInteger(entry.idx)).toBe(true);
+      expect(entry.idx).toBeGreaterThanOrEqual(0);
+      expect(Number.isInteger(entry.qnum)).toBe(true);
+      expect(entry.qnum).toBeGreaterThanOrEqual(1);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Pins the 16 fresh curator overrides from Tracks J+L+O (2026-05-04) where the dataset's `q.c` is medically correct but disagrees with IMA's published answer key. Without a regression test, a future "helpful" audit could silently flip these back toward IMA's wrong key.

## Why this matters

Across 16 c-disagreements audited via 3-signal triangulation (clinical reasoning + IMA + Track-A AI), **0 flips warranted**. IMA's published key is medically wrong in ~70% of disagreement cases. Examples: post-2017-IDSA fulminant CDI, Wolff-Chaikoff amiodarone pattern, AEIOU urgent-dialysis indication, RBD prodromal synucleinopathy.

## What this PR adds

- `.audit_logs/curator_overrides.json` — machine-readable registry, appendable for future audits
- `tests/curatorOverridesRatchet.test.js` — 7 cases asserting per-entry `q.c` (and `q.c_accept` where pinned) matches expected. Mutation-tested.

## Coverage

16 of ~110 documented overrides. The 94 prior remain narrative-only in `.audit_logs/review/{tag}.md`. Future pass can machine-extract them.

## Test plan

- [x] `npm run verify` clean (1103 passed | 7 skipped, was 1096+7 before this PR)
- [x] Mutation test: changing `overrides[0].expected_c=99` makes the test fail loud with `"idx=2391 (J/2020/q#10): expected c=99, got c=3 — stage-4 pressure ulcer + sepsis abx"`. Restored, suite green.
- [ ] CI green
- [ ] No live witness needed — test-only, no shipped behavior change, no trinity bump

## Notes

No trinity bump per pushback agreement — test-only addition, no SW cache invalidation needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)