### PR TITLE
fix(chaos-bot): pin served-canonical option-frame contract in v4 judge

### DIFF
--- a/scripts/chaos-doctor-bot-v4.mjs
+++ b/scripts/chaos-doctor-bot-v4.mjs
@@ -46,6 +46,7 @@ import { createWriteStream } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { extractJson } from './lib/extractJson.mjs';
+import { resolveAppVerdict } from './lib/optionResolver.mjs';
 
 const DEFAULT_URL = 'https://eiasash.github.io/Geriatrics/';
 const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
@@ -335,10 +336,21 @@ async function doctorOneQuestion(page, workerId, log) {
   }
   await sleep(rand(900, 1700));
 
-  // Detect app's correct idx + explanation + source
+  // Detect app's correct idx + explanation + source.
+  // Geri's monolith uses `<button onclick="pick(canonicalIdx)">` rendered in
+  // shuffled DOM order. There is no `data-i` attribute — the bot reads the
+  // .ok button's DOM position via `all.indexOf(ok)`, which is the DISPLAY
+  // position (matching the AI's letter space). Both `aiIdx` and `appIdx`
+  // are therefore display-frame here, and `resolveAppVerdict` collapses to
+  // identity for Geri. We still funnel through the resolver so that any
+  // future port to a `data-i` rendering (e.g. a Geri rewrite mirroring
+  // FM/IM) cannot silently re-introduce the served↔canonical drift bug
+  // that produced ~240/241 false positives in the 2026-05-08 triage.
   const appIdx = await detectAppCorrectIdx(page);
   const { explanation, source } = await extractExplanationAndSource(page);
-  const disagrees = appIdx != null && appIdx !== aiIdx;
+  const appVerdict = resolveAppVerdict(q.options, appIdx);
+  const appDisplayIdx = appVerdict ? appVerdict.displayIdx : null;
+  const disagrees = appDisplayIdx != null && appDisplayIdx !== aiIdx;
 
   // v4: methodology guard. If appIdx is null after a check click in practice
   // mode, our entry path probably fell back to exam mode. Log it so we can
@@ -361,22 +373,27 @@ async function doctorOneQuestion(page, workerId, log) {
     return { advanced: true, stemHash };
   }
 
-  // 2) Judge — v4 prompt validates the APP, not blends with AI's pick
-  const appLetter = 'ABCD'[appIdx];
+  // 2) Judge — v4 prompt validates the APP, not blends with AI's pick.
+  // Use the resolver output so the judge sentence quotes the option TEXT
+  // (not just a letter), matching the FM/IM siblings. For Geri this is
+  // mechanically identical to `'ABCD'[appIdx]` + `q.options[appIdx].text`,
+  // but adopting the same shape sibling-wide keeps the contract uniform.
+  const appLetter = appVerdict ? appVerdict.displayLetter : '?';
+  const appText = appVerdict ? appVerdict.canonicalText : '(unresolved)';
   const userPrompt2 = `Question (Hebrew):
 ${q.stem}
 
 Options:
 ${q.options.map((o, i) => `${'ABCD'[i]}. ${o.text}`).join('\n')}
 
-App's claimed correct answer: ${appLetter}
+App's claimed correct answer: ${appLetter} (${appText})
 App's explanation:
 ${(explanation || '(no explanation rendered)').slice(0, 1500)}
 ${source ? `\nApp's cited source: ${source}` : ''}
 
 (Context — NOT for adjudication: AI prior pick was ${aiLetter}: ${pickJson.why || 'no rationale'})
 
-Validate the APP's claimed answer ${appLetter} against board-level family-medicine evidence.`;
+Validate the APP's claimed answer ${appLetter} (${appText}) against board-level geriatric-medicine evidence.`;
   let judgeResp = null;
   try { judgeResp = await callClaude(SYS_DOCTOR_JUDGE, userPrompt2, { maxTokens: 400 }); }
   catch (e) { log.bugs.push({ at: nowIso(), type: 'ai-error', context: 'judge', message: e.message }); }
@@ -408,13 +425,16 @@ Validate the APP's claimed answer ${appLetter} against board-level family-medici
     log.actions.push({ at: nowIso(), type: 'ai-source', plausible: sourceJson.citation_plausible, citation: cite, conf: sourceJson.confidence });
   }
 
-  // Record finding
+  // Record finding.
+  // For Geri, `appIdx` and `appDisplayIdx` are the same value (display
+  // frame), but persist both fields for sibling-aligned record shape.
   const finding = {
     workerId,
     stem: q.stem.slice(0, 300),
     options: q.options.map((o) => o.text.slice(0, 120)),
+    optionCanonicalIdx: q.options.map((o) => Number(o.idx)),
     aiLetter, aiIdx, aiWhy: pickJson.why || null, aiConf: pickJson.confidence,
-    appIdx, appLetter,
+    appIdx, appDisplayIdx, appLetter, appText,
     disagrees,
     judge: judgeJson,
     source: sourceJson,

--- a/scripts/lib/optionResolver.mjs
+++ b/scripts/lib/optionResolver.mjs
@@ -1,0 +1,102 @@
+// Pure helpers for chaos-doctor-bot v4 served↔canonical option resolution.
+//
+// Why this module exists
+// ----------------------
+// FM/IM dist bundles render answer options in a SHUFFLED order (display
+// position) but tag each <button data-action="pick"> with `data-i="<canonical
+// index>"` (the original position in `q.o`). The bot read these into a flat
+// `options[]` array in DOM/display order while preserving each option's
+// canonical index in `option.idx`.
+//
+// v4-as-shipped mixed two coordinate frames:
+//   - `aiLetter` came from prompting the model with options labeled A..D in
+//     DISPLAY order, so `aiIdx = LETTER_TO_IDX[aiLetter]` is a DISPLAY position.
+//   - `appIdx` came from `data-i` on the .ok button — a CANONICAL index.
+//
+// Two bugs followed:
+//   (1) Click: `[data-action="pick"][data-i="${aiIdx}"]` interpreted the
+//       display-position number as a canonical data-i, so when shuffle ≠
+//       identity the bot clicked the WRONG option. (Did not corrupt the
+//       answer-key signal because `detectAppCorrectIdx` reads .ok regardless
+//       of which button the bot clicked, but did contaminate `disagrees`.)
+//   (2) Judge prompt: `App's claimed correct answer: ${'ABCD'[appIdx]}` used
+//       a canonical-index-→-letter mapping while the model's letter space
+//       was display-frame. Result: the judge model wrote sentences like
+//       "App claims D (Arterial Hypertension)" when the served-position-3
+//       option happened to be Arterial Hypertension, even though the app's
+//       canonical answer was Venous Insufficiency. Triage 2026-05-10
+//       attributed ~240/241 false-positive flags to this single mismatch.
+//
+// The fix below keeps the AI letter space in display frame (the model only
+// ever sees served options) and translates appIdx into:
+//   • the served letter the app's correct option lives at (for "claimed X"),
+//   • the canonical option text (so the judge sentence quotes the right
+//     option even if our display↔canonical mapping is somehow wrong).
+//
+// Geri's bot operates entirely in display frame (no data-i — the app's
+// onclick="pick(origI)" handler does the translation) and therefore does
+// not have this bug. Geri's port is a no-op, but a regression test pins
+// the contract.
+
+/**
+ * Translate a canonical (data-i) index into the display position the bot
+ * actually served to the AI judge.
+ *
+ * @param {Array<{idx:number, text:string}>} servedOptions
+ *   The bot's `q.options` array — entries are in DISPLAY (DOM) order, with
+ *   `idx` carrying the canonical index from `data-i`.
+ * @param {number} canonicalIdx
+ *   A canonical index (e.g. `appIdx` from `detectAppCorrectIdx`).
+ * @returns {number|null}
+ *   The matching display position, or `null` if not found.
+ */
+export function canonicalToDisplay(servedOptions, canonicalIdx) {
+  if (!Array.isArray(servedOptions) || canonicalIdx == null) return null;
+  for (let i = 0; i < servedOptions.length; i++) {
+    const o = servedOptions[i];
+    if (o && Number(o.idx) === Number(canonicalIdx)) return i;
+  }
+  return null;
+}
+
+/**
+ * Translate a display (AI-letter) position into the canonical (data-i) index
+ * the app expects in `pick(...)` / `[data-i="N"]` selectors.
+ *
+ * @param {Array<{idx:number, text:string}>} servedOptions
+ * @param {number} displayIdx
+ * @returns {number|null}
+ */
+export function displayToCanonical(servedOptions, displayIdx) {
+  if (!Array.isArray(servedOptions) || displayIdx == null) return null;
+  if (displayIdx < 0 || displayIdx >= servedOptions.length) return null;
+  const o = servedOptions[displayIdx];
+  if (!o || o.idx == null) return null;
+  return Number(o.idx);
+}
+
+/**
+ * Resolve `appIdx` to a verdict triple:
+ *   { displayIdx, displayLetter, canonicalText }
+ *
+ * `canonicalText` is the option text the bot ACTUALLY served at the matching
+ * display position — i.e. the same string the AI model saw labeled by
+ * `displayLetter`. This is what the judge-prompt sentence "App's claimed
+ * correct answer: <letter> (<text>)" should use.
+ *
+ * Returns `null` if `appIdx` cannot be located in `servedOptions`.
+ *
+ * @param {Array<{idx:number, text:string}>} servedOptions
+ * @param {number} appIdx Canonical index from `data-i` on the .ok button.
+ * @param {string[]} [letterTable=['A','B','C','D','E','F','G','H']]
+ */
+export function resolveAppVerdict(servedOptions, appIdx, letterTable) {
+  const LETTERS = letterTable || ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
+  const displayIdx = canonicalToDisplay(servedOptions, appIdx);
+  if (displayIdx == null) return null;
+  return {
+    displayIdx,
+    displayLetter: LETTERS[displayIdx] || '?',
+    canonicalText: servedOptions[displayIdx].text,
+  };
+}

--- a/tests/chaosBotV4OptionResolver.test.js
+++ b/tests/chaosBotV4OptionResolver.test.js
@@ -1,0 +1,160 @@
+// Regression tests for chaos-doctor-bot v4 served↔canonical option
+// resolution. Anchors the fix for the 2026-05-08 triage finding: ~240/241
+// flagged questions were false positives caused by the bot mixing
+// coordinate frames between the AI's letter space (display order, A..D)
+// and `data-i` (canonical order in `q.o`).
+//
+// Smoking-gun reproduction: FM idx 84 ("ulcer over Medial Malleolus,
+// most common cause"). Canonical `q.o[3] = "Venous Insufficiency"` and
+// `q.c = 3`. The bot served:
+//
+//   [A] Venous Insufficiency      data-i=3
+//   [B] ANCA associated Vasculitis data-i=2
+//   [C] Atherosclerosis            data-i=0
+//   [D] Arterial Hypertension      data-i=1
+//
+// `detectAppCorrectIdx` returns 3 (canonical, the .ok button's data-i).
+// The pre-fix bot wrote "App claims D" (`'ABCD'[3]`) which the judge
+// model interpreted against served labels — D was Arterial Hypertension.
+// False-positive "drift" verdict followed.
+//
+// See `~/repos/.audit_logs/triage_2026-05-08/REPORT_2026-05-10.md` for
+// the full pattern. Do NOT delete these tests without first re-reading
+// that report.
+import { describe, it, expect } from 'vitest';
+import {
+  canonicalToDisplay,
+  displayToCanonical,
+  resolveAppVerdict,
+} from '../scripts/lib/optionResolver.mjs';
+
+describe('chaos-doctor-bot v4 optionResolver — coordinate-frame translation', () => {
+  // The canonical FM idx 84 served-options snapshot, taken verbatim from
+  // the chaos-reports JSONL on 2026-05-08T05:01:49.832Z (run id
+  // v4-overnight-20260508T045637-fix3).
+  const fmIdx84Served = [
+    { idx: 3, text: 'Venous Insufficiency' },
+    { idx: 2, text: 'ANCA associated Vasculitis' },
+    { idx: 0, text: 'Atherosclerosis' },
+    { idx: 1, text: 'Arterial Hypertension' },
+  ];
+
+  describe('canonicalToDisplay', () => {
+    it('locates a canonical idx at its served display position', () => {
+      // canonical 3 (Venous Insufficiency) is at display position 0 (A)
+      expect(canonicalToDisplay(fmIdx84Served, 3)).toBe(0);
+      // canonical 1 (Arterial Hypertension) is at display position 3 (D)
+      expect(canonicalToDisplay(fmIdx84Served, 1)).toBe(3);
+    });
+
+    it('returns null when the canonical idx is not in served options', () => {
+      expect(canonicalToDisplay(fmIdx84Served, 99)).toBeNull();
+    });
+
+    it('handles invalid input shapes', () => {
+      expect(canonicalToDisplay(null, 0)).toBeNull();
+      expect(canonicalToDisplay([], 0)).toBeNull();
+      expect(canonicalToDisplay(fmIdx84Served, null)).toBeNull();
+    });
+
+    it('matches even when idx came in as a string (data-i is text)', () => {
+      const stringy = [{ idx: '3', text: 'a' }, { idx: '0', text: 'b' }];
+      expect(canonicalToDisplay(stringy, 3)).toBe(0);
+      expect(canonicalToDisplay(stringy, 0)).toBe(1);
+    });
+  });
+
+  describe('displayToCanonical', () => {
+    it('translates a display position to the canonical data-i value', () => {
+      // display position 0 → canonical 3
+      expect(displayToCanonical(fmIdx84Served, 0)).toBe(3);
+      // display position 3 → canonical 1
+      expect(displayToCanonical(fmIdx84Served, 3)).toBe(1);
+    });
+
+    it('returns null on out-of-range display positions', () => {
+      expect(displayToCanonical(fmIdx84Served, -1)).toBeNull();
+      expect(displayToCanonical(fmIdx84Served, 4)).toBeNull();
+      expect(displayToCanonical(fmIdx84Served, null)).toBeNull();
+    });
+
+    it('is the inverse of canonicalToDisplay across all served indices', () => {
+      for (let i = 0; i < fmIdx84Served.length; i++) {
+        const canon = displayToCanonical(fmIdx84Served, i);
+        expect(canonicalToDisplay(fmIdx84Served, canon)).toBe(i);
+      }
+    });
+  });
+
+  describe('resolveAppVerdict — the FM idx 84 smoking-gun scenario', () => {
+    it('resolves canonical idx 3 to display letter A with the correct option text', () => {
+      // The bot's `appIdx` is canonical 3 (data-i on the .ok button).
+      // The judge model sees options labeled in DISPLAY order (A=Venous,
+      // B=ANCA, C=Athero, D=ArtHTN). The pre-fix bot wrote "App claims D"
+      // and quoted Arterial Hypertension; the post-fix bot must write
+      // "App claims A (Venous Insufficiency)".
+      const verdict = resolveAppVerdict(fmIdx84Served, 3);
+      expect(verdict).not.toBeNull();
+      expect(verdict.displayIdx).toBe(0);
+      expect(verdict.displayLetter).toBe('A');
+      expect(verdict.canonicalText).toBe('Venous Insufficiency');
+      // Anti-regression: the verdict must NOT quote Arterial Hypertension
+      // (the served-position-3 occupant in the buggy frame).
+      expect(verdict.canonicalText).not.toBe('Arterial Hypertension');
+    });
+
+    it('returns null when appIdx cannot be located (defensive)', () => {
+      expect(resolveAppVerdict(fmIdx84Served, null)).toBeNull();
+      expect(resolveAppVerdict(fmIdx84Served, 99)).toBeNull();
+      expect(resolveAppVerdict([], 3)).toBeNull();
+    });
+
+    it('handles identity (unshuffled) options correctly — Geri-style display frame', () => {
+      // When canonical idx == display position (no shuffle), the resolver
+      // collapses to identity. This pins the contract that the resolver
+      // is safe to wrap around bots that already operate in display frame
+      // (e.g. Geri's monolith renders <button onclick="pick(origI)"> in
+      // shuffled DOM order but exposes no `data-i`, so the bot's
+      // `option.idx` falls back to the loop counter == display position).
+      const identity = [
+        { idx: 0, text: 'Aleph' },
+        { idx: 1, text: 'Bet' },
+        { idx: 2, text: 'Gimel' },
+        { idx: 3, text: 'Dalet' },
+      ];
+      for (let i = 0; i < 4; i++) {
+        const v = resolveAppVerdict(identity, i);
+        expect(v.displayIdx).toBe(i);
+        expect(v.displayLetter).toBe('ABCD'[i]);
+        expect(v.canonicalText).toBe(identity[i].text);
+      }
+    });
+
+    it('respects custom letter tables (>=5 options for GRS8 imports)', () => {
+      const fiveOpts = [
+        { idx: 4, text: 'epsilon' },
+        { idx: 0, text: 'alpha' },
+        { idx: 1, text: 'beta' },
+        { idx: 2, text: 'gamma' },
+        { idx: 3, text: 'delta' },
+      ];
+      const v = resolveAppVerdict(fiveOpts, 4, ['A', 'B', 'C', 'D', 'E']);
+      expect(v.displayLetter).toBe('A');
+      expect(v.canonicalText).toBe('epsilon');
+    });
+  });
+
+  describe('end-to-end: judge-prompt sentence reconstruction', () => {
+    // This is the primary contract test: given the FM idx 84 record, the
+    // bot's judge prompt must include the canonical option text — not
+    // the served-position-N text under the old appIdx-as-letter mapping.
+    it('FM idx 84: judge sentence quotes Venous Insufficiency, not Arterial Hypertension', () => {
+      const appIdx = 3; // canonical, data-i on the .ok button
+      const verdict = resolveAppVerdict(fmIdx84Served, appIdx);
+      const judgeSentence = `App's claimed correct answer: ${verdict.displayLetter} (${verdict.canonicalText})`;
+      expect(judgeSentence).toBe("App's claimed correct answer: A (Venous Insufficiency)");
+      expect(judgeSentence).not.toContain('Arterial Hypertension');
+      expect(judgeSentence).not.toMatch(/\(D\)|claimed correct answer: D/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Sibling-aligned port of the FM/IM `chaos-doctor-bot-v4.mjs` letter-resolution fix. Triage of the 2026-05-08 chaos-doctor-v4 run (`~/repos/.audit_logs/triage_2026-05-08/REPORT_2026-05-10.md`) found **~240/241** flagged questions were false positives caused by FM/IM bots mixing display-frame letter labels (what the AI saw) with canonical-frame `appIdx` (`data-i` on the `.ok` button).

**Geriatrics is not affected by this bug** — the monolith renders `<button onclick="pick(canonicalIdx)">` in shuffled DOM order without a `data-i` attribute, and the bot reads `.ok` via `all.indexOf(ok)`. Both `aiIdx` and `appIdx` are display-frame end to end. Geri's bot was already correct (1 of 33 Geri flags in the triage queue is an artifact, but per the report that one is unrelated to the served-canonical bug).

## Why ship this PR anyway

1. Wires `scripts/lib/optionResolver.mjs` in as a **no-op identity layer** in Geri (canonical idx == display position when `data-i` is absent), so any future port to a `data-i` rendering (e.g. a Geri rewrite mirroring FM/IM) cannot silently re-introduce the served↔canonical drift bug.
2. Reshapes the judge prompt sentence to quote both the served letter AND the canonical option text — uniform contract with FM/IM, harder for future model-prompt drift to confuse.
3. Adds `tests/chaosBotV4OptionResolver.test.js` (12 tests) reproducing the FM idx 84 smoking-gun verbatim. Even though Geri can't currently produce this bug, the test pins the resolver contract so a future "extract Geri's `data-i` selectors to mirror FM/IM" refactor stays safe.
4. Records `appDisplayIdx + appText` alongside legacy `appIdx` in the JSONL ledger for sibling-aligned record shape across all three medical PWAs.

## Sibling PRs (must land together)

- FamilyMedicine: https://github.com/Eiasash/FamilyMedicine/pull/44
- InternalMedicine: https://github.com/Eiasash/InternalMedicine/pull/104
- Geriatrics: this PR

## Test plan

- [x] New regression test `tests/chaosBotV4OptionResolver.test.js` (12 tests).
- [x] `npm run verify` passes (1253 tests + 7 skipped, full SW + brace + innerHTML + Harrison Hebrew gates).
- [x] `node --check scripts/chaos-doctor-bot-v4.mjs` parses cleanly.

## Files

- `scripts/lib/optionResolver.mjs` (new) — pure helper module
- `scripts/chaos-doctor-bot-v4.mjs` — judge prompt + finding-record shape uniform with FM/IM
- `tests/chaosBotV4OptionResolver.test.js` (new) — 12 regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)