### PR TITLE
v10.64.69: Israeli-source cluster batch — 38 q.ref edits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.68",
+  "version": "10.64.69",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -6994,8 +6994,11 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.68';
+const APP_VERSION='10.64.69';
 const CHANGELOG={
+'10.64.69':[
+'⚖️ Bot D Opus 4.7 Israeli-source cluster batch (terminal-only, no PDF prestage — Israeli statutes/reports are well-known canonical citations). 38 questions had q.ref incorrectly citing a Hazzard chapter when the actual source is an Israeli statute, MOH circular, or Israeli statistical report. Repointed to: 4 Dying Patient Law (התשס"ו-2005), 8 Patient Rights Law (התשנ"ו-1996), 6 Legal Capacity & Guardianship Law (תיקון 18 / 2016 — ייפוי כוח מתמשך / מקבל החלטות נתמך), 4 חוזר מנכ"ל 6/2023 (driving fitness), 1 NHI Law (התשנ"ד-1994), 1 Equal Rights for PWD Law (התשנ"ח-1998), 13 JDC-Brookdale "65+ בישראל" statistical compendium, 1 Ministry of Justice General Custodian. Pre-condition guard verified all 38 idx held expected old refs (Ch 7: 15, Ch 26: 10, Ch 2: 13). Manual triage held out: idx 454 (epilepsy/driving — Min. of Transport vs MOH unclear), idx 456 (sleep meds + driving — bot suggested Hazzard not statute), idx 608 (carry-forward from vision_eye batch — qid follows ids 29-35 legal-exception pattern), idx 955 (MCI driving — bot suggested Hazzard Ch 28 not MOH circular).',
+],
 '10.64.68':[
 '🔭 Bot D Opus 4.7 vision_eye cluster batch (web Claude pre-staged Hazzard 8e PDF verification): 18 questions about AMD/cataract/glaucoma/visual impairment had q.ref incorrectly citing "Hazzard Ch 34 — HEARING LOSS: ASSESSMENT AND MANAGEMENT" (literally the wrong sense). Repointed to "Hazzard Ch 33 — LOW VISION: ASSESSMENT AND REHABILITATION". Source verified against Hazzard 8e Ch 33 PDF passages on AMD (p ~473), cataract (p 474), glaucoma. Affected idx: 263, 264, 412, 445, 449, 463, 466, 633, 634, 635, 636, 640, 1236, 1238, 1239, 1242, 1243, 1247. Edge cases held out for separate triage: idx 101 (compound ref with Harrison suffix), idx 608 (legal-citation exception per CLAUDE.md ids 29-35), idx 2589 (different wrong ref Ch 88). 12 actual hearing-loss questions retain their correct Ch 34 ref.',
 ],

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.68';
+const CACHE='shlav-a-v10.64.69';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 // CRITICAL_URLS = the bare-minimum app shell required for offline boot.
 // Anything else (data/*.json, fonts, icons) is best-effort in the install

--- a/tests/dataIntegrity.test.js
+++ b/tests/dataIntegrity.test.js
@@ -557,8 +557,8 @@ describe("cross-file referential integrity", () => {
         "CDC", "ACIP", "STEADI", "WHO",
         // Trial / cohort name patterns
         "Trial", "Study", "Cohort",
-        // Israeli MOH / clinical guidance
-        "חוזר", "חוק",
+        // Israeli MOH / clinical guidance + Israeli statutes / government / statistical sources
+        "חוזר", "חוק", "מכון", "משרד", "אפוטרופוס", "הלשכה", "הר\"י", "למ\"ס",
       ].join("|"),
       "i",
     );


### PR DESCRIPTION
## Summary

Bot D Opus 4.7 Israeli-source batch — second cluster drained from the
2026-05-08 wrong_textbook triage queue (vision_eye PR #170 was first).

38 questions had q.ref citing the wrong Hazzard chapter (Ch 7 / Ch 26 / Ch 2)
when the actual source is an Israeli statute, MOH circular, or Israeli
statistical report. Repointed to canonical Israeli citations.

**Lane discipline:** terminal-only batch — Israeli statutes are
well-known canonical citations; no Hazzard PDF prestage required
(deviation from Phase 2 protocol, explicitly approved per "apply A").

## Citation breakdown

| # | Citation | idx |
|---:|---|---|
| 4 | Dying Patient Law (התשס"ו-2005) | 31, 564, 573, 2667 |
| 8 | Patient Rights Law (התשנ"ו-1996) | 504, 507, 613, 616, 617, 2442, 2446, 2450 |
| 6 | Legal Capacity & Guardianship (תיקון 18 / 2016) | 515, 603, 605, 609, 610, 2443 |
| 4 | חוזר מנכ"ל 6/2023 (driving fitness) | 453, 509, 512, 593 |
| 1 | NHI Law (התשנ"ד-1994) | 619 |
| 1 | Equal Rights for PWD Law (התשנ"ח-1998) | 622 |
| 13 | JDC-Brookdale "65+ בישראל" | 93, 121, 195, 2397, 2518, 2613, 2675, 2901, 2972, 3198, 3259, 3323, 3461 |
| 1 | Ministry of Justice General Custodian | 607 |

## Pre-condition guard + count math

- All 38 idx verified to hold expected old refs before edit.
- Ch 7: 101 → 86 (drop 15) ✓
- Ch 26: 68 → 58 (drop 10) ✓
- Ch 2: 32 → 19 (drop 13) ✓
- Total old-refs removed: 38, total new-citations added: 38 ✓

## Manual triage held out (NOT in this batch)

- idx 454 — epilepsy/driving: bot suggested Min. of Transport, ambiguous vs MOH circular
- idx 456 — sleep meds + driving: bot suggested Hazzard Ch 41, not Israeli source
- idx 608 — carry-forward from vision_eye batch (qid follows ids 29-35 legal-exception pattern)
- idx 955 — MCI driving evaluation: bot suggested Hazzard Ch 28

## Test changes

`tests/dataIntegrity.test.js` REF_PATTERN allowlist extended with
Israeli-source keywords: `מכון | משרד | אפוטרופוס | הלשכה | הר"י | למ"ס`.
Per the test's stated intent ("Add new ones as sources expand").

## Test plan

- [x] Pre-condition guard passes for all 38 idx
- [x] `npm run verify` passes (1228 tests, 0 failed)
- [x] Trinity sync at v10.64.69
- [x] CHANGELOG entry for v10.64.69 added
- [ ] verify-deploy.sh confirms live URL serving v10.64.69 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)