### PR TITLE
v10.64.72: idx 608 → legal_capacity (false carry-forward drain)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.71",
+  "version": "10.64.72",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -6994,8 +6994,11 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.71';
+const APP_VERSION='10.64.72';
 const CHANGELOG={
+'10.64.72':[
+'⚖️ idx 608 false-carry-forward drain — single q.ref edit. After Eias\'s schema check confirmed identical keys to peers, the "ids 29-35 schema-exception" tag from yesterday\'s vision_eye dictation was identified as cautious-misapplied. idx 608 is unambiguously Israeli ייפוי כוח מתמשך (the joint/separate-by-domain modes and General Custodian filing are defining features of Amendment 18 / 2016 to the Legal Capacity Law). Repointed to canonical legal_capacity citation, mirroring the exact string already shipped to idx 515, 603, 605, 609, 610, 2443 in PR #171 — bucket consistency. legal_capacity peer count: 6 → 7. ti=32 (Guardianship) sits in the 29-35 legal-topics exception range that project rules carve out for Israeli law citations.',
+],
 '10.64.71':[
 '🧹 Ch 22 suffix-strip pilot — drains 5 questions where bot-flagged compound ref "Hazzard Ch 22 — MEDICATION PRESCRIBING AND DE-PRESCRIBING· Harrison Ch [286/79]" had Ch 22 confirmed correct but a wrong-stamped Harrison suffix. Repointed to clean "Hazzard Ch 22 — MEDICATION PRESCRIBING AND DE-PRESCRIBING" (canonical form already used 117× in repo). Affected idx: 221 (lorazepam insomnia adverse effects), 1310 (warfarin/AF + MCI med-adherence), 1731 (diphenhydramine OTC + confusion/falls), 1917 (chemo metoclopramide EPS), 3406 (anticholinergic effect comparison). Bot for each explicitly named "Ch 22 is appropriate; remove Harrison [STEMI/Cancer-Infections] which is unrelated". 22 of 27 flagged compound-ref questions held back: 4 borderline (Ch 22 plausible but bot prefers different chapter — idx 29, 301, 1454, 1593) and 18 wrong-cluster (Ch 22 itself is wrong half — idx 206, 341, 351, 1314, 1397, 1511, 1737, 1774, 1786, 1888, 1967, 2154, 2308, 1916, 1920, 1958, 1960, 2179) queued for SZMC-project per-Q prestage. 5 unflagged questions sharing the same compound ref (idx 46, 1745, 1751, 1752, 2248) NOT touched — bot did not flag them; 2248 is genuine STEMI Q where compound ref may be correct.',
 ],

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.71';
+const CACHE='shlav-a-v10.64.72';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 // CRITICAL_URLS = the bare-minimum app shell required for offline boot.
 // Anything else (data/*.json, fonts, icons) is best-effort in the install


### PR DESCRIPTION
## Summary

Single q.ref edit. Drains a flag that was held back from PR #171 due
to a cautious-misapplied "ids 29-35 schema-exception" tag from the
vision_eye carry-forward dictation.

After terminal's schema check confirmed identical keys to peers and
ti=32 (Guardianship) sits in the documented 29-35 legal-topics
exception range, idx 608 was confirmed as a clean legal_capacity
candidate.

| field | before | after |
|---|---|---|
| `ref` | Hazzard Ch 26 — LEGAL ISSUES | חוק הכשרות המשפטית והאפוטרופסות, התשכ"ב-1962, תיקון 18 (2016) — ייפוי כוח מתמשך / מקבל החלטות נתמך |

Mirrors the exact string already shipped to idx 515, 603, 605, 609,
610, 2443 in PR #171. **legal_capacity bucket peer count: 6 → 7.**

## Q content

`q`: כמה מיופי כוח ניתן למנות בייפוי כוח מתמשך?

The joint/separate-by-domain proxy modes (option 0, the correct
answer) and General Custodian filing (referenced in the explanation)
are defining features of Amendment 18 (2016) to the Legal Capacity &
Guardianship Law. There is no Hazzard chapter that covers this — Ch
26 covers US legal frameworks (advance directives, healthcare
proxies, US POA), so the original stamp was wrong on substance.

## Test plan

- [x] Pre-condition guard passed (idx 608 held expected old ref)
- [x] `npm run verify` passes (1228 tests, 0 failed)
- [x] Trinity sync at v10.64.72
- [x] CHANGELOG entry added
- [x] Bucket-consistency check: 6 peers pre-apply, 7 post-apply
- [ ] verify-deploy.sh confirms live URL serves v10.64.72 after merge

## Meta-finding (optional follow-up)

The "carry-forward" tags from yesterday's vision_eye EOD dictation
were applied conservatively. idx 608 was a false carry-forward
(schema-equivalent to peers, no actual exception). idx 101 and 2589
were already drained in PR #172 with their distinct compound-ref
fixes; those were genuine carry-forwards. No re-audit needed unless
future "carry-forward" tags appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)