### PR TITLE
docs(CLAUDE.md): correct falsified solo-lane direct-push instruction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -667,14 +667,20 @@ layer; v10.64.46 regenerated 75 drifted Qs after detector v3.
 
 ### Two-Claude race
 
-The user runs Claude Code (terminal) and claude.ai (web) in parallel. Both
-lanes can push to main. Lane discipline:
+The user runs Claude Code (terminal) and claude.ai (web) in parallel.
+**Neither lane pushes to `main` directly** — the global `~/.claude/CLAUDE.md`
+"never push main directly — always PR" rule is hard-enforced by the
+auto-mode permission classifier and overrides any repo-level solo-lane
+carve-out. Lane discipline:
 
 - **Both lanes active**: branch first — `claude/web-<slug>` for web Claude,
   `claude/term-<slug>` for terminal Claude — and PR to main. Avoid touching
   the other lane's known files mid-session.
-- **Solo lane**: direct push to main is the release path (CI gates, Pages
-  deploys ~60s). No PR ceremony needed.
+- **Solo lane**: still branch `claude/term-<slug>` + PR (no extra two-Claude
+  coordination ceremony, but the PR is mandatory — a `git push origin main`
+  is denied by the classifier regardless of a correct solo-lane
+  self-justification). CI gates, then ask the user to merge. Geri audit-5
+  (2026-05-17) hit this: direct push denied → resolved via PR #227.
 - **Session start**: `git log --all --since="1 day ago" --oneline` to detect
   parallel work before editing shared surfaces (`questions.json`, `sw.js`,
   version files, `shared/fsrs.js`, `harrison_chapters.json`).
@@ -836,7 +842,7 @@ Reach **1,000+ tests** with coverage of every data file, every engine function, 
 
 - `main` — production branch, auto-deployed to GitHub Pages
 - Feature branches: `claude/web-<slug>` (web Claude), `claude/term-<slug>` (terminal Claude), `claude/<description>-<id>` (other)
-- Solo lane: direct push to `main` is the release path (CI gates, Pages deploys ~60s)
+- Solo lane: branch `claude/term-<slug>` + PR (the global always-PR guardrail overrides repo-level solo carve-outs — the auto-mode classifier denies direct `main` pushes; see "Two-Claude race" under Known Traps)
 - Both lanes active: branch first + PR — see "Two-Claude race" under Known Traps
 - All PRs target `main`
 - CI must pass before merging


### PR DESCRIPTION
## Why

Follow-up to PR #227 (audit-5 B5). STEP 0 of every audit-N brief derives a
"solo lane → direct push to `main`" release path from this file's
**Branch Policy** + **Two-Claude race** sections. That instruction is
**falsified**: the global `~/.claude/CLAUDE.md` "never push main directly
— always PR" rule is hard-enforced by the auto-mode permission classifier
and structurally overrides any repo-level solo-lane carve-out. Geri
audit-5 (2026-05-17) hit exactly this — a correct solo-lane
`git push origin main` was denied; resolved via PR #227.

The memory `feedback_global_always_pr_overrides_repo_solo_push` mitigated
the *surprise* for future sessions; this edit removes the falsified
*instruction at source* so STEP 0 stops asserting a denied release path
every session (the bandage vs the fix).

## What

- **Two-Claude race**: solo-lane bullet → "branch `claude/term-<slug>`
  + PR (PR mandatory; direct push denied by the classifier); CI gates,
  then ask the user to merge". Lead-in "Both lanes can push to main"
  (now contradicted by the corrected bullets) → "Neither lane pushes to
  `main` directly" for internal consistency.
- **Branch Policy**: solo-lane bullet → same correction.

Docs-only; no code/test/version change; trinity untouched. This PR's own
existence (branch+PR for a one-line policy fix) is the corrected rule
applied to itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)