### PR TITLE
Bot C + Bot D default to claude-opus-4-7

### DIFF
--- a/scripts/gen_ai_hard_geri.mjs
+++ b/scripts/gen_ai_hard_geri.mjs
@@ -41,7 +41,7 @@ const API_KEY = process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_API_KEY;
 if (!API_KEY) { console.error('ANTHROPIC_API_KEY (or CLAUDE_API_KEY) env var not set.'); process.exit(2); }
 if (API_KEY.length !== 108) { console.error(`API key length=${API_KEY.length}, expected 108`); process.exit(2); }
 
-const MODEL = process.env.AI_MODEL || 'claude-sonnet-4-6';
+const MODEL = process.env.AI_MODEL || 'claude-opus-4-7';
 const COST_CAP_USD = Number(process.env.CHAOS_COST_CAP_USD || 25);
 const COST = { calls: 0, inTok: 0, outTok: 0 };
 const priceUsd = () => (COST.inTok / 1e6) * 3 + (COST.outTok / 1e6) * 15;

--- a/scripts/source-scanner.mjs
+++ b/scripts/source-scanner.mjs
@@ -35,7 +35,7 @@ import process from 'node:process';
 import { extractJson } from './lib/extractJson.mjs';
 
 const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
-const MODEL = process.env.SCAN_MODEL || 'claude-sonnet-4-6';
+const MODEL = process.env.SCAN_MODEL || 'claude-opus-4-7';
 const KEY = process.env.CLAUDE_API_KEY;
 if (!KEY) { console.error('CLAUDE_API_KEY not set'); process.exit(2); }
 if (KEY.length !== 108) { console.error(`CLAUDE_API_KEY length=${KEY.length}, expected 108`); process.exit(2); }


### PR DESCRIPTION
Per user directive: Bot C (gen_ai_hard_geri.mjs) + Bot D (source-scanner.mjs) default to Opus 4.7 for sharper board-grade reasoning. Env override preserved (AI_MODEL / SCAN_MODEL). Cost ~5x. Phase 7 was already on opus-4-7 from scaffold. Chaos doctor-bots stay on Sonnet for bulk telemetry.