### PR TITLE
v10.64.70: atomic 5 batch — carry-forward + manual triage drains

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.69",
+  "version": "10.64.70",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -6994,8 +6994,11 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.69';
+const APP_VERSION='10.64.70';
 const CHANGELOG={
+'10.64.70':[
+'🧹 Atomic 5 batch — drains carry-forward edge cases from vision_eye (PR #170) and manual-triage holdouts from Israeli-source batch (PR #171). idx 101 (vision Q double-wrong: cited Ch 34 HEARING + Harrison 52 Jaundice for a vision question — fixed to Hazzard 8e Ch 33 LOW VISION + Harrison 22e visual loss). idx 2589 (vision Q wrongly cited Ch 88 CANCER — same fix). idx 454 (epilepsy + driving fitness — repointed to MOH Director-General Circular 6/2023, not Min. of Transport). idx 955 (MCI + driving evaluation — same MOH 6/2023 circular, MCI section, not Hazzard Ch 28 Geriatric Assessment which doesn\'t carry the regulatory threshold). idx 456 (sleep meds + driving — Hazzard 8e sleep chapter, generic). Pre-condition guard verified all 5 idx held distinct expected old refs. Test changes: REF_PATTERN allowlist extended with "MOH" for the Director-General Circular citation format. idx 608 still held out — user surfacing Q text for the legal_capacity ref decision.',
+],
 '10.64.69':[
 '⚖️ Bot D Opus 4.7 Israeli-source cluster batch (terminal-only, no PDF prestage — Israeli statutes/reports are well-known canonical citations). 38 questions had q.ref incorrectly citing a Hazzard chapter when the actual source is an Israeli statute, MOH circular, or Israeli statistical report. Repointed to: 4 Dying Patient Law (התשס"ו-2005), 8 Patient Rights Law (התשנ"ו-1996), 6 Legal Capacity & Guardianship Law (תיקון 18 / 2016 — ייפוי כוח מתמשך / מקבל החלטות נתמך), 4 חוזר מנכ"ל 6/2023 (driving fitness), 1 NHI Law (התשנ"ד-1994), 1 Equal Rights for PWD Law (התשנ"ח-1998), 13 JDC-Brookdale "65+ בישראל" statistical compendium, 1 Ministry of Justice General Custodian. Pre-condition guard verified all 38 idx held expected old refs (Ch 7: 15, Ch 26: 10, Ch 2: 13). Manual triage held out: idx 454 (epilepsy/driving — Min. of Transport vs MOH unclear), idx 456 (sleep meds + driving — bot suggested Hazzard not statute), idx 608 (carry-forward from vision_eye batch — qid follows ids 29-35 legal-exception pattern), idx 955 (MCI driving — bot suggested Hazzard Ch 28 not MOH circular).',
 ],

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.69';
+const CACHE='shlav-a-v10.64.70';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 // CRITICAL_URLS = the bare-minimum app shell required for offline boot.
 // Anything else (data/*.json, fonts, icons) is best-effort in the install

--- a/tests/dataIntegrity.test.js
+++ b/tests/dataIntegrity.test.js
@@ -559,6 +559,7 @@ describe("cross-file referential integrity", () => {
         "Trial", "Study", "Cohort",
         // Israeli MOH / clinical guidance + Israeli statutes / government / statistical sources
         "חוזר", "חוק", "מכון", "משרד", "אפוטרופוס", "הלשכה", "הר\"י", "למ\"ס",
+        "MOH", "Circular", "Director-General",
       ].join("|"),
       "i",
     );


### PR DESCRIPTION
## Summary

Drains 5 atomic edge cases held out from prior batches:
- 2 carry-forward from vision_eye (PR #170): idx 101, 2589
- 3 manual-triage from Israeli-source (PR #171): idx 454, 955, 456

## Per-idx changes

| idx | old ref | new ref |
|---:|---|---|
| 101 | Hazzard Ch 34 HEARING + Harrison Ch 52 Jaundice | Hazzard 8e Ch 33 LOW VISION · Harrison 22e Visual Loss |
| 2589 | Hazzard Ch 88 CANCER | Hazzard 8e Ch 33 LOW VISION · Harrison 22e Visual Loss |
| 454 | Hazzard Ch 26 LEGAL ISSUES | Israeli MOH Director-General Circular 6/2023 — כשירות לנהיגה |
| 955 | Hazzard Ch 26 LEGAL ISSUES | Israeli MOH Director-General Circular 6/2023 — כשירות לנהיגה (MCI section) |
| 456 | Hazzard Ch 26 LEGAL ISSUES | Hazzard 8e Ch on Sleep Disorders in Older Adults |

## Reasoning

- **101 / 2589**: both are vision questions previously held out as
  carry-forward. 101 had a compound double-wrong ref (HEARING +
  Jaundice for a vision Q); 2589 had Ch 88 CANCER for a vision Q.
  Both repointed to the LOW VISION compound.
- **454 / 955**: driving fitness questions. The MOH Director-General
  Circular 6/2023 is the actual Israeli regulator for medical
  driving-fitness assessment (covers epilepsy, MCI, dementia, etc).
  Bot's earlier suggestions (Min. of Transport for 454, Hazzard Ch
  28 Geriatric Assessment for 955) miss the regulatory threshold.
- **456**: generic sleep-meds question. Hazzard sleep chapter is the
  appropriate textbook citation; bot already named this in suggestion.

## Pre-condition guard + count math

All 5 idx held distinct expected old refs before edit. Each verified
post-apply against its specific new_ref. No bulk count-math (each
edit is unique).

## Held out: idx 608

The original "ids 29-35 schema-exception" tag from the carry-forward
list turned out not to apply on terminal's schema check (idx 608
has the same standard schema as peers). Surfacing the Q text for
user confirmation before applying.

## Test plan

- [x] All 5 pre-condition guards passed
- [x] `npm run verify` passes (1228 tests, 0 failed)
- [x] Trinity sync at v10.64.70
- [x] CHANGELOG entry for v10.64.70 added
- [x] REF_PATTERN extended to allow MOH / Circular / Director-General
- [ ] verify-deploy.sh confirms live URL serves v10.64.70 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)