### PR TITLE
v10.64.68: vision_eye batch (18 q.ref Ch 34→Ch 33)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.67",
+  "version": "10.64.68",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -6994,8 +6994,11 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.67';
+const APP_VERSION='10.64.68';
 const CHANGELOG={
+'10.64.68':[
+'🔭 Bot D Opus 4.7 vision_eye cluster batch (web Claude pre-staged Hazzard 8e PDF verification): 18 questions about AMD/cataract/glaucoma/visual impairment had q.ref incorrectly citing "Hazzard Ch 34 — HEARING LOSS: ASSESSMENT AND MANAGEMENT" (literally the wrong sense). Repointed to "Hazzard Ch 33 — LOW VISION: ASSESSMENT AND REHABILITATION". Source verified against Hazzard 8e Ch 33 PDF passages on AMD (p ~473), cataract (p 474), glaucoma. Affected idx: 263, 264, 412, 445, 449, 463, 466, 633, 634, 635, 636, 640, 1236, 1238, 1239, 1242, 1243, 1247. Edge cases held out for separate triage: idx 101 (compound ref with Harrison suffix), idx 608 (legal-citation exception per CLAUDE.md ids 29-35), idx 2589 (different wrong ref Ch 88). 12 actual hearing-loss questions retain their correct Ch 34 ref.',
+],
 '10.64.67':[
 '🧹 Bot D Opus 4.7 surfaced 26 q.ref entries with "FRAIL TY" typo (should be "FRAILTY"). Cosmetic fix to chapter-name string in citation field; no answer/option/explanation changes. All 26 sampled questions verified to be genuine Hazzard Ch 42 (Frailty) topics — Fried criteria, frailty assessment, peri-op frailty. Sample-verified 5/26 against question content before applying.',
 ],

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.67';
+const CACHE='shlav-a-v10.64.68';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 // CRITICAL_URLS = the bare-minimum app shell required for offline boot.
 // Anything else (data/*.json, fonts, icons) is best-effort in the install


### PR DESCRIPTION
**First cluster-batch from Bot D Opus 4.7 triage pipeline.**

Web Claude pre-staged Hazzard 8e Ch 33 source verification (`.audit_logs/bot_d_opus_triage_2026-05-08/clusters/vision_eye_SOURCE_PRESTAGE.md`).

18 surgical q.ref edits — vision questions (AMD/cataract/glaucoma/visual impairment) repointed from Ch 34 HEARING (literally wrong sense) to Ch 33 LOW VISION. Source quotes from Hazzard 8e in commit body.

Edge cases (idx 101/608/2589) held out for separate triage.
12 actual hearing-loss questions retain Ch 34 ref.
1228 tests pass. npm run verify clean.