### PR TITLE
fix(scripts): check-inline-js.py is Windows cp1252-safe

### DIFF
--- a/scripts/check-inline-js.py
+++ b/scripts/check-inline-js.py
@@ -22,7 +22,13 @@ HTML = ROOT / "shlav-a-mega.html"
 if not HTML.exists():
     print(f"FAIL: {HTML} not found", file=sys.stderr); sys.exit(2)
 
-source = HTML.read_text()
+# Explicit utf-8 on read AND write below — shlav-a-mega.html contains
+# Hebrew + LRM/RLM marks, and inline <script> bodies carry the same content
+# into the temp .mjs files we feed to `node --check`. Without explicit
+# encoding, Python's default on Windows is cp1252 and read_text/write each
+# fail with UnicodeDecodeError/UnicodeEncodeError on the first non-Latin-1
+# byte. Workspace global CLAUDE.md documents this as a standing trap.
+source = HTML.read_text(encoding="utf-8")
 # Inline script = <script ...>...</script> WITHOUT src= attribute
 pattern = re.compile(r"<script(?:(?!\bsrc=)[^>])*?>([\s\S]*?)</script>", re.IGNORECASE)
 scripts = pattern.findall(source)
@@ -34,7 +40,7 @@ failed = 0
 for i, body in enumerate(scripts):
     if body.count("\n") < 5:
         continue  # tiny scripts (configs, install probes); not worth the overhead
-    with tempfile.NamedTemporaryFile(suffix=".mjs", mode="w", delete=False) as f:
+    with tempfile.NamedTemporaryFile(suffix=".mjs", mode="w", delete=False, encoding="utf-8") as f:
         f.write(body)
         fname = f.name
     res = subprocess.run(["node", "--check", fname], capture_output=True, text=True)


### PR DESCRIPTION
## Summary

`scripts/check-inline-js.py` (added in v10.64.101, commit 63c5214) used Python's default file encoding, which is cp1252 on Windows. The script reads `shlav-a-mega.html` (UTF-8 with Hebrew + LRM/RLM marks) and writes inline-script bodies to temp `.mjs` files for `node --check` — both operations crash with `UnicodeDecodeError` / `UnicodeEncodeError` on the first non-Latin-1 byte. CI runs on Linux (utf-8 default) so the bug didn't surface there; Windows local `npm run verify` ran into it immediately.

## Root cause

Two sites, same fix class:

```python
# line 25 — read
source = HTML.read_text()  # cp1252 default on Windows; fails on Hebrew

# line 37 — write
tempfile.NamedTemporaryFile(suffix=".mjs", mode="w", delete=False)
                                                              # ^ also cp1252 default
```

## Fix

Both calls now pass `encoding="utf-8"` explicitly. Comment at line 25 names the trap so the next maintainer adding a file operation in this script sees why utf-8 is pinned (workspace global `CLAUDE.md` documents this as a standing Windows trap; per its guidance, "Default to setting `PYTHONUTF8=1` for any python invocation that touches files" — this script no longer needs that fallback).

## Verification

- **Before:** `npm run verify` fails on Windows at line 25 with `UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d in position 27529`. Workaround required: `PYTHONUTF8=1 npm run verify`.
- **After:** `npm run verify` clean WITHOUT `PYTHONUTF8=1`. 7/7 gate checks, 1289 tests + 7 skipped, ~2.3s total.

Behavior unchanged on Linux (utf-8 is already the default there).

## Scope

Touched only the one script that was observably broken. Other Python check scripts in the verify chain (`check-version-sync.py`, `check-brace-balance.py`, `check-innerhtml.py`, `check-innerhtml-pieces.py`) ran clean WITHOUT the workaround in the v4.2 + smoke sessions, so they're already handling encoding correctly. If a future audit finds the same hazard elsewhere, that's its own PR with its own diff.

## Test plan
- [x] `unset PYTHONUTF8 && npm run verify` → 7/7 + 1289 tests pass
- [ ] CI green
- [ ] Squash-merge after CI

## Refs

- v10.64.101 (`63c5214`) — introduced the script that surfaced this trap
- Workspace global `~/.claude/CLAUDE.md` — the standing "Hebrew + cp1252" trap

🤖 Generated with [Claude Code](https://claude.com/claude-code)