### PR TITLE
v10.64.87: a11y SW update banner dismiss button (✕)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.86",
+  "version": "10.64.87",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -7003,8 +7003,11 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.86';
+const APP_VERSION='10.64.87';
 const CHANGELOG={
+'10.64.87':[
+'♿ Accessibility — SW update banner dismiss button (the ✕ that appears when a new version is queued for activation). v10.64.86 live re-audit (playwright, fired right after the v86 SW deploy queued a fresh update banner) found this button at 3.86:1: white text on a `rgba(255,255,255,0.2)` tint over the teal-700 (#0D7377→#14919B) gradient. Fails WCAG AA. Two minimum-code edits in src/sw-update.js: (1) bg `rgba(255,255,255,.2)` → `rgba(0,0,0,.25)` — flips the tint from "lighter than banner" to "darker than banner". White text on the resulting darker teal (~rgb(9,80,83)) computes to 8.27:1 (AAA). (2) Added `aria-label="Dismiss update banner"` + matching `title` — the ✕ glyph is not an accessible name on its own, screen readers announced the button as "button" with no purpose. Trinity bumped 10.64.86 → 10.64.87. Conditional surface — only visible to users who already have v85 (or earlier) cached when v87 deploys, so it self-resolves the next time the SW completes its update cycle.',
+],
 '10.64.86':[
 '♿ Accessibility — issue #125 final close. v10.64.85 live re-audit (playwright) found 1 residual: amber-600 (#d97706) buttons with white text rendering at 3.19:1 — fails WCAG AA. The pattern appeared 4× in source: 3 "✓ מאומת" verification buttons (imgDep on 2 render paths + e_issue) and 1 "שלח לבדיקת AI" submit-for-AI-review button. All four shared the identical inline pattern `background:#d97706;color:#fff`. Single replace_all bumped amber-600 → amber-800 (#92400e), pushing white-on-amber from 3.19:1 to 7.39:1 (AAA). Surrounding container styling (yellow-100 #fef3c7 boxes with amber-800 #92400e text at 6.89:1) is unchanged — those passed AA already. The amber-800 button bg now matches the box-text color, which actually improves visual cohesion. Trinity bumped 10.64.85 → 10.64.86. With this, issue #125 closes at 38 → 0 contrast violations: 100% reduction across v10.64.82 (dir=rtl + skip-link + dead ids) → v10.64.83 (theme-aware dm-btn + slate hierarchy) → v10.64.84 (👤 JS-override clear) → v10.64.85 (4 residuals: pomo + share + review-disabled + quiz-on) → v10.64.86 (final amber-button class).',
 ],

--- a/src/sw-update.js
+++ b/src/sw-update.js
@@ -14,7 +14,7 @@ b.style.cssText='position:fixed;top:0;left:0;right:0;z-index:99999;background:li
 b.innerHTML='<div><b>🆕 עדכון זמין!</b> גרסה חדשה מוכנה</div>'+
 '<div style="display:flex;gap:6px;flex-shrink:0">'+
 '<button data-action="apply-update" style="background:rgb(var(--card-bg));color:#0D7377;border:none;border-radius:8px;padding:6px 14px;font-size:11px;font-weight:700;cursor:pointer">🔄 עדכן עכשיו</button>'+
-'<button data-action="dismiss-update" style="background:rgba(255,255,255,.2);color:#fff;border:none;border-radius:8px;padding:6px 10px;font-size:11px;cursor:pointer">✕</button>'+
+'<button data-action="dismiss-update" aria-label="Dismiss update banner" title="Dismiss update banner" style="background:rgba(0,0,0,.25);color:#fff;border:none;border-radius:8px;padding:6px 10px;font-size:11px;cursor:pointer">✕</button>'+
 '</div>';
 document.body.prepend(b);
 }

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.86';
+const CACHE='shlav-a-v10.64.87';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 // CRITICAL_URLS = the bare-minimum app shell required for offline boot.
 // Anything else (data/*.json, fonts, icons) is best-effort in the install

--- a/tests/a11yIssue125.test.js
+++ b/tests/a11yIssue125.test.js
@@ -208,3 +208,21 @@ describe("a11y issue #125 — v10.64.86 final close (amber buttons)", () => {
     expect(html).toMatch(/markEIssueVerified[^"']*[^>]*style="[^"]*background:#92400e/);
   });
 });
+
+describe("a11y issue #125 — v10.64.87 SW update banner dismiss button", () => {
+  let swUpdateSrc = '';
+  beforeAll(() => {
+    swUpdateSrc = readFileSync(resolve(__dirname, '../src/sw-update.js'), 'utf-8');
+  });
+
+  it("dismiss button background is rgba(0,0,0,.25), not rgba(255,255,255,.2)", () => {
+    // v10.64.87 fix: dark tint over teal gradient (white text → ~8.27:1 AAA)
+    // vs the prior light tint which gave white-on-light-teal at ~3.86:1.
+    expect(swUpdateSrc).toMatch(/data-action="dismiss-update"[^>]*background:rgba\(0,0,0,\.25\)/);
+    expect(swUpdateSrc).not.toMatch(/data-action="dismiss-update"[^>]*background:rgba\(255,255,255,\.2\)/);
+  });
+
+  it("dismiss button has aria-label (✕ alone is not an accessible name)", () => {
+    expect(swUpdateSrc).toMatch(/data-action="dismiss-update"[^>]*aria-label="Dismiss update banner"/);
+  });
+});


### PR DESCRIPTION
Live re-audit on v10.64.86 surfaced this conditional element after deploy queued the SW update banner.

## Fix (`src/sw-update.js`)

| edit | before | after |
|---|---|---|
| dismiss button bg | `rgba(255,255,255,.2)` over teal gradient → 3.86:1 | `rgba(0,0,0,.25)` over teal → 8.27:1 (AAA) |
| dismiss button accessible name | none (✕ glyph only) | `aria-label="Dismiss update banner"` + title |

## Verification

- `npm run verify` GREEN: trinity aligned 10.64.86 → 10.64.87, **1272 vitest passing + 7 skipped** (2 new regression guards in tests/a11yIssue125.test.js)
- Conditional surface — only fires when SW has update queued; will self-resolve on next deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)