### PR TITLE
audit-5: validator-before-prompt for B5 judge JSON-shape failure

### DIFF
--- a/docs/AUDIT5_B5_result_2026-05-17.md
+++ b/docs/AUDIT5_B5_result_2026-05-17.md
@@ -1,0 +1,85 @@
+# Audit-5 — chaos-doctor-bot v4 B5 (judge JSON-shape failure) — RESULT
+
+**Date:** 2026-05-17 · **Branch:** `main` (solo lane) · **Spend:** $0 (no
+chaos run — diagnosable + gateable from the existing audit-3 ledger + a
+deterministic fixture; a fresh chaos re-judge is the wrong gate per
+audit-4) · **Trinity:** untouched at v10.64.130 (scripts/tests/docs only —
+correctly no bump).
+
+Tracked report of record (clone-visible). Pre-registered gate +
+append-only RESULT: `docs/AUDIT5_PRE_REGISTERED_GATE.md`. Gitignored
+working artifacts: `chaos-reports/v4/audit5_b5_2026-05-17/`.
+
+## Defect
+
+B5 = the 22/86 audit-3 `disagrees:true` rows where
+`judge.app_answer_correct` was non-boolean — a `SYS_DOCTOR_JUDGE`
+structured-output discipline failure (≈26% of the disagreement rows),
+distinct from the (non-existent) audit-4 letter↔index artifact.
+
+## Root cause (Phase 1 — established by evidence, not hypothesis)
+
+`scripts/chaos-doctor-bot-v4.mjs:560`
+(`judgeResp ? (extractJson(judgeResp.text) || {}) : {}`):
+
+1. `ai-error context=judge` across the whole run = **0** → the judge
+   `callClaude` never threw; `judgeResp` never null from an exception.
+2. The separate explain `callClaude` on the same question succeeded
+   **22/22** (boolean `sound`) → API healthy; failure judge-call-specific.
+3. ⇒ `extractJson(judgeResp.text)` returned **null** → `|| {}` silently
+   substituted `{}` → `app_answer_correct` undefined = B5. Every B5 judge
+   object is exactly `{confidence, explanation_sound}` — both injected by
+   the unrelated explain channel (`:654-658`); the judge contributed
+   nothing.
+4. The judge channel had **no `ai-parse-error` log** (the pick channel
+   logs at `:462`) and **no corrective retry** — the failure was silent
+   and un-retried by design omission.
+
+Cross-tab independently re-derived from the raw ledger (every cell read
+off source, no subtraction — `feedback-cross-tab-not-derived-delta`):
+`has-letter×aac-False=61`, `no-letter×aac-True=3` (B1, benign),
+`no-letter×aac-non-bool=22` (B5), B2=B3=0, Σ=86. Matches the brief and the
+audit-4 doc (audit-4's numbers *verified*, not laundered).
+
+The raw failing judge **text** was never persisted (ledger keeps only the
+post-`extractJson` object), so the literal 22 strings are unrecoverable.
+The gate therefore anchors to a git-tracked constructed fixture of the
+failure shapes (the brief explicitly permits "or a captured fixture").
+
+## Fix (validator-before-prompt — pre-decided class)
+
+| Artifact | What |
+|---|---|
+| `scripts/lib/judgeShapeValidator.mjs` | `validateJudgeShape(obj)` (ok iff `typeof obj.app_answer_correct==='boolean'`) + `judgeWithShapeRetry({...,callJudge,log})` — post-extract shape check + **exactly one** corrective re-ask (cap=1), composed THROUGH the existing `extractJson.mjs`; closes the silent-gap with a typed `ai-parse-error context:'judge'` mirroring pick `:462` |
+| `scripts/chaos-doctor-bot-v4.mjs` | bare `extractJson(...)||{}` at `:560` → injectable `judgeWithShapeRetry` (callClaude injected → unit-testable, no API/playwright) |
+| `tests/chaosBotV4JudgeShapeValidator.test.js` (15) + `tests/fixtures/judgeShapeFailures.json` | the deterministic-replay guard (P1 detection + P2 cap=1 symmetric wiring); git-tracked fixture = fresh-eye-visible replay corpus |
+
+`callClaude`'s internal 3-attempt **network** retry is orthogonal; the
+shape-cap=1 is layered above it → at most 2 model responses per judge turn
+(verified: stub invoked exactly 2× in both shape branches, never 3).
+
+## Gate result — all 3 predicates MET, TRIP NOT met
+
+- **P1**: fixture splits exactly **6 nonconforming / 2 conforming**;
+  0 false-negatives on the verdict axis.
+- **P2**: conforming-stub → **0/22** residual, 0 logs, 2 calls/item;
+  nonconforming-stub → **22/22** stays `{}`, **22/22** typed-logged,
+  2 calls/item (cap holds — never 3); throw → 0 shape-retry + 1
+  `ai-error`. Corrective is a validator-gated re-ask.
+- **P3**: 3 baseline suites green (34); carried-forward c_accept-AWARE
+  oracle over the audit-3 ledger = `0/0/0` (== audit-4 Regression B);
+  `npm run verify` = **72 files / 1396 + 7 skipped**; trinity untouched.
+
+Pre→post (deterministic replay): pre-fix 22/22 non-boolean **silently**
+(0 logs/0 retries); post-fix 6/6 shapes flagged, conforming-corrective ⇒
+**22/22 → 0/22**, failing-corrective ⇒ 22/22 but now **22/22
+typed-logged** (B5 observable). Recovery conditional on the retry
+conforming — the honest framing.
+
+## Out of scope (handed off untouched)
+
+Content adjudication of the clean **B4 (37 distinct Qs)** — separate,
+un-pre-committed, PDF-verified-per-v9.81-idx-510 decision. **No `q.c`
+flip, no `broken` change, no distractor regen.** Audit-4 letter-frame
+gate stays CLOSED; the 3 B1 no-letter rows are benign; `stop_reason`
+capture explicitly cut (non-speculative).

--- a/docs/AUDIT5_PRE_REGISTERED_GATE.md
+++ b/docs/AUDIT5_PRE_REGISTERED_GATE.md
@@ -1,0 +1,144 @@
+# Audit-5 — chaos-doctor-bot v4 B5 (judge JSON-shape failure) — PRE-REGISTERED GATE
+
+Written **before** the validator code. Append-only; do not retro-edit
+(`feedback_spec_provenance_append_only`). Lane: terminal, solo. Trinity:
+untouched (scripts/tests/docs only — correctly **no bump**, mirrors audit-4).
+
+## STEP 0 (distrust contract) — results
+
+- **0.1** `HEAD == 3170e35` on `main`, clean tree (`git status --porcelain`
+  empty: only `## main...origin/main`). HEAD is the kickoff-doc commit;
+  parent `79b15ed` → **HEAD descends from 79b15ed ✅**. Audit-4 chain
+  present in exact asserted order: `1c8e656`(fix) → `bbc2cd8`(test) →
+  `3225d11`/`a086d43`/`79b15ed`(docs). ✅ CONFIRMED.
+- **0.2** Concurrent lane: no `claude/web-*` branch exists; only non-main
+  branches are 4-day-old remote-only `claude/term-*regen*`; `main` ==
+  `origin/main` == HEAD `3170e35`. No live branch touching the bot or the
+  shared engine within 24h. → **SOLO → direct push to main is the release
+  path** (still as separate fix-commit + test-commit). ✅
+- **0.3** Audit-4 baseline green: `npx vitest run
+  tests/chaosJudgeLetterFrame.test.js tests/extractAcceptedDisplayIdxSet.test.js
+  tests/chaosCacceptRatchet.test.js` → **3 files / 34 tests passed.** ✅
+- **0.4** Cross-tab **independently re-derived** from the raw ledger
+  `chaos-reports/v4/audit3_caccept_fix_2026-05-17/medical_findings_ai_v4.jsonl`
+  (592 rows) — every cell read off the source, **no subtraction**
+  (`feedback-cross-tab-not-derived-delta`); script
+  `chaos-reports/v4/audit5_b5_2026-05-17/rederive_crosstab.py`:
+
+  | | aac=True (B1) | aac=False (B4) | aac non-bool (B5) | row tot |
+  |---|---|---|---|---|
+  | **has letter** | 0 | **61** | 0 | 61 |
+  | **no letter** | **3** | 0 | **22** | 25 |
+  | **col tot** | 3 | 61 | 22 | **86** |
+
+  Σ all 6 cells = 86 == `disagrees:true`. **Exactly matches** the brief's
+  expected table and the audit-4 doc table (trap #4: audit-4's numbers
+  *verified*, not laundered). B2=B3=0 (no override/broken rows within
+  aac=False, per audit-4 triage). ✅
+
+## Root cause (systematic-debugging Phase 1 — established by evidence)
+
+`scripts/chaos-doctor-bot-v4.mjs:560`:
+`const judgeJson = judgeResp ? (extractJson(judgeResp.text) || {}) : {};`
+
+For **all 22** B5 rows:
+
+1. `ai-error context=judge` count across the whole run = **0** → the judge
+   `callClaude` never threw; `judgeResp` was never null from an exception.
+2. The separate explain `callClaude` on the same question succeeded
+   **22/22** (boolean `sound`) → API healthy; failure is judge-call-specific,
+   not an outage.
+3. ⇒ `extractJson(judgeResp.text)` returned **null** (judge output not a
+   parseable brace-balanced JSON object) → `|| {}` silently substituted
+   `{}` → `judgeJson.app_answer_correct` = `undefined` (non-boolean) = B5.
+4. Every B5 judge object has the exact key-shape `{confidence,
+   explanation_sound}` — both injected from the unrelated explain channel
+   (lines 654-658); the judge contributed nothing.
+5. The judge channel has **no `ai-parse-error` log** (the pick channel does,
+   at line 462) and **no corrective retry** — the failure is silent and
+   un-retried *by design omission*. This silent-failure gap is in-scope to
+   close (parity with the pick channel; non-speculative — the failure mode
+   demonstrably occurs 22/86, unlike the audit-4 cut validator).
+
+**Constraint:** the ledger preserves only the post-`extractJson` `judge`
+object, **not** the raw failing judge text. The literal 22 failing strings
+are unrecoverable. The deterministic-replay gate therefore anchors to a
+**git-tracked constructed fixture** of the failure shapes (the brief
+explicitly permits "or a captured fixture"). This refines *what* the gate
+anchors to; it does not weaken it (a fresh chaos re-judge is the wrong gate
+anyway — audit-4: "don't re-judge an already-clean judge").
+
+## Fix class (pre-decided, locked) — validator-before-prompt
+
+Post-generate JSON-shape validator on the `SYS_DOCTOR_JUDGE` response +
+**exactly one** corrective retry (cap=1 per `feedback_validator_before_prompt`).
+Wires *through* the existing `scripts/lib/extractJson.mjs` (grep-existing-utility:
+the helper is already imported+used at line 49/560 — compose, do not
+re-implement JSON parsing). New module `scripts/lib/judgeShapeValidator.mjs`
+(sibling to `extractJson.mjs` / `optionResolver.mjs`); bot lines 558-560
+refactor into an injectable `judgeWithShapeRetry({...,callJudge,log})` pure
+function (same dependency-injection shape audit-4 gave `resolveJudgeLetter`).
+
+## THE THREE DETERMINISTIC PREDICATES (registered before code — literal targets)
+
+### P1 — Detection
+`validateJudgeShape(obj)` ⇒ `{ok:true}` **iff** `obj` is a non-null object
+AND `typeof obj.app_answer_correct === 'boolean'`. Fixture
+`tests/fixtures/judgeShapeFailures.json` = **8** raw model-output text
+samples; each piped through `extractJson` then `validateJudgeShape`:
+
+- **6 nonconforming → ok:false**: `truncated_json`, `prose_then_truncated`,
+  `prose_only_no_json`, `fenced_then_truncated`, `json_string_bool`
+  (`"app_answer_correct":"true"`), `json_missing_aac`.
+- **2 conforming → ok:true**: `bare_valid_json`, `fenced_valid_json`.
+
+**TARGET (literal): exactly 6 flagged, 2 pass. 0 false-negatives on the
+missing/non-boolean-`app_answer_correct` axis.**
+
+### P2 — Retry wiring (cap=1; injected stub `callJudge`, no API/playwright)
+Replay over a 22-element array modelling the empirical B5 corpus (all
+initially nonconforming):
+
+- **Stub-conforming 2nd response** → residual non-boolean = **0/22**
+  (all recovered); `callJudge` invoked **exactly 2× per item** (1 original
+  + 1 corrective; never 3 — shape-cap=1 layered above `callClaude`'s
+  orthogonal internal network-retry); `ai-parse-error` log entries = **0**.
+- **Stub-nonconforming 2nd response** → residual = **22/22** (`judgeJson`
+  stays `{}`); `callJudge` invoked **exactly 2× per item** (cap holds —
+  never a 2nd corrective retry); typed `{type:'ai-parse-error',
+  context:'judge'}` in `log.bugs` = **22/22** (silent-gap closed; mirrors
+  line 462).
+- **Stub throws (API-outage class)** → **no** shape retry; one
+  `{type:'ai-error',context:'judge'}`; returns `{}` (preserves current
+  behavior — a throw is not a shape problem).
+
+**TARGET (literal): {0/22 recovered, 0 log, 2 calls} | {22/22 stays-{}, 22
+log, 2 calls} | {throw → 0 shape-retry, 1 ai-error}. Invocation count
+symmetric (2) across both shape branches.**
+
+### P3 — Regression integrity (additive-change proof)
+- 3 STEP-0 baseline tests stay green (34 tests).
+- c_accept-AWARE oracle `classify_isok_fps.py` **carried forward** into
+  `chaos-reports/v4/audit5_b5_2026-05-17/` (not trusted in place — copied +
+  re-run; its own pre-fix contract self-validates it isn't c_accept-blind),
+  run over the audit-3 ledger ⇒ `isOk_pick_FPs:0, any_isOk_FPs:0,
+  unresolved_total:0` (== audit-4 Regression B — the validator change must
+  not perturb `disagrees`/scoring).
+- Full `npm run verify` green; trinity untouched.
+
+## TRIP CONDITION
+If P1 ≠ 6/2, **or** P2 ≠ the literal targets with cap=1, **or** P3 regresses
+(any baseline test red, or oracle ≠ 0/0/0, or `npm run verify` red) →
+**STOP and report. Premise-falsification is a valid outcome** (as audit-4
+showed). Do not ship a partial; do not loosen a predicate post-hoc.
+
+## OUT OF SCOPE (do NOT pre-commit / do NOT touch)
+- Content adjudication of the clean B4 (37 distinct Qs) — separate,
+  un-pre-committed, PDF-verified-per-v9.81-idx-510 decision. Handed off
+  untouched. No `q.c` flip, no `broken` change, no distractor regen.
+- Re-litigating audit-4's letter↔index gate (CLOSED by falsification).
+- The 3 B1 no-letter rows (judge confirmed app; benign — not B5).
+- `stop_reason` capture in `callClaude` — would disambiguate truncation
+  vs prose-only on *future* runs, but the fix does not depend on it and
+  the brief is tight. **Explicitly cut** (non-speculative scope discipline,
+  mirrors audit-4's cut of the speculative live validator).

--- a/docs/AUDIT5_PRE_REGISTERED_GATE.md
+++ b/docs/AUDIT5_PRE_REGISTERED_GATE.md
@@ -142,3 +142,43 @@ showed). Do not ship a partial; do not loosen a predicate post-hoc.
   vs prose-only on *future* runs, but the fix does not depend on it and
   the brief is tight. **Explicitly cut** (non-speculative scope discipline,
   mirrors audit-4's cut of the speculative live validator).
+
+---
+
+## [2026-05-17, appended post-implementation] RESULT — all 3 predicates met, TRIP NOT met
+
+Append-only. Validator: `scripts/lib/judgeShapeValidator.mjs`; wired at
+`scripts/chaos-doctor-bot-v4.mjs` (bare `extractJson(...)||{}` → injectable
+`judgeWithShapeRetry`). Guard: `tests/chaosBotV4JudgeShapeValidator.test.js`
+(15 tests) + git-tracked fixture `tests/fixtures/judgeShapeFailures.json`.
+
+- **P1 detection — MET.** Fixture splits **exactly 6 nonconforming /
+  2 conforming**; 0 false-negatives on the non-boolean-`app_answer_correct`
+  axis (incl. `json_string_bool`, `json_missing_aac`).
+- **P2 retry wiring — MET (cap=1, symmetric).** Conforming-stub:
+  **0/22 residual**, 0 `ai-parse-error`, **2 callJudge/item**.
+  Nonconforming-stub: **22/22 stays `{}`**, **22/22 typed
+  `{type:'ai-parse-error',context:'judge'}`** (silent-gap closed; mirrors
+  pick `:462`), **2 callJudge/item — never 3** (a 3rd-queued conforming
+  response is provably never reached). Hard throw: **no shape retry,
+  1 `ai-error`, `{}`** (pre-audit-5 behavior preserved). Corrective retry
+  is a validator-gated RE-ASK (2nd userPrompt ≠ 1st, schema restated) —
+  validator-before-prompt, not prompt-only.
+- **P3 regression — MET (additive).** 3 baseline suites green (34).
+  Carried-forward c_accept-AWARE oracle (copied into
+  `chaos-reports/v4/audit5_b5_2026-05-17/`, self-validated) over the
+  audit-3 ledger: `isOk_pick_FPs:0, any_isOk_FPs:0, unresolved_total:0`
+  (== audit-4 Regression B). Full `npm run verify`: **72 files / 1396
+  passed + 7 skipped**; **trinity untouched at v10.64.130** (scripts/
+  tests/docs only — correctly no bump).
+
+Honest pre/post deterministic-replay metric: pre-fix the 22-shape B5
+corpus produced 22/22 non-boolean **silently** (0 logs, 0 retries).
+Post-fix replay: 6/6 nonconforming shapes flagged; conforming corrective
+⇒ **22/22 → 0/22 residual**; still-failing corrective ⇒ 22/22 residual
+but **22/22 now typed-logged** (B5 observable, no longer invisible).
+Recovery is conditional on the retry conforming — the honest framing; a
+fresh stochastic rate is the gate the brief forbade.
+
+**TRIP CONDITION NOT MET.** No predicate failed; no falsification. Clean
+bug-fix-with-tests ship → workspace fresh-eye route not triggered.

--- a/scripts/chaos-doctor-bot-v4.mjs
+++ b/scripts/chaos-doctor-bot-v4.mjs
@@ -47,6 +47,7 @@ import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { extractJson } from './lib/extractJson.mjs';
+import { judgeWithShapeRetry } from './lib/judgeShapeValidator.mjs';
 import {
   resolveAppVerdict,
   resolveJudgeLetter,
@@ -554,10 +555,19 @@ ${source ? `\nApp's cited source: ${source}` : ''}
 (Context — NOT for adjudication: AI prior pick was ${aiLetter}: ${pickJson.why || 'no rationale'})
 
 Validate the APP's claimed answer ${appLetter} (${appText}) against board-level geriatric-medicine evidence.`;
-  let judgeResp = null;
-  try { judgeResp = await callClaude(SYS_DOCTOR_JUDGE, userPrompt2, { maxTokens: 400 }); }
-  catch (e) { log.bugs.push({ at: nowIso(), type: 'ai-error', context: 'judge', message: e.message }); }
-  const judgeJson = judgeResp ? (extractJson(judgeResp.text) || {}) : {};
+  // 2026-05-17 audit-5 (B5): post-generate JSON-shape validator + exactly
+  // one corrective retry. Replaces the bare `extractJson(...) || {}` that
+  // silently produced 22/86 audit-3 non-boolean verdicts with no log + no
+  // retry. callClaude is injected so the path is unit-testable (see
+  // scripts/lib/judgeShapeValidator.mjs + docs/AUDIT5_PRE_REGISTERED_GATE.md).
+  const judgeJson = await judgeWithShapeRetry({
+    system: SYS_DOCTOR_JUDGE,
+    userPrompt: userPrompt2,
+    maxTokens: 400,
+    callJudge: callClaude,
+    log,
+    nowIso,
+  });
   log.actions.push({
     at: nowIso(), type: 'ai-judge',
     app_answer_correct: judgeJson.app_answer_correct,

--- a/scripts/lib/judgeShapeValidator.mjs
+++ b/scripts/lib/judgeShapeValidator.mjs
@@ -1,0 +1,108 @@
+// Audit-5 (2026-05-17) — judge JSON-shape validator + corrective retry.
+//
+// ROOT CAUSE (B5, evidence-established): for 22/86 audit-3 disagreement
+// rows `extractJson(judgeResp.text)` returned null at
+// chaos-doctor-bot-v4.mjs:560; `|| {}` silently substituted `{}`;
+// `app_answer_correct` -> undefined; the judge channel had NO parse-error
+// log + NO corrective retry (the pick channel logs at :462). 0 thrown
+// judge errors and explain on the same Q succeeded 22/22 -> the failure
+// is judge-call-specific, not an API outage.
+//
+// FIX CLASS (pre-decided, locked): validator-before-prompt
+// (feedback_validator_before_prompt) — post-generate shape check + exactly
+// ONE corrective re-ask, layered ABOVE callClaude's orthogonal internal
+// network-retry. Composes THROUGH the existing extractJson.mjs
+// (grep-existing-utility: do not re-implement JSON parsing).
+//
+// See docs/AUDIT5_PRE_REGISTERED_GATE.md (committed before this module).
+// Unit contract: tests/chaosBotV4JudgeShapeValidator.test.js.
+
+import { extractJson } from './extractJson.mjs';
+
+// The SYS_DOCTOR_JUDGE contract is satisfied iff there is a boolean
+// app_answer_correct verdict. Everything else (null/extract-fail,
+// missing key, string "true", number 1) is a B5 shape failure.
+export function validateJudgeShape(obj) {
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) {
+    return { ok: false, reason: 'not-an-object' };
+  }
+  if (typeof obj.app_answer_correct !== 'boolean') {
+    return { ok: false, reason: 'app_answer_correct-not-boolean' };
+  }
+  return { ok: true, reason: 'ok' };
+}
+
+// One corrective re-ask appended to the original prompt: restate the strict
+// schema and demand JSON-only (directly attacks the prose-overflow
+// truncation sub-cause without speculating which sub-cause it was). Gated on
+// validator detection -> validator-before-prompt, NOT a prompt-only tweak.
+function correctivePrompt(userPrompt, badText) {
+  return `${userPrompt}
+
+[RETRY] Your previous response did not contain a valid JSON verdict.
+Respond with ONLY this JSON object on a single line — no prose, no markdown, no code fence:
+{"app_answer_correct":true|false,"confidence":0..100,"issue":"<=300 chars or null","correct_letter_if_app_wrong":"A"|"B"|"C"|"D"|null}
+Your previous (rejected) output started: ${String(badText || '').slice(0, 120)}`;
+}
+
+// Drop-in replacement for the bare
+//   `judgeResp ? (extractJson(judgeResp.text) || {}) : {}`
+// at chaos-doctor-bot-v4.mjs:560. `callJudge` is injected (= callClaude in
+// production) so this is unit-testable with a stub — no API, no playwright.
+// Returns the validated judge object, or `{}` when no boolean verdict could
+// be obtained after exactly one corrective retry (cap=1).
+export async function judgeWithShapeRetry({
+  system,
+  userPrompt,
+  maxTokens = 400,
+  callJudge,
+  log,
+  nowIso,
+}) {
+  const stamp =
+    typeof nowIso === 'function' ? nowIso : () => new Date().toISOString();
+
+  let resp;
+  try {
+    resp = await callJudge(system, userPrompt, { maxTokens });
+  } catch (e) {
+    // A throw means callJudge's own (network) retries already failed — an
+    // API problem, not a shape problem. Preserve pre-audit-5 behavior:
+    // log ai-error, NO shape retry, empty verdict.
+    log.bugs.push({
+      at: stamp(), type: 'ai-error', context: 'judge', message: e.message,
+    });
+    return {};
+  }
+
+  let obj = extractJson(resp.text);
+  if (validateJudgeShape(obj).ok) return obj;
+
+  // Exactly ONE corrective retry (cap=1 — feedback_validator_before_prompt:
+  // beyond 1 you are masking a prompt problem, not fixing shape adherence).
+  let resp2;
+  try {
+    resp2 = await callJudge(
+      system, correctivePrompt(userPrompt, resp.text), { maxTokens },
+    );
+  } catch (e) {
+    log.bugs.push({
+      at: stamp(), type: 'ai-error', context: 'judge', message: e.message,
+    });
+    return {};
+  }
+
+  const obj2 = extractJson(resp2.text);
+  if (validateJudgeShape(obj2).ok) return obj2;
+
+  // Still no boolean verdict. Close the silent-failure gap: emit a typed
+  // parse-error mirroring the pick channel (chaos-doctor-bot-v4.mjs:462) so
+  // B5 is observable post-run instead of vanishing into `{}`.
+  log.bugs.push({
+    at: stamp(),
+    type: 'ai-parse-error',
+    context: 'judge',
+    text: String(resp2.text || '').slice(0, 200),
+  });
+  return {};
+}

--- a/tests/chaosBotV4JudgeShapeValidator.test.js
+++ b/tests/chaosBotV4JudgeShapeValidator.test.js
@@ -172,3 +172,27 @@ describe('P2 — judgeWithShapeRetry wiring (cap=1, injected stub)', () => {
     expect(log.bugs.length).toBe(0);
   });
 });
+
+// Load-bearing RED pin: the P1 fixture proves the detector RED on the
+// failure SHAPE FAMILY (truncation/prose/string-bool/missing-key). This
+// block additionally pins it RED on the *literal observed* B5 input —
+// proven, not assumed — without perturbing the pre-registered 6/2 fixture.
+// Audit-3 `b5_rows_dump.json`: ALL 22 B5 rows had EXACTLY the post-explain-
+// back-fill object `{confidence, explanation_sound}` (the judge itself
+// contributed nothing). The PRODUCTION decision input at the replaced
+// chaos-doctor-bot-v4.mjs:560 is `extractJson(rawJudgeText)` -> null (the
+// judge text was unparseable). Both must be RED or the detector misses the
+// real defect, not just its cousins.
+describe('literal observed B5 input — RED pin (not just synthetic cousins)', () => {
+  it('(A) production input: unparseable judge text -> extractJson null -> ok:false', () => {
+    expect(extractJson('{"app_answer_correct":tr')).toBe(null); // truncated
+    expect(extractJson('Yes, the app answer is correct per Hazzard 8e.')).toBe(null); // prose-only
+    expect(validateJudgeShape(null).ok).toBe(false);
+  });
+
+  it('(B) literal 22x-observed ledger artifact {confidence, explanation_sound} -> ok:false', () => {
+    expect(validateJudgeShape({ confidence: 97, explanation_sound: false }).ok).toBe(false);
+    // key-order independent (the 22 rows appeared in both serializations)
+    expect(validateJudgeShape({ explanation_sound: false, confidence: 90 }).ok).toBe(false);
+  });
+});

--- a/tests/chaosBotV4JudgeShapeValidator.test.js
+++ b/tests/chaosBotV4JudgeShapeValidator.test.js
@@ -1,0 +1,174 @@
+// Audit-5 (2026-05-17) — B5 judge JSON-shape-failure guard.
+//
+// WHAT THIS PINS
+// --------------
+// Audit-3 produced 22/86 `disagrees:true` rows where `judge.app_answer_correct`
+// was non-boolean. Root cause (evidence, not hypothesis): for all 22,
+// `extractJson(judgeResp.text)` returned null at chaos-doctor-bot-v4.mjs:560,
+// `|| {}` silently substituted `{}`, and the judge channel had NO parse-error
+// log + NO corrective retry (the pick channel logs this at :462). 0 thrown
+// judge errors; explain on the same Q succeeded 22/22 -> the failure is
+// judge-call-specific, not an API outage. See
+// docs/AUDIT5_PRE_REGISTERED_GATE.md (the gate, committed BEFORE this test).
+//
+// The audit-3 ledger keeps only the post-extract judge OBJECT, not the raw
+// failing TEXT, so the literal 22 strings are unrecoverable. This guard
+// replays the failure SHAPES via tests/fixtures/judgeShapeFailures.json
+// (git-tracked deterministic-replay corpus) + an injected `callJudge` stub
+// (no API, no playwright).
+//
+// THE THREE PRE-REGISTERED PREDICATES (literal targets — do not loosen)
+//   P1 detection      : fixture splits exactly 6 nonconforming / 2 conforming.
+//   P2 retry wiring   : cap=1; {conforming-stub -> 0/22 residual, 0 logs} |
+//                        {nonconforming-stub -> 22/22 stays-{}, 22 typed
+//                        ai-parse-error logs} | {throw -> 0 shape-retry,
+//                        1 ai-error}; callJudge invoked exactly 2x in BOTH
+//                        shape branches (symmetric; never 3 — shape-cap=1 is
+//                        layered ABOVE callClaude's orthogonal network retry).
+//   P3 regression     : enforced by the 3 baseline suites + the carried-
+//                        forward c_accept-AWARE oracle (run in the gate doc),
+//                        not here.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { extractJson } from '../scripts/lib/extractJson.mjs';
+import {
+  validateJudgeShape,
+  judgeWithShapeRetry,
+} from '../scripts/lib/judgeShapeValidator.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIX = JSON.parse(
+  readFileSync(join(HERE, 'fixtures/judgeShapeFailures.json'), 'utf8'),
+);
+
+// raw model-output texts for the stub (NONCONF -> extractJson null).
+const NONCONF = '{"app_answer_correct":tr';
+const CONF =
+  '{"app_answer_correct":false,"confidence":80,"issue":null,"correct_letter_if_app_wrong":"C"}';
+
+// callClaude-shaped stub: returns queued raw texts; records every call.
+function makeStub(queue) {
+  let i = 0;
+  const calls = [];
+  const fn = async (system, userPrompt, opts) => {
+    calls.push({ system, userPrompt, opts });
+    const r = queue[Math.min(i, queue.length - 1)];
+    i += 1;
+    if (r instanceof Error) throw r;
+    return { text: r, inputTokens: 1, outputTokens: 1 };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+describe('P1 — validateJudgeShape detection', () => {
+  for (const s of FIX.samples) {
+    it(`${s.name} -> ok:${s.expect_ok}`, () => {
+      expect(validateJudgeShape(extractJson(s.raw)).ok).toBe(s.expect_ok);
+    });
+  }
+
+  it('fixture splits exactly 6 nonconforming / 2 conforming (P1 target)', () => {
+    const oks = FIX.samples.map((s) => validateJudgeShape(extractJson(s.raw)).ok);
+    expect(oks.filter((x) => x === true).length).toBe(2);
+    expect(oks.filter((x) => x === false).length).toBe(6);
+  });
+
+  it('only a boolean app_answer_correct is ok', () => {
+    expect(validateJudgeShape(null).ok).toBe(false);
+    expect(validateJudgeShape(undefined).ok).toBe(false);
+    expect(validateJudgeShape('x').ok).toBe(false);
+    expect(validateJudgeShape({}).ok).toBe(false);
+    expect(validateJudgeShape({ app_answer_correct: 1 }).ok).toBe(false);
+    expect(validateJudgeShape({ app_answer_correct: 'true' }).ok).toBe(false);
+    expect(validateJudgeShape({ app_answer_correct: true }).ok).toBe(true);
+    expect(validateJudgeShape({ app_answer_correct: false }).ok).toBe(true);
+  });
+});
+
+describe('P2 — judgeWithShapeRetry wiring (cap=1, injected stub)', () => {
+  it('conforming retry: 0/22 residual, exactly 2 calls/item, 0 parse-error logs', async () => {
+    let residual = 0;
+    let totalCalls = 0;
+    const log = { bugs: [] };
+    for (let k = 0; k < 22; k++) {
+      const stub = makeStub([NONCONF, CONF]);
+      const j = await judgeWithShapeRetry({
+        system: 'S', userPrompt: 'U', maxTokens: 400,
+        callJudge: stub, log, nowIso: () => 'T',
+      });
+      if (typeof j.app_answer_correct !== 'boolean') residual += 1;
+      expect(stub.calls.length).toBe(2); // 1 original + 1 corrective (cap=1)
+      totalCalls += stub.calls.length;
+    }
+    expect(residual).toBe(0);
+    expect(totalCalls).toBe(44);
+    expect(
+      log.bugs.filter((b) => b.type === 'ai-parse-error' && b.context === 'judge').length,
+    ).toBe(0);
+  });
+
+  it('nonconforming retry: 22/22 stays {}, exactly 2 calls/item (never 3), 22 typed logs', async () => {
+    let residual = 0;
+    const log = { bugs: [] };
+    for (let k = 0; k < 22; k++) {
+      // 3rd queued response WOULD conform — cap=1 must stop at 2 and never reach it.
+      const stub = makeStub([NONCONF, NONCONF, CONF]);
+      const j = await judgeWithShapeRetry({
+        system: 'S', userPrompt: 'U', maxTokens: 400,
+        callJudge: stub, log, nowIso: () => 'T',
+      });
+      if (typeof j.app_answer_correct !== 'boolean') residual += 1;
+      expect(Object.keys(j).length).toBe(0); // judgeJson stays {}
+      expect(stub.calls.length).toBe(2); // cap=1: no 2nd corrective retry
+    }
+    expect(residual).toBe(22);
+    const pe = log.bugs.filter(
+      (b) => b.type === 'ai-parse-error' && b.context === 'judge',
+    );
+    expect(pe.length).toBe(22); // silent-failure gap closed (mirrors pick :462)
+    expect(pe[0]).toHaveProperty('text');
+    expect(pe[0]).toHaveProperty('at');
+  });
+
+  it('hard throw: no shape retry, 1 ai-error, returns {}', async () => {
+    const log = { bugs: [] };
+    const stub = makeStub([new Error('Claude API 529: overloaded')]);
+    const j = await judgeWithShapeRetry({
+      system: 'S', userPrompt: 'U', maxTokens: 400,
+      callJudge: stub, log, nowIso: () => 'T',
+    });
+    expect(Object.keys(j).length).toBe(0);
+    expect(stub.calls.length).toBe(1); // a throw is not a shape problem
+    expect(
+      log.bugs.filter((b) => b.type === 'ai-error' && b.context === 'judge').length,
+    ).toBe(1);
+    expect(log.bugs.filter((b) => b.type === 'ai-parse-error').length).toBe(0);
+  });
+
+  it('corrective retry is a validator-gated RE-ASK (not prompt-only)', async () => {
+    const log = { bugs: [] };
+    const stub = makeStub([NONCONF, CONF]);
+    await judgeWithShapeRetry({
+      system: 'S', userPrompt: 'ORIGINAL_PROMPT', maxTokens: 400,
+      callJudge: stub, log, nowIso: () => 'T',
+    });
+    expect(stub.calls[0].userPrompt).toBe('ORIGINAL_PROMPT');
+    expect(stub.calls[1].userPrompt).not.toBe('ORIGINAL_PROMPT');
+    expect(stub.calls[1].userPrompt).toContain('app_answer_correct'); // schema restated
+  });
+
+  it('conforming on FIRST call fires no retry (1 call, 0 logs)', async () => {
+    const log = { bugs: [] };
+    const stub = makeStub([CONF]);
+    const j = await judgeWithShapeRetry({
+      system: 'S', userPrompt: 'U', maxTokens: 400,
+      callJudge: stub, log, nowIso: () => 'T',
+    });
+    expect(typeof j.app_answer_correct).toBe('boolean');
+    expect(stub.calls.length).toBe(1);
+    expect(log.bugs.length).toBe(0);
+  });
+});

--- a/tests/fixtures/judgeShapeFailures.json
+++ b/tests/fixtures/judgeShapeFailures.json
@@ -1,0 +1,53 @@
+{
+  "_doc": "Audit-5 B5 deterministic-replay corpus. The audit-3 ledger preserves only the post-extractJson judge OBJECT, not the raw failing judge TEXT, so the literal 22 B5 strings are unrecoverable. This git-tracked fixture reproduces the failure SHAPES instead (the brief explicitly permits 'or a captured fixture'). Each sample is piped through extractJson() then validateJudgeShape(); expect_ok is the required {ok}. P1 target: exactly 6 nonconforming (ok:false) + 2 conforming (ok:true).",
+  "samples": [
+    {
+      "name": "bare_valid_json",
+      "expect_ok": true,
+      "note": "the contract shape — boolean app_answer_correct",
+      "raw": "{\"app_answer_correct\":true,\"confidence\":90,\"issue\":null,\"correct_letter_if_app_wrong\":null}"
+    },
+    {
+      "name": "fenced_valid_json",
+      "expect_ok": true,
+      "note": "extractJson already strips ```json fences (do not re-handle)",
+      "raw": "```json\n{\"app_answer_correct\":false,\"confidence\":85,\"issue\":\"App key contradicts Hazzard 8e Ch 43\",\"correct_letter_if_app_wrong\":\"B\"}\n```"
+    },
+    {
+      "name": "truncated_json",
+      "expect_ok": false,
+      "note": "maxTokens cut mid-token — brace-walk never closes -> extractJson null",
+      "raw": "{\"app_answer_correct\":tr"
+    },
+    {
+      "name": "prose_then_truncated",
+      "expect_ok": false,
+      "note": "model wrote reasoning prose first, JSON cut before close",
+      "raw": "The app's claimed answer is medically correct per board-level evidence. {\"app_answer_correct\":"
+    },
+    {
+      "name": "prose_only_no_json",
+      "expect_ok": false,
+      "note": "no '{' at all -> extractJson null",
+      "raw": "Yes — the app's claimed answer is correct. This aligns with Hazzard 8e and GRS8 guidance on the management of frailty in the very old."
+    },
+    {
+      "name": "fenced_then_truncated",
+      "expect_ok": false,
+      "note": "leading fence stripped, unterminated string inside -> extractJson null",
+      "raw": "```json\n{\"app_answer_correct\":true,\"confidence\":90,\"issue\":\"The explanation correctly identifies that orthostatic hypotension in this patient is most likely "
+    },
+    {
+      "name": "json_string_bool",
+      "expect_ok": false,
+      "note": "parses fine BUT app_answer_correct is the STRING \"true\", not a boolean",
+      "raw": "{\"app_answer_correct\":\"true\",\"confidence\":90,\"issue\":null,\"correct_letter_if_app_wrong\":null}"
+    },
+    {
+      "name": "json_missing_aac",
+      "expect_ok": false,
+      "note": "valid JSON object but the verdict key is absent (the literal B5 empty-extract analogue once explain back-fills confidence)",
+      "raw": "{\"confidence\":90,\"issue\":\"Deferred to textbook; <80% confident the app is wrong\",\"correct_letter_if_app_wrong\":null}"
+    }
+  ]
+}


### PR DESCRIPTION
## What

Closes audit-5 B5: the 22/86 audit-3 `disagrees:true` rows where
`judge.app_answer_correct` was non-boolean — a `SYS_DOCTOR_JUDGE`
structured-output discipline failure (≈26% of disagreement rows).

## Root cause (Phase 1 — evidence, not hypothesis)

`scripts/chaos-doctor-bot-v4.mjs:560` (`extractJson(judgeResp.text) || {}`):
0 thrown judge errors run-wide; explain on the same Q succeeded 22/22 (API
healthy → judge-call-specific); `extractJson` returned null → `|| {}`
silently → `app_answer_correct` undefined. Judge channel had no parse-error
log (pick channel logs at `:462`) and no retry. Cross-tab independently
re-derived from the raw ledger (no subtraction): 61/3/22, Σ=86 — matches
the brief and audit-4 doc.

## Fix (validator-before-prompt — pre-decided class)

- `scripts/lib/judgeShapeValidator.mjs`: `validateJudgeShape` (ok iff
  `typeof app_answer_correct==='boolean'`) + `judgeWithShapeRetry` —
  post-extract shape check + **exactly one** corrective re-ask (cap=1),
  composed THROUGH the existing `extractJson.mjs`; closes the silent-gap
  with a typed `ai-parse-error context:'judge'` mirroring pick `:462`.
- Bot `:560` bare `extractJson||{}` → injectable `judgeWithShapeRetry`
  (callClaude injected → unit-testable; shape-cap=1 layered above
  callClaude's orthogonal network retry).

## Gate (pre-registered before code — `docs/AUDIT5_PRE_REGISTERED_GATE.md`)

All 3 predicates MET, TRIP NOT met:
- **P1** fixture splits exactly 6 nonconforming / 2 conforming.
- **P2** cap=1 symmetric: conf-stub 0/22 + 0 logs + 2 calls; nonconf-stub
  22/22-{} + 22 typed logs + 2 calls (never 3); throw → 1 ai-error + 0 retry.
- **P3** 3 baseline suites green; carried-forward c_accept-AWARE oracle
  0/0/0 over the audit-3 ledger (== audit-4 Regression B);
  `npm run verify` 72 files / 1396 + 7 skipped; **trinity untouched at
  v10.64.130** (scripts/tests/docs only — no bump).

15-test guard `tests/chaosBotV4JudgeShapeValidator.test.js` + git-tracked
fixture. TDD: test written + watched fail (module-missing RED) before the
module. Clean B4 (37 Qs) handed off untouched (separate decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)