### PR TITLE
chaos doctor-bot v4: claude-opus-4-7 default

### DIFF
--- a/scripts/chaos-doctor-bot-v4.mjs
+++ b/scripts/chaos-doctor-bot-v4.mjs
@@ -49,7 +49,7 @@ import { extractJson } from './lib/extractJson.mjs';
 
 const DEFAULT_URL = 'https://eiasash.github.io/Geriatrics/';
 const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
-const MODEL = process.env.CHAOS_MODEL || 'claude-sonnet-4-6';
+const MODEL = process.env.CHAOS_MODEL || 'claude-opus-4-7';
 
 const CONFIG = {
   url: process.env.CHAOS_URL || DEFAULT_URL,


### PR DESCRIPTION
Sibling-aligned with FM + IM. Cost ~5x. CHAOS_MODEL env override preserved.