### PR TITLE
v10.64.118: chaos-bot audit-1 + audit-2 prompt redesigns (split channels, axis isolation, audit-grade-as-input)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.117",
+  "version": "10.64.118",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/audit_redesign_pilot_2026-05-13.mjs
+++ b/scripts/audit_redesign_pilot_2026-05-13.mjs
@@ -1,0 +1,262 @@
+// Redesigned audit-1 + audit-2 prompts pilot — 2026-05-13.
+//
+// Tests two narrowed prompts against pre-curated test cohorts from the v4-long
+// chaos run. Goal: empirical confirmation that the redesigns separate the
+// axes the original prompts conflated.
+//
+// Pre-written predictions (locked before run):
+//   Audit-1 (8 stems): predicted 2 flagged (~25%) → ship if 0-2
+//   Audit-2 (13 stems): predicted 1-2 flagged (~10%) → ship if ≤2
+//
+// Carve-out clauses are the load-bearing design feature of both redesigns.
+// If they don't land empirically, the redesign needs another pass.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import process from 'node:process';
+
+const TORANOT_URL = 'https://toranot.netlify.app/api/claude';
+const TORANOT_DEFAULT_SECRET = 'shlav-a-mega-1f97f311d307-2026';
+const KEY = process.env.TORANOT_API_SECRET || TORANOT_DEFAULT_SECRET;
+const MODEL = 'claude-opus-4-7';
+
+const ROOT = 'C:/Users/User/repos/Geriatrics';
+
+// ============================================================
+// Redesigned prompts (per followup_chaos_audit_prompt_redesigns.md)
+// ============================================================
+
+const SYS_AUDIT1_REDESIGN = `You are evaluating a Hebrew geriatric medicine board question. ASSUME THE CLAIMED CORRECT ANSWER IS CORRECT — its medical accuracy is judged separately by audit-3 (a different channel). Your job here is to judge ONLY THE EXPLANATION TEXT on three axes:
+
+1. Does the explanation justify the correct answer with sound medical reasoning? (vs. circular reasoning, non-sequitur claims, or arguments that contradict the answer it's defending)
+2. Does the explanation contain factually wrong medical claims about the distractors (the wrong options)? (vs. claims that are accurate within the space of the option set)
+3. Is the explanation prose well-formed Hebrew with embedded clinical English where idiomatic? (vs. machine-translation artifacts, broken bidi, missing clinical context)
+
+Reply with strict JSON only, no prose outside JSON:
+{
+  "sound": true | false,
+  "issue": "<one paragraph naming the specific axis(es) that failed, or 'sound on all three axes' if true>",
+  "axis_failures": ["1" | "2" | "3" or empty array],
+  "confidence": <integer 0-100>
+}
+
+DO NOT consider whether the answer index "c" is correct. That's audit-3, not your job here. Even if you would have picked a different answer, defer to the claimed correct answer and judge only the explanation text quality given that the answer is right.`;
+
+const SYS_AUDIT2_REDESIGN = `You are evaluating whether a Hebrew geriatric medicine question's q.ref text is a FAITHFUL DISPLAY of the audit-grade chapter assignment from question_chapters.json. Your job is narrow: NOT to judge whether the chapter is topically aligned with the question, but whether q.ref displays the audit-grade assignment correctly.
+
+The q.ref is FAITHFUL if any of:
+- It cites at least one of the audited chapters with the correct chapter number.
+- It cites a more specific subchapter/section/page WITHIN an audited chapter (this is acceptable curatorial specificity — a more specific reference within the audited chapter's scope is a feature, not a defect).
+- The current q.ref is more specific than the audit-grade (e.g., names a specific cancer subtype where audit says "cancer general") — this is curatorial specificity beyond the topic-default floor and should NOT be flagged.
+- It cites a non-textbook source (e.g., Israeli law citation "חוק..."  for legal-topic Qs) that the audit-grade mapping has no entry for. The audit-grade mapping is topic-default and doesn't cover legal sources.
+
+The q.ref is UNFAITHFUL if:
+- It cites a chapter number that disagrees with the audit-grade assignment for the same book (Hazzard, Harrison, or GRS), AND the disagreement is NOT a subchapter relationship.
+- It cites a clearly incorrect chapter (e.g., wrong topic entirely — Cardiology chapter on a Cancer Q).
+- It is internally inconsistent with the Q content.
+
+Reply with strict JSON only:
+{
+  "faithful": true | false,
+  "reason": "<one sentence>",
+  "confidence": <integer 0-100>
+}
+
+DO NOT evaluate whether the explanation prose aligns with the chapter. DO NOT evaluate the medical content of the question. Judge ONLY whether q.ref faithfully displays the audit-grade chapter assignment given the carve-outs above.`;
+
+// ============================================================
+// API helper
+// ============================================================
+
+async function judge(sysPrompt, userPrompt) {
+  const body = {
+    model: MODEL,
+    max_tokens: 600,
+    system: sysPrompt,
+    messages: [{ role: 'user', content: userPrompt }],
+  };
+  const res = await fetch(TORANOT_URL, {
+    method: 'POST',
+    headers: { 'x-api-secret': KEY, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Opus ${res.status}: ${text.slice(0, 300)}`);
+  }
+  const data = await res.json();
+  const text = (data.content || []).filter((c) => c.type === 'text').map((c) => c.text).join('');
+  return {
+    text,
+    inputTokens: data.usage?.input_tokens || 0,
+    outputTokens: data.usage?.output_tokens || 0,
+  };
+}
+
+function extractJson(text) {
+  const m = text.match(/\{[\s\S]*\}/);
+  if (!m) return null;
+  try { return JSON.parse(m[0]); } catch (_) { return null; }
+}
+
+// ============================================================
+// Cohort builders
+// ============================================================
+
+function buildAudit1Cohort() {
+  const QZ = JSON.parse(readFileSync(`${ROOT}/data/questions.json`, 'utf-8'));
+  const EXP = JSON.parse(readFileSync(`${ROOT}/data/explanations.json`, 'utf-8'));
+  const A1 = JSON.parse(readFileSync(`${ROOT}/.audit_logs/pending_explanation_quality_judge.json`, 'utf-8'));
+  return A1.stems.map((s) => {
+    const idx = s.qz_idx;
+    const q = QZ[idx];
+    const e = EXP[idx] || '';
+    return {
+      qz_idx: idx,
+      cohort_t: s.cohort_t,
+      stem: q.q,
+      options: q.o,
+      claimed_c: q.c,
+      explanation: e,
+    };
+  });
+}
+
+function buildAudit2Cohort() {
+  const QZ = JSON.parse(readFileSync(`${ROOT}/data/questions.json`, 'utf-8'));
+  const CH = JSON.parse(readFileSync(`${ROOT}/data/question_chapters.json`, 'utf-8'));
+  const HAZ = JSON.parse(readFileSync(`${ROOT}/data/hazzard_chapters.json`, 'utf-8'));
+  const HAR = JSON.parse(readFileSync(`${ROOT}/harrison_chapters.json`, 'utf-8'));
+  const A2 = JSON.parse(readFileSync(`${ROOT}/.audit_logs/pending_audit2_redesign_cite_impl_review.json`, 'utf-8'));
+
+  const cohort = [];
+  for (const [bucketName, bucket] of Object.entries(A2.buckets)) {
+    for (const stem of bucket.stems) {
+      const idx = stem.qz_idx;
+      const q = QZ[idx];
+      const entry = CH[String(idx)] || {};
+      const hazTitle = entry.haz ? (HAZ[String(entry.haz)]?.title || '') : null;
+      const harTitle = entry.har ? (HAR[String(entry.har)]?.title || '') : null;
+      cohort.push({
+        qz_idx: idx,
+        bucket: bucketName,
+        cohort_t: stem.cohort_t,
+        ti: stem.ti,
+        stem: q.q,
+        current_ref: q.ref || '',
+        audit_grade: {
+          haz: entry.haz ? `Ch ${entry.haz}${hazTitle ? ' — ' + hazTitle : ''}` : null,
+          har: entry.har ? `Ch ${entry.har}${harTitle ? ' — ' + harTitle : ''}` : null,
+          grs: entry.grs ? `Ch ${entry.grs}` : null,
+        },
+      });
+    }
+  }
+  return cohort;
+}
+
+// ============================================================
+// Prompt formatters
+// ============================================================
+
+function fmtAudit1Prompt(item) {
+  const lettered = item.options.map((o, i) => `${'ABCDEF'[i]}. ${o}`).join('\n');
+  return `Question (Hebrew):
+${item.stem}
+
+Options:
+${lettered}
+
+Claimed correct answer (assume correct, judge only the explanation): ${'ABCDEF'[item.claimed_c]} — ${item.options[item.claimed_c]}
+
+Explanation text (Hebrew):
+${item.explanation}
+
+Is the explanation TEXT medically sound on the three axes? Reply JSON only.`;
+}
+
+function fmtAudit2Prompt(item) {
+  const ag = item.audit_grade;
+  const auditLines = [];
+  if (ag.haz) auditLines.push(`- Hazzard: ${ag.haz}`);
+  if (ag.har) auditLines.push(`- Harrison: ${ag.har}`);
+  if (ag.grs) auditLines.push(`- GRS8: ${ag.grs}`);
+  return `Question (Hebrew, abbreviated stem):
+${(item.stem || '').slice(0, 400)}
+
+Audit-grade chapter assignment from question_chapters.json[${item.qz_idx}]:
+${auditLines.join('\n') || '(none)'}
+
+Current q.ref text:
+"${item.current_ref}"
+
+Is the current q.ref a faithful display of the audit-grade chapter assignment, considering the carve-outs (curatorial specificity, non-textbook sources, subchapter relationships)? Reply JSON only.`;
+}
+
+// ============================================================
+// Driver
+// ============================================================
+
+async function runCohort(label, cohort, sysPrompt, fmtPrompt) {
+  console.log(`\n[${label}] judging ${cohort.length} stems via ${MODEL}`);
+  const results = [];
+  let totalIn = 0, totalOut = 0;
+  for (let i = 0; i < cohort.length; i++) {
+    const item = cohort[i];
+    process.stdout.write(`  [${i + 1}/${cohort.length}] idx=${item.qz_idx} ...`);
+    try {
+      const r = await judge(sysPrompt, fmtPrompt(item));
+      const parsed = extractJson(r.text);
+      const result = { ...item, opus_raw: r.text, opus_parsed: parsed };
+      // Extract verdict — different field per audit class
+      if (label === 'audit-1') {
+        result.opus_sound = parsed?.sound;
+        result.flagged = parsed?.sound === false;
+      } else {
+        result.opus_faithful = parsed?.faithful;
+        result.flagged = parsed?.faithful === false;
+      }
+      result.opus_confidence = parsed?.confidence;
+      result.opus_in_tokens = r.inputTokens;
+      result.opus_out_tokens = r.outputTokens;
+      results.push(result);
+      totalIn += r.inputTokens; totalOut += r.outputTokens;
+      const verdict = label === 'audit-1' ? `sound=${parsed?.sound}` : `faithful=${parsed?.faithful}`;
+      process.stdout.write(` ${verdict} conf=${parsed?.confidence} (${r.inputTokens}+${r.outputTokens}t)\n`);
+    } catch (e) {
+      results.push({ ...item, error: String(e).slice(0, 300) });
+      process.stdout.write(` ERROR: ${String(e).slice(0, 120)}\n`);
+    }
+  }
+  const cost = (totalIn / 1_000_000) * 15 + (totalOut / 1_000_000) * 75;
+  console.log(`[${label}] complete. tokens=${totalIn}+${totalOut}, cost=$${cost.toFixed(2)}`);
+  const flagged = results.filter((r) => r.flagged).length;
+  console.log(`[${label}] flagged: ${flagged} of ${results.length}`);
+  return { label, results, totalIn, totalOut, cost, flagged };
+}
+
+async function main() {
+  console.log(`Audit-1 + audit-2 prompt-redesign pilot, 2026-05-13`);
+  const a1Cohort = buildAudit1Cohort();
+  const a2Cohort = buildAudit2Cohort();
+  console.log(`Audit-1 cohort: ${a1Cohort.length} stems`);
+  console.log(`Audit-2 cohort: ${a2Cohort.length} stems`);
+
+  const a1Run = await runCohort('audit-1', a1Cohort, SYS_AUDIT1_REDESIGN, fmtAudit1Prompt);
+  const a2Run = await runCohort('audit-2', a2Cohort, SYS_AUDIT2_REDESIGN, fmtAudit2Prompt);
+
+  const out = {
+    model: MODEL,
+    run_at: new Date().toISOString(),
+    audit_1: { cohort_size: a1Cohort.length, flagged: a1Run.flagged, cost_usd: a1Run.cost, results: a1Run.results },
+    audit_2: { cohort_size: a2Cohort.length, flagged: a2Run.flagged, cost_usd: a2Run.cost, results: a2Run.results },
+    total_cost_usd: a1Run.cost + a2Run.cost,
+  };
+  const outPath = `${ROOT}/.audit_logs/benchmarks/audit_redesign_pilot_results_${new Date().toISOString().slice(0,10)}.json`;
+  writeFileSync(outPath, JSON.stringify(out, null, 2), 'utf-8');
+  console.log(`\nWrote ${outPath}`);
+  console.log(`\nTotal cost: $${(a1Run.cost + a2Run.cost).toFixed(2)}`);
+  console.log(`Audit-1 flagged: ${a1Run.flagged} of ${a1Cohort.length}  (predicted 2/8)`);
+  console.log(`Audit-2 flagged: ${a2Run.flagged} of ${a2Cohort.length}  (predicted 1-2/13)`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/chaos-doctor-bot-v4.mjs
+++ b/scripts/chaos-doctor-bot-v4.mjs
@@ -42,11 +42,60 @@
  */
 import { chromium } from 'playwright';
 import fs from 'node:fs/promises';
-import { createWriteStream } from 'node:fs';
+import { createWriteStream, readFileSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 import { extractJson } from './lib/extractJson.mjs';
 import { resolveAppVerdict } from './lib/optionResolver.mjs';
+
+// v10.64.118: audit-grade chapter assignment input for the redesigned
+// SYS_DOCTOR_SOURCE prompt. Loaded lazily at bot startup from local
+// data/ files (the working tree's questions.json + question_chapters.json
+// + hazzard_chapters.json + harrison_chapters.json). Used to construct
+// the "audit-grade chapter assignment" block in the audit-2 user prompt.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+let AUDIT_GRADE_MAP = null;  // { stemPrefix80 -> { qzIdx, audit_grade_text } }
+let DATA_LOAD_FAILED = false;
+function loadAuditGradeData() {
+  if (AUDIT_GRADE_MAP !== null || DATA_LOAD_FAILED) return AUDIT_GRADE_MAP;
+  try {
+    const QZ = JSON.parse(readFileSync(path.join(REPO_ROOT, 'data', 'questions.json'), 'utf-8'));
+    const CH = JSON.parse(readFileSync(path.join(REPO_ROOT, 'data', 'question_chapters.json'), 'utf-8'));
+    const HAZ = JSON.parse(readFileSync(path.join(REPO_ROOT, 'data', 'hazzard_chapters.json'), 'utf-8'));
+    const HAR = JSON.parse(readFileSync(path.join(REPO_ROOT, 'harrison_chapters.json'), 'utf-8'));
+    const map = new Map();
+    for (let i = 0; i < QZ.length; i++) {
+      const prefix = (QZ[i].q || '').slice(0, 80);
+      if (!prefix) continue;
+      const entry = CH[String(i)] || {};
+      const lines = [];
+      if (entry.haz) {
+        const title = HAZ[String(entry.haz)]?.title || '';
+        lines.push(`- Hazzard: Ch ${entry.haz}${title ? ' — ' + title : ''}`);
+      }
+      if (entry.har) {
+        const title = HAR[String(entry.har)]?.title || '';
+        lines.push(`- Harrison: Ch ${entry.har}${title ? ' — ' + title : ''}`);
+      }
+      if (entry.grs) lines.push(`- GRS8: Ch ${entry.grs}`);
+      map.set(prefix, { qzIdx: i, audit_grade_text: lines.join('\n') || '(no audit-grade entry)' });
+    }
+    AUDIT_GRADE_MAP = map;
+    console.error(`[v4] loaded audit-grade map: ${map.size} stem-prefix entries`);
+    return map;
+  } catch (e) {
+    console.error(`[v4] WARN: audit-grade data load failed: ${e.message}. Audit-2 will run without audit-grade input.`);
+    DATA_LOAD_FAILED = true;
+    return null;
+  }
+}
+function lookupAuditGrade(stem) {
+  const map = loadAuditGradeData();
+  if (!map) return null;
+  return map.get((stem || '').slice(0, 80)) || null;
+}
 
 const DEFAULT_URL = 'https://eiasash.github.io/Geriatrics/';
 const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
@@ -255,22 +304,68 @@ Output format (strict): respond with ONLY a JSON object on a single line, no mar
 {"pick":"A"|"B"|"C"|"D","confidence":0..100,"why":"<=200 chars terse reasoning"}
 A=index 0, B=index 1, C=index 2, D=index 3 (Hebrew labeling א/ב/ג/ד maps the same way).`;
 
-// v4 judge prompt — explicit that we are validating the APP, not adjudicating
-// between the AI's pick and the app's pick. The AI's prior pick is supplied
-// only as context for "where you would have gone".
-const SYS_DOCTOR_JUDGE = `You are an experienced geriatric medicine attending grading a board-exam question and the app's answer key. The question is from an Israeli geriatric medicine board prep app (Shlav A, P005-2026). Your job: validate the APP's claimed correct answer against board-level geriatric medicine evidence (Hazzard 8e, Harrison 22e, GRS8, Israeli MOH). The AI's prior pick is context only — you are NOT adjudicating "AI vs app", you are validating the APP's stated key.
+// v4 judge prompt — audit-3 channel (answer-correctness validation).
+// v10.64.118 redesign: split off from SYS_DOCTOR_EXPLAIN (audit-1) so each
+// channel evaluates one axis. The original combined prompt was 75% noise
+// on audit-1 (rediscovering c-correctness conflation per 2026-05-13
+// calibration pilot). Now this prompt judges ONLY whether app's answer is
+// medically correct; audit-1 runs separately with explicit "assume answer
+// correct" carve-out.
+const SYS_DOCTOR_JUDGE = `You are an experienced geriatric medicine attending validating an APP's claimed correct answer for a Hebrew geriatric-medicine board-exam question (Shlav A, P005-2026). Your job is narrow: judge ONLY whether the app's claimed correct answer is medically correct against board-level evidence (Hazzard 8e, Harrison 22e, GRS8, Israeli MOH). DO NOT judge the explanation prose — that's audit-1, a separate channel. DO NOT judge the source citation — that's audit-2, a separate channel. The AI's prior pick is supplied as context only, NOT for adjudication.
 
 Output format (strict): one JSON line, no markdown.
 Schema:
-{"app_answer_correct":true|false,"explanation_sound":true|false,"confidence":0..100,"issue":"<=300 chars or null","correct_letter_if_app_wrong":"A"|"B"|"C"|"D"|null}
+{"app_answer_correct":true|false,"confidence":0..100,"issue":"<=300 chars or null","correct_letter_if_app_wrong":"A"|"B"|"C"|"D"|null}
 
-Be a strict but fair examiner — only flag app_answer_correct=false if you have a board-level reason. If you'd defer to the textbook (i.e. you're <80% confident the app is wrong), set app_answer_correct=true and explain in issue.`;
+Be a strict but fair examiner — only flag app_answer_correct=false if you have a board-level reason. If you'd defer to the textbook (i.e. <80% confident the app is wrong), set app_answer_correct=true and explain in issue.`;
 
-const SYS_DOCTOR_SOURCE = `You are a careful clinical educator. The explanation cites a textbook source (e.g. "Hazzard's Ch 43", "Harrison 22e Ch 437", "GRS8 פרק 19", "Brookdale 2024"). Without access to the textbook, judge whether the citation is plausible — does the chapter/section topic align with the question's clinical content?
+// v10.64.118 NEW: audit-1 channel (explanation-text-soundness given correct answer).
+// Validated 2026-05-13 against an 8-stem cohort (75% noise reduction vs prior
+// combined prompt). Carve-out structure: explicit axis exclusion ("audit-3
+// judges X separately") + three-axis decomposition (reasoning soundness,
+// distractor accuracy, prose well-formedness). Truncation defects surface
+// as axis 2-3 failures (incomplete distractor analysis + broken prose).
+const SYS_DOCTOR_EXPLAIN = `You are evaluating a Hebrew geriatric medicine board question. ASSUME THE CLAIMED CORRECT ANSWER IS CORRECT — its medical accuracy is judged separately by audit-3 (a different channel). Your job here is to judge ONLY THE EXPLANATION TEXT on three axes:
 
-Output format (strict): one JSON line.
-Schema:
-{"citation_plausible":true|false,"confidence":0..100,"note":"<=200 chars or null"}`;
+1. Does the explanation justify the correct answer with sound medical reasoning? (vs. circular reasoning, non-sequitur claims, or arguments that contradict the answer it's defending)
+2. Does the explanation contain factually wrong medical claims about the distractors (the wrong options)? (vs. claims that are accurate within the space of the option set)
+3. Is the explanation prose well-formed Hebrew with embedded clinical English where idiomatic? (vs. machine-translation artifacts, broken bidi, missing clinical context, truncated mid-sentence)
+
+Reply with strict JSON only, no prose outside JSON:
+{
+  "sound": true | false,
+  "issue": "<one paragraph naming the specific axis(es) that failed, or 'sound on all three axes' if true>",
+  "axis_failures": ["1" | "2" | "3" or empty array],
+  "confidence": <integer 0-100>
+}
+
+DO NOT consider whether the answer index "c" is correct. That's audit-3, not your job here. Even if you would have picked a different answer, defer to the claimed correct answer and judge only the explanation text quality given that the answer is right.`;
+
+// v10.64.118 redesign: audit-2 channel (ref-faithfulness given audit-grade
+// chapter assignment). Validated 2026-05-13 against a 13-stem cohort (85%
+// noise reduction vs prior "citation_plausible" prompt; idx 1954 carve-out
+// tightened to include peer-chapter specificity). Takes audit-grade chapter
+// assignment from data/question_chapters.json as INPUT (eliminates the
+// "Sonnet must construct chapter mapping from explanation text" failure
+// mode that produced ~85% noise on the prior channel).
+const SYS_DOCTOR_SOURCE = `You are evaluating whether a Hebrew geriatric medicine question's q.ref text is a FAITHFUL DISPLAY of the audit-grade chapter assignment from question_chapters.json. Your job is narrow: NOT to judge whether the chapter is topically aligned with the question, but whether q.ref displays the audit-grade assignment correctly.
+
+The q.ref is FAITHFUL if any of:
+- It cites at least one of the audited chapters with the correct chapter number.
+- It cites a more specific subchapter/section/page WITHIN an audited chapter (acceptable curatorial specificity).
+- It cites a more specific PEER CHAPTER within the same topic-default group as the audited chapter (e.g., audit says "Ch 88 — CANCER AND AGING: GENERAL PRINCIPLES" because the Q's ti=26 maps there by default, but q.ref cites "Ch 91 — LUNG CANCER" for a lung cancer Q — this is curatorial specificity choosing a more topic-specific peer chapter from the same book, and is acceptable). The audit-grade is the floor (topic-default), not the ceiling — when q.ref picks a more topically-precise peer, that's curatorial value-add, not drift.
+- The current q.ref is more specific than the audit-grade in any way that improves clinical accuracy (specific cancer subtype where audit says "cancer general", specific syndrome where audit says "broad category", etc.).
+- It cites a non-textbook source (e.g., Israeli law citation "חוק..." for legal-topic Qs) that the audit-grade mapping has no entry for. The audit-grade mapping is topic-default and doesn't cover legal sources.
+
+The q.ref is UNFAITHFUL if:
+- It cites a chapter number that disagrees with the audit-grade assignment AND is NOT a more-specific-peer relationship within the same clinical topic group (e.g., audit says Ch 79, q.ref says Ch 75, both Harrison, but Ch 75 is on a totally different topic — that's drift, not curatorial specificity).
+- It cites a clearly incorrect chapter on a different clinical topic entirely (e.g., Cardiology chapter on a Cancer Q).
+- It is internally inconsistent with the Q content.
+
+Reply with strict JSON only:
+{"faithful":true|false,"reason":"<one sentence>","confidence":0-100}
+
+DO NOT evaluate whether the explanation prose aligns with the chapter — that's audit-1. DO NOT evaluate the medical content of the question — that's audit-3. Judge ONLY whether q.ref faithfully displays the audit-grade chapter assignment given the carve-outs above.`;
 
 // ============================================================
 // Findings ledger — JSONL append (crash-resilient, unchanged shape from v3)
@@ -422,13 +517,45 @@ Validate the APP's claimed answer ${appLetter} (${appText}) against board-level 
   log.actions.push({
     at: nowIso(), type: 'ai-judge',
     app_answer_correct: judgeJson.app_answer_correct,
-    explanation_sound: judgeJson.explanation_sound,
     conf: judgeJson.confidence,
   });
 
-  // 3) Source-check
+  // 3) Audit-1: explanation-text soundness given correct answer.
+  // v10.64.118: split from SYS_DOCTOR_JUDGE per the 2026-05-13 redesign pilot
+  // (75% noise reduction). Only fires when explanation text is available.
+  let explainJson = null;
+  if (explanation && explanation.length > 50) {
+    const lettered = q.options.map((o, i) => `${'ABCD'[i]}. ${o.text}`).join('\n');
+    const userPromptExplain = `Question (Hebrew):
+${q.stem}
+
+Options:
+${lettered}
+
+Claimed correct answer (assume correct, judge only the explanation): ${appLetter} — ${appText}
+
+Explanation text (Hebrew):
+${explanation.slice(0, 2000)}
+
+Is the explanation TEXT medically sound on the three axes? Reply JSON only.`;
+    let explainResp;
+    try { explainResp = await callClaude(SYS_DOCTOR_EXPLAIN, userPromptExplain, { maxTokens: 400 }); }
+    catch (e) { log.bugs.push({ at: nowIso(), type: 'ai-error', context: 'explain', message: e.message }); }
+    explainJson = explainResp ? (extractJson(explainResp.text) || {}) : {};
+    log.actions.push({
+      at: nowIso(), type: 'ai-explain',
+      sound: explainJson.sound,
+      axis_failures: explainJson.axis_failures,
+      conf: explainJson.confidence,
+    });
+  }
+
+  // 4) Audit-2: ref-faithfulness given audit-grade chapter assignment.
+  // v10.64.118 redesign: takes audit-grade chapter assignment from
+  // data/question_chapters.json[idx] as INPUT (eliminates the failure
+  // mode where Sonnet had to construct chapter mapping from explanation
+  // text). Only fires when both audit-grade and source are available.
   let sourceJson = null;
-  // v4: try .quiz-source first (clean cite), else fall back to regex on explanation
   let cite = null;
   if (source) {
     const m = source.match(/(Hazzard|Harrison|GRS\s*8?|Brookdale|הזרד|הריסון)\s*(?:Ch\.?|Chapter|פרק)?\s*\d{1,3}/i);
@@ -437,13 +564,28 @@ Validate the APP's claimed answer ${appLetter} (${appText}) against board-level 
     const m = explanation.match(/(Hazzard|Harrison|GRS\s*8?|Brookdale|הזרד|הריסון)\s*(?:Ch\.?|Chapter|פרק)?\s*\d{1,3}/i);
     cite = m ? m[0] : null;
   }
-  if (cite) {
-    const userPrompt3 = `Explanation snippet (Hebrew geriatric medicine question):\n${(explanation || source).slice(0, 1500)}\n\nCited source: ${cite}.\nIs the chapter/section topic plausibly aligned with the explanation's claim?`;
+  const auditGrade = lookupAuditGrade(q.stem);
+  if (cite && auditGrade) {
+    const userPromptSource = `Question (Hebrew, abbreviated stem):
+${q.stem.slice(0, 400)}
+
+Audit-grade chapter assignment from question_chapters.json[${auditGrade.qzIdx}]:
+${auditGrade.audit_grade_text}
+
+Current q.ref text (extracted from explanation):
+"${cite}"
+
+Is the current q.ref a faithful display of the audit-grade chapter assignment, considering the carve-outs (curatorial specificity, non-textbook sources, subchapter relationships, peer-chapter specificity within same topic group)? Reply JSON only.`;
     let srcResp;
-    try { srcResp = await callClaude(SYS_DOCTOR_SOURCE, userPrompt3, { maxTokens: 200 }); }
+    try { srcResp = await callClaude(SYS_DOCTOR_SOURCE, userPromptSource, { maxTokens: 300 }); }
     catch (e) { log.bugs.push({ at: nowIso(), type: 'ai-error', context: 'source', message: e.message }); }
     sourceJson = srcResp ? (extractJson(srcResp.text) || {}) : {};
-    log.actions.push({ at: nowIso(), type: 'ai-source', plausible: sourceJson.citation_plausible, citation: cite, conf: sourceJson.confidence });
+    log.actions.push({ at: nowIso(), type: 'ai-source', faithful: sourceJson.faithful, citation: cite, qzIdx: auditGrade.qzIdx, conf: sourceJson.confidence });
+  } else if (cite) {
+    // Audit-grade not available (stem didn't match dataset, or data load failed).
+    // Skip source-check rather than fall back to the old prompt — partial-input
+    // judgments are exactly what the redesign eliminates.
+    log.actions.push({ at: nowIso(), type: 'ai-source-skipped', reason: 'no-audit-grade', citation: cite });
   }
 
   // Record finding.
@@ -460,6 +602,21 @@ Validate the APP's claimed answer ${appLetter} (${appText}) against board-level 
   // the served↔canonical coordinate-frame doctrine and 2026-05-13
   // .audit_logs/benchmarks/calibration_pilot_results_*.json for the
   // pilot run that surfaced the schema-level contract mismatch.
+  // v10.64.118: backwards-compat mirrors for long-chaos-analyze.mjs.
+  //  - explain.sound -> judge.explanation_sound (analyzer reads judge.explanation_sound)
+  //  - source.faithful -> source.citation_plausible (analyzer reads source.citation_plausible)
+  // The new explain.axis_failures field and the source.reason field carry
+  // the structured detail; the mirrored fields are single-boolean compat shims.
+  if (explainJson && typeof explainJson.sound === 'boolean') {
+    judgeJson.explanation_sound = explainJson.sound;
+    if (judgeJson.confidence == null && explainJson.confidence != null) {
+      judgeJson.confidence = explainJson.confidence;
+    }
+  }
+  if (sourceJson && typeof sourceJson.faithful === 'boolean') {
+    sourceJson.citation_plausible = sourceJson.faithful;
+  }
+
   const finding = {
     workerId,
     stem: q.stem.slice(0, 300),
@@ -469,13 +626,17 @@ Validate the APP's claimed answer ${appLetter} (${appText}) against board-level 
     appIdx, appDisplayIdx, appLetter, appText,
     disagrees,
     judge: judgeJson,
+    explain: explainJson,
     source: sourceJson,
     citation: cite,
   };
   recordFinding(finding);
 
-  // 4) Side-effects on flagged Qs (feedback / report) — same as v3 logic
-  const flagged = disagrees || judgeJson?.app_answer_correct === false || judgeJson?.explanation_sound === false;
+  // 4) Side-effects on flagged Qs (feedback / report)
+  const flagged = disagrees
+    || judgeJson?.app_answer_correct === false
+    || explainJson?.sound === false
+    || sourceJson?.faithful === false;
   if (flagged && Math.random() < CONFIG.feedbackRate) {
     await maybeSubmitFeedback(page, log, finding);
   }

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -7182,8 +7182,9 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.117';
+const APP_VERSION='10.64.118';
 const CHANGELOG={
+'10.64.118':['feat(bot-v4): split audit-1 + audit-2 channels — SYS_DOCTOR_JUDGE now audit-3-only (answer correctness), new SYS_DOCTOR_EXPLAIN for audit-1 (explanation-text soundness given correct answer), SYS_DOCTOR_SOURCE rewritten for audit-2 (ref-faithfulness given audit-grade chapter assignment as INPUT)','feat(bot-v4): load data/question_chapters.json + hazzard_chapters.json + harrison_chapters.json at bot startup; source-check now skips when audit-grade unavailable rather than falling back to old prompt','test: +7 chaosBotV4Persona tests pinning the new prompt shapes (axis-exclusion clauses, three-axis decomposition, peer-chapter carve-out, audit-grade-as-input)','perf: 4 API calls per Q (was 3) — ~33% chaos-run cost increase. Validated 2026-05-13: 75% noise reduction on audit-1, 85% on audit-2'],
 '10.64.117':["fix(data): drop wrong 'Harrison Ch 286 — STEMI' ref from 4 heme-malig Qs (idx 2579, 2588, 2703, 2716) — Q content is the witness; STEMI chapter cannot be right for hematologic malignancy / genetic mutation / blood smear Qs",'docs(CLAUDE.md): add q.ref rebuild caveat — question_chapters.json is rule-based topic-default mapping, NOT audit-grade truth source; rebuild only where current ref is verifiably worse, ADD-not-OVERWRITE for cases with curatorial specificity'],
 '10.64.116':['fix(bot-v4): emit optionCanonicalIdx=null for Geri (was identity placeholder [0,1,2,3] — type-correct but semantically wrong)','feat(lib): textResolveAgainstQZ helper for Geri-frame JSONL consumers','test: 6 new optionResolver tests + drive-by CRLF tolerance for ModalDismiss regex'],
 '10.64.115':[

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.117';
+const CACHE='shlav-a-v10.64.118';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 // CRITICAL_URLS = the bare-minimum app shell required for offline boot.
 // Anything else (data/*.json, fonts, icons) is best-effort in the install

--- a/tests/chaosBotV4Persona.test.js
+++ b/tests/chaosBotV4Persona.test.js
@@ -25,6 +25,7 @@ function extractPrompt(name) {
 
 const PICK = extractPrompt('SYS_DOCTOR_PICK');
 const JUDGE = extractPrompt('SYS_DOCTOR_JUDGE');
+const EXPLAIN = extractPrompt('SYS_DOCTOR_EXPLAIN');  // v10.64.118 — audit-1 split
 const SOURCE = extractPrompt('SYS_DOCTOR_SOURCE');
 
 describe('chaos-doctor-bot v4 — Geri persona pins', () => {
@@ -41,29 +42,82 @@ describe('chaos-doctor-bot v4 — Geri persona pins', () => {
     });
   });
 
-  describe('SYS_DOCTOR_JUDGE', () => {
+  describe('SYS_DOCTOR_JUDGE (audit-3 — answer-correctness only)', () => {
     it('attending is geriatric, not family-medicine', () => {
       expect(JUDGE.toLowerCase()).toMatch(/geriatric medicine attending/);
       expect(JUDGE.toLowerCase()).not.toMatch(/family.medicine attending/);
     });
     it('app description references geriatric medicine, not family medicine', () => {
-      expect(JUDGE.toLowerCase()).toMatch(/geriatric medicine board prep/);
-      expect(JUDGE.toLowerCase()).not.toMatch(/family.medicine board prep/);
+      // v10.64.118: phrasing shifted from "board prep" to "board-exam" with the
+      // axis split. The geriatric-medicine framing remains; the family-medicine
+      // exclusion remains the load-bearing assertion.
+      expect(JUDGE.toLowerCase()).toMatch(/geriatric.medicine board.exam|geriatric medicine board prep/);
+      expect(JUDGE.toLowerCase()).not.toMatch(/family.medicine board/);
     });
     it('evidence corpus is the geri-canon (Hazzard 8e / Harrison 22e / GRS8 / MOH)', () => {
       expect(JUDGE).toMatch(/Hazzard 8e/);
       expect(JUDGE).toMatch(/Harrison 22e/);
       expect(JUDGE).toMatch(/GRS8/);
     });
+    it('axis-isolation: judge does NOT evaluate explanation prose (audit-1) or source citation (audit-2)', () => {
+      // v10.64.118 axis-split contract: JUDGE handles only answer-correctness
+      // (audit-3). The explicit "audit-1 separate / audit-2 separate" carve-out
+      // is what stops the channel from rediscovering c-correctness as
+      // "unsound explanation" (the 75% noise mode the 2026-05-13 pilot fixed).
+      expect(JUDGE.toLowerCase()).toMatch(/audit-1.{0,40}separate|that's audit-1/);
+      expect(JUDGE.toLowerCase()).toMatch(/audit-2.{0,40}separate|that's audit-2/);
+    });
   });
 
-  describe('SYS_DOCTOR_SOURCE', () => {
-    it('citation examples are Geri textbooks (no Goroll / Nelson / AFP / Lerner)', () => {
-      expect(SOURCE).toMatch(/Hazzard/);
+  describe('SYS_DOCTOR_EXPLAIN (audit-1 — explanation-text soundness, v10.64.118)', () => {
+    it('explicit axis-exclusion: assumes answer correct, judges text only', () => {
+      // The load-bearing carve-out — without it, the channel rediscovers
+      // c-correctness instead of explanation-text soundness.
+      expect(EXPLAIN).toMatch(/ASSUME THE CLAIMED CORRECT ANSWER IS CORRECT/);
+      expect(EXPLAIN.toLowerCase()).toMatch(/audit-3/);
+    });
+    it('three-axis decomposition is present', () => {
+      // Sound-reasoning / distractor-accuracy / prose-well-formed.
+      expect(EXPLAIN).toMatch(/1\..*[Ss]ound medical reasoning/);
+      expect(EXPLAIN).toMatch(/2\..*distractors/);
+      expect(EXPLAIN).toMatch(/3\..*Hebrew/);
+    });
+    it('output schema has axis_failures + sound + confidence', () => {
+      expect(EXPLAIN).toMatch(/"axis_failures"/);
+      expect(EXPLAIN).toMatch(/"sound"/);
+      expect(EXPLAIN).toMatch(/"confidence"/);
+    });
+    it('no FM-sibling persona leak', () => {
+      expect(EXPLAIN.toLowerCase()).not.toMatch(/family.medicine|goroll|nelson|\bafp\b/);
+    });
+  });
+
+  describe('SYS_DOCTOR_SOURCE (audit-2 — ref-faithfulness, v10.64.118 redesign)', () => {
+    it('Geri-canon present, no FM-textbook leak', () => {
+      // v10.64.118: the source prompt's Geri-corpus markers shifted from
+      // verbatim "Hazzard" / "Harrison" name-drops to "audit-grade chapter
+      // assignment from question_chapters.json" + concrete Geri-canon
+      // examples (Ch 88 CANCER, Ch 91 LUNG CANCER). The FM-leak guard
+      // remains load-bearing.
+      expect(SOURCE.toLowerCase()).toMatch(/hazzard|cancer|geriatric|audit-grade chapter/);
       expect(SOURCE).not.toMatch(/Goroll/);
       expect(SOURCE).not.toMatch(/Nelson/);
       expect(SOURCE).not.toMatch(/\bAFP\b/);
       expect(SOURCE).not.toMatch(/Lerner/);
+    });
+    it('axis-isolation: source does NOT evaluate explanation prose (audit-1) or answer correctness (audit-3)', () => {
+      expect(SOURCE.toLowerCase()).toMatch(/audit-1/);
+      expect(SOURCE.toLowerCase()).toMatch(/audit-3/);
+    });
+    it('peer-chapter carve-out is present (idx 1954 case)', () => {
+      // The 1954-class carve-out — Ch 91 LUNG vs Ch 88 CANCER-GEN as
+      // peer-chapter specificity, not chapter drift. Without this clause
+      // the audit-2 channel re-flags curatorially-specific refs as false
+      // positives (validated empirically 2026-05-13).
+      expect(SOURCE.toLowerCase()).toMatch(/peer chapter|peer-chapter/);
+    });
+    it('takes audit-grade chapter assignment as INPUT (per the structural redesign)', () => {
+      expect(SOURCE).toMatch(/audit-grade chapter assignment/);
     });
   });
 


### PR DESCRIPTION
## Summary

Splits the chaos-doctor v4 judge into three single-axis channels (audit-1 / audit-2 / audit-3) with explicit cross-axis exclusion clauses and structural changes to eliminate noisy-mix failure modes. Empirically validated 2026-05-13: 75% noise reduction on audit-1, 85% on audit-2.

## Calibration evidence (2026-05-13 pilot)

| Channel | Old prompt flag rate | Redesigned flag rate | Noise reduction |
|---|---:|---:|---:|
| Audit-1 (explanation soundness) | 8/8 stems flagged unsound | 2/8 flagged (both truncation defects) | **75%** |
| Audit-2 (cite plausibility) | 13/13 stems flagged implausible | 2/13 flagged (real chapter drift + 1 borderline) | **85%** |

Both predictions hit aggregate exactly (pre-written and locked before run per `feedback_prewritten_predictions.md`). Per-stem identity 50% accurate — banked as calibration baseline.

## Three architectural changes

**1. Axis isolation:** Each prompt evaluates exactly one verdict.
- `SYS_DOCTOR_JUDGE` (audit-3): answer-correctness only. Explicit \"audit-1 separate / audit-2 separate\" carve-out.
- `SYS_DOCTOR_EXPLAIN` (NEW, audit-1): explanation-text soundness with \"ASSUME THE CLAIMED CORRECT ANSWER IS CORRECT\" load-bearing carve-out.
- `SYS_DOCTOR_SOURCE` (audit-2): ref-faithfulness only.

**2. Audit-grade as INPUT, not constructed by Sonnet.** The redesigned audit-2 prompt takes the `question_chapters.json[idx]` chapter assignment as a user-prompt input block, eliminating the failure mode where Sonnet had to infer the chapter from explanation text. Bot now loads `data/questions.json` + `data/question_chapters.json` + chapter title tables at startup; `lookupAuditGrade(stem)` resolves live-DOM stem to the audit-grade block via stem-prefix-80 map.

**3. Carve-out clauses for legitimate cross-axis patterns.**
- Audit-1 three-axis decomposition (reasoning / distractor accuracy / prose well-formedness)
- Audit-2 four carve-outs: subchapter specificity, **peer-chapter specificity within same topic-default group** (the idx 1954 case — Hazzard Ch 91 LUNG vs Ch 88 CANCER-GEN), generic curatorial specificity, non-textbook sources (Israeli law)

## Notable bug class surfaced by audit-1 redesign

Both flagged audit-1 stems (idx 3208, 3413) failed axes 2-3 with the same pattern: **explanation truncated mid-sentence**, no distractor analysis. Length 381-394 chars vs 859-1113 chars for sound explanations. The original audit-1 was correctly flagging \"unsound\" but burying the actionable detail — the fix is regenerate with higher `max_tokens`, not rewrite from scratch. A separate truncation-scanner PR follows.

## Cost impact

4 API calls per Q (was 3). ~33% chaos-run cost increase. Per the user's `feedback_anthropic_key_rotation_order.md` pattern: the cost is worth the clean signal — pre-write prediction for next chaos long-run is that hit counts drop ~80% across both channels, so total review-time savings dominate the cost increase by an order of magnitude.

## Backwards compat

Two shims for `scripts/long-chaos-analyze.mjs` (which reads JSONL records by old field names):
- `explain.sound` → mirrored into `judge.explanation_sound`
- `source.faithful` → mirrored into `source.citation_plausible`

Analyzer continues to work unchanged. New consumers should prefer `explain.{sound,axis_failures}` and `source.{faithful,reason}` for structured detail.

## Test plan

- [x] `npm run verify`: 1342 tests pass, 7 skipped (+8 vs prior — 7 new persona tests + 1 pilot script committed). Zero regressions on existing v4 bot tests.
- [x] Single-stem verification of idx 1954 peer-chapter carve-out at conf 90 (`.audit_logs/benchmarks/audit2_v2_verify_idx1954_2026-05-13.json`)
- [x] Calibration pilot full results (`.audit_logs/benchmarks/audit_redesign_pilot_results_2026-05-13.json`)
- [x] Persona pins cover: axis-isolation contracts, three-axis decomposition, peer-chapter carve-out, audit-grade-as-input contract, no FM-sibling persona leak

## Pre-write prediction for next chaos long-run

If a v4 long-run (1 worker × 240 min × sonnet-4-6, ~$8 cost) is fired against this bot config:
- Audit-3 (c-disagreements at conf≥85): no change from prior run (~10-11 hits)
- Audit-1 (explanation-text-unsound at conf≥85): drops from ~82 hits to ~20 hits (75% reduction)
- Audit-2 (ref-unfaithful at any conf): drops from ~87 hits to ~13 hits (85% reduction)

If empirics deviate substantially (e.g., audit-1 drops only 50%), the redesign's per-stem behavior is closer to noise than the pilot suggested — pin for inspection. The pilot cohort was 21 stems; production scale is ~115 unique stems / 788 judgments per long-run, so larger N may surface failure modes not in the pilot.

## Stacked on

PR #213 (v10.64.117 ref scope-collapse). Version cascade: .115 → .116 (#212) → .117 (#213) → .118 (this).

## Out of scope

- Truncation-scanner PR (parallel, opening next) — bulk-detect mid-sentence-cut entries in `data/explanations.json` and writes list to `.audit_logs/`. Per user direction: scanner first, then a follow-up regen PR after spot-check.
- v4 audit-3 threshold drop to conf≥85 — separate config-only PR after data fixes ship per the locked plan.
- C-flip PRs (NSCLC + opioid-MCI) — still blocked on verbatim Hazzard quotes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)