### PR TITLE
feat(audit-6 opt-0): judge parse-failure instrument + corrected bucketing rule

### DIFF
--- a/scripts/bucketJudgeParseFailures.mjs
+++ b/scripts/bucketJudgeParseFailures.mjs
@@ -45,13 +45,32 @@ for (const f of files) {
 const summary = summarizeLedger(rows);
 console.log(JSON.stringify(summary, null, 2));
 
-// One-line operator verdict so the routing decision is unambiguous.
+// Operator verdict. The DECISION INPUT is the UNDERLYING population
+// (every first-attempt failure) — NOT the residual. The residual +
+// reconciliation are printed as diagnostics, never as the routing basis.
 const c = summary.counts;
+const rc = summary.residual_counts;
+const rec = summary.reconciliation;
 console.log(
-  `\n# verdict: ${summary.total} judge parse-failures | ` +
-  `truncation(a)=${c.truncation} -> Geri max_tokens, ZERO Toranot | ` +
-  `genuine_prose(b)=${c.genuine_prose} -> ONLY this is a Toranot conversation | ` +
+  `\n# UNDERLYING (decision input — ${summary.total} first-attempt judge failures):\n` +
+  `  truncation(a)=${c.truncation} -> Geri max_tokens, ZERO Toranot | ` +
+  `genuine_prose(b)=${c.genuine_prose} -> the ONLY Toranot conversation | ` +
   `wrong_shape=${c.wrong_shape} -> Geri prompt/schema | ` +
   `ambiguous=${c.ambiguous} -> eyeball THIS bucket's raw text | ` +
   `empty=${c.empty} unknown=${c.unknown}`,
 );
+console.log(
+  `# residual (diagnostic — recovered:false, ≡ retry's class-dependent miss): ` +
+  `trunc=${rc.truncation} prose=${rc.genuine_prose} wrong=${rc.wrong_shape} ` +
+  `ambig=${rc.ambiguous} empty=${rc.empty} unk=${rc.unknown}`,
+);
+console.log(
+  `# reconciliation: firstfail(recovered:false)=${rec.firstfail_unrecovered} ` +
+  `vs ai-parse-error=${rec.ai_parse_error} -> ${rec.match ? 'OK' : 'MISMATCH (instrument drift / pre-instrument ledger)'}`,
+);
+if (summary.total === 0) {
+  console.log(
+    '# NOTE: 0 underlying rows. A pre-instrument ledger cannot answer the ' +
+    'audit-6 question — run a fresh bounded long-chaos-run.sh; there is no shortcut.',
+  );
+}

--- a/scripts/bucketJudgeParseFailures.mjs
+++ b/scripts/bucketJudgeParseFailures.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// Audit-6 Option-0 (2026-05-18) — CLI: bucket judge parse-failures from a
+// chaos-doctor-bot-v4 JSONL ledger into the audit-6 ternary.
+//
+// Usage:
+//   node scripts/bucketJudgeParseFailures.mjs <ledger.jsonl> [more.jsonl ...]
+//
+// Reads bot bug-log JSONL (one JSON object per line — the bot's log.bugs
+// entries), filters ai-parse-error/context=judge, applies the rule from
+// scripts/lib/bucketParseFailures.mjs (single source of truth, unit-pinned
+// by tests/chaosBotV4BucketRule.test.js), prints a JSON summary.
+//
+// This is the "bucket" half of the audit-6 "run one bounded sample,
+// bucket" step — it is read-only and FREE (operates on whatever ledger
+// already exists). The bounded SAMPLE itself (paid judge calls) is a
+// user-triggered op: `scripts/long-chaos-run.sh` (proxy mode), then point
+// this at chaos-reports/v4/<run>/medical_findings_ai_v4.jsonl or the
+// bug-log it writes. Mirror of the audit-5 oracle's print-JSON style.
+
+import { readFileSync } from 'node:fs';
+import { summarizeLedger } from './lib/bucketParseFailures.mjs';
+
+const files = process.argv.slice(2);
+if (files.length === 0) {
+  console.error('usage: node scripts/bucketJudgeParseFailures.mjs <ledger.jsonl> [...]');
+  process.exit(2);
+}
+
+const rows = [];
+for (const f of files) {
+  let raw;
+  try {
+    raw = readFileSync(f, 'utf8');
+  } catch (e) {
+    console.error(`cannot read ${f}: ${e.message}`);
+    process.exit(2);
+  }
+  for (const line of raw.split(/\r?\n/)) {
+    const s = line.trim();
+    if (!s) continue;
+    try { rows.push(JSON.parse(s)); } catch { /* skip non-JSON lines */ }
+  }
+}
+
+const summary = summarizeLedger(rows);
+console.log(JSON.stringify(summary, null, 2));
+
+// One-line operator verdict so the routing decision is unambiguous.
+const c = summary.counts;
+console.log(
+  `\n# verdict: ${summary.total} judge parse-failures | ` +
+  `truncation(a)=${c.truncation} -> Geri max_tokens, ZERO Toranot | ` +
+  `genuine_prose(b)=${c.genuine_prose} -> ONLY this is a Toranot conversation | ` +
+  `wrong_shape=${c.wrong_shape} -> Geri prompt/schema | ` +
+  `ambiguous=${c.ambiguous} -> eyeball THIS bucket's raw text | ` +
+  `empty=${c.empty} unknown=${c.unknown}`,
+);

--- a/scripts/chaos-doctor-bot-v4.mjs
+++ b/scripts/chaos-doctor-bot-v4.mjs
@@ -208,7 +208,10 @@ async function callClaude(systemPrompt, userPrompt, { maxTokens = 400, retries =
       COST.totalCalls += 1;
       COST.totalInTokens += inT;
       COST.totalOutTokens += outT;
-      return { text, inputTokens: inT, outputTokens: outT };
+      // Audit-6 Option-0: surface stop_reason so judge parse-failures can
+      // be bucketed (max_tokens ⟺ truncation; the single direct length-cut
+      // signal). Null when upstream omits it (proxy/stream tap).
+      return { text, inputTokens: inT, outputTokens: outT, stopReason: data.stop_reason || null };
     } catch (e) {
       lastErr = e;
       await sleep((attempt + 1) * 800);

--- a/scripts/lib/bucketParseFailures.mjs
+++ b/scripts/lib/bucketParseFailures.mjs
@@ -1,0 +1,80 @@
+// Audit-6 Option-0 (2026-05-18) — judge parse-failure bucketing RULE.
+//
+// THE rule, in one place (single source of truth; pinned by
+// tests/chaosBotV4BucketRule.test.js). It was re-derived/corrected
+// TWICE in review — the correction that matters:
+//
+//   TRUNCATION is a property of stop_reason, FULL STOP.
+//   first_stop_reason === 'max_tokens'  <=> length-cut, for ANY branch.
+//   The extractJson null-branch is NEVER a standalone truncation signal
+//   (a model can finish naturally — end_turn — and still emit an
+//   unmatched '{' => 'unbalanced'; that is malformed/prose, not a cut,
+//   and a max_tokens bump won't touch it). Counting (end_turn,
+//   unbalanced) as truncation inflates the exact number that decides
+//   whether the cross-repo Toranot proxy gets touched.
+//
+// So: bucket on stop_reason first; branch only refines the
+// NOT-max_tokens rows. Only 'genuine_prose' is a structured-output /
+// Toranot conversation; 'truncation' and 'wrong_shape' are cheap
+// zero-Toranot Geri-side fixes; 'ambiguous' (the two non-no_brace
+// not-max_tokens cells) needs the bounded-sample raw-text eyeball.
+
+export const EYEBALL_CATEGORY = 'ambiguous';
+
+export const FIX_ROUTING = {
+  truncation:
+    "(a) length-cut. Fix: Geri-side judge max_tokens bump / verdict-schema trim. ZERO Toranot.",
+  genuine_prose:
+    '(b) model emitted prose, no JSON. The ONLY structured-output / Toranot conversation (then option 2 only — option 3 strictly dominated).',
+  wrong_shape:
+    'parseable JSON but failed validateJudgeShape (string-bool / missing-key). Fix: Geri-side prompt/schema. ZERO Toranot.',
+  ambiguous:
+    'malformed-JSON vs prose-with-incidental-braces — undecidable from (stop_reason,branch) alone. Resolve by bounded-sample raw-text eyeball of THIS bucket only.',
+  empty:
+    'no text at all — degenerate / throw-adjacent. Inspect the callClaude path, not the judge contract.',
+  unknown:
+    'pre-instrument or unrecognized row — predates (first_stop_reason, first_branch); not bucketable.',
+};
+
+// Pure. Input: one ai-parse-error/context=judge log entry (or just its
+// {first_stop_reason, first_branch}). Output: a fix-routing category.
+export function bucketJudgeFailure(entry) {
+  const sr = entry && entry.first_stop_reason;
+  const br = entry && entry.first_branch;
+  if (sr === 'max_tokens') return 'truncation'; // any branch — stop_reason is the cut signal
+  switch (br) {
+    case 'no_brace': return 'genuine_prose';
+    case 'parsed': return 'wrong_shape';
+    case 'unbalanced': return 'ambiguous';
+    case 'parse_threw': return 'ambiguous';
+    case 'empty': return 'empty';
+    default: return 'unknown';
+  }
+}
+
+const ZERO = () => ({
+  truncation: 0, genuine_prose: 0, wrong_shape: 0,
+  ambiguous: 0, empty: 0, unknown: 0,
+});
+
+// rows: array of parsed JSONL ledger entries (bot's log.bugs). Filters to
+// the judge parse-failure channel and applies the rule.
+export function summarizeLedger(rows) {
+  const counts = ZERO();
+  const grid = {}; // `${stop_reason}|${branch}` -> n (operator convenience)
+  let total = 0;
+  for (const r of Array.isArray(rows) ? rows : []) {
+    if (!r || r.type !== 'ai-parse-error' || r.context !== 'judge') continue;
+    total += 1;
+    counts[bucketJudgeFailure(r)] += 1;
+    const key = `${r.first_stop_reason ?? 'null'}|${r.first_branch ?? 'null'}`;
+    grid[key] = (grid[key] || 0) + 1;
+  }
+  return {
+    total,
+    counts,
+    grid,
+    eyeball_total: counts[EYEBALL_CATEGORY],
+    fix_routing: FIX_ROUTING,
+  };
+}

--- a/scripts/lib/bucketParseFailures.mjs
+++ b/scripts/lib/bucketParseFailures.mjs
@@ -57,24 +57,50 @@ const ZERO = () => ({
   ambiguous: 0, empty: 0, unknown: 0,
 });
 
-// rows: array of parsed JSONL ledger entries (bot's log.bugs). Filters to
-// the judge parse-failure channel and applies the rule.
+// rows: array of parsed JSONL ledger entries (bot's log.bugs).
+//
+// PRIMARY population = `judge-shape-firstfail`/judge rows = the
+// UN-CONDITIONED first-attempt failures = exactly the audit-6 target
+// (~26% underlying), what the decision tree consumes. The audit-5
+// `ai-parse-error` log fires only on DOUBLE failure (~7% residual,
+// retry-recovery is class-dependent → a biased estimator of the
+// underlying composition); we do NOT bucket off it for the primary.
+// `residual_counts` = the recovered:false subset (the residual view,
+// quantifies the retry's class-dependent recovery). `reconciliation`
+// cross-checks recovered:false against the independent ai-parse-error
+// count — a mismatch means the instrument drifted.
 export function summarizeLedger(rows) {
-  const counts = ZERO();
-  const grid = {}; // `${stop_reason}|${branch}` -> n (operator convenience)
+  const counts = ZERO();          // underlying — ALL first-attempt failures
+  const residual_counts = ZERO(); // recovered:false subset (≡ double-failures)
+  const grid = {};                // `${stop_reason}|${branch}` -> n (underlying)
   let total = 0;
+  let firstfail_unrecovered = 0;
+  let ai_parse_error = 0;
   for (const r of Array.isArray(rows) ? rows : []) {
-    if (!r || r.type !== 'ai-parse-error' || r.context !== 'judge') continue;
+    if (!r || r.context !== 'judge') continue;
+    if (r.type === 'ai-parse-error') { ai_parse_error += 1; continue; }
+    if (r.type !== 'judge-shape-firstfail') continue;
     total += 1;
-    counts[bucketJudgeFailure(r)] += 1;
+    const cat = bucketJudgeFailure(r);
+    counts[cat] += 1;
     const key = `${r.first_stop_reason ?? 'null'}|${r.first_branch ?? 'null'}`;
     grid[key] = (grid[key] || 0) + 1;
+    if (r.recovered === false) {
+      residual_counts[cat] += 1;
+      firstfail_unrecovered += 1;
+    }
   }
   return {
     total,
     counts,
+    residual_counts,
     grid,
     eyeball_total: counts[EYEBALL_CATEGORY],
+    reconciliation: {
+      firstfail_unrecovered,
+      ai_parse_error,
+      match: firstfail_unrecovered === ai_parse_error,
+    },
     fix_routing: FIX_ROUTING,
   };
 }

--- a/scripts/lib/extractJson.mjs
+++ b/scripts/lib/extractJson.mjs
@@ -4,13 +4,31 @@
 // ai-parse-error events in v3 workers 1, 8, 10).
 //
 // Standalone module so unit tests don't pull in the bot's playwright dep.
+//
+// Audit-6 Option-0 (2026-05-18): the scan is factored into `_scan`, which
+// returns BOTH the parsed value AND which branch produced it. `extractJson`
+// is preserved as a thin `_scan(t).value` wrapper — its return value is
+// byte-identical for every input (the audit-5 floor; do not change it).
+// `classifyExtractFailure` exposes `_scan(t).branch` so the next bounded
+// chaos run can bucket judge JSON-parse failures into the ternary the
+// audit-6 STEP-0 doc requires — WITHOUT a duplicated parser (DRY /
+// grep-existing-utility) and WITHOUT raw-text retention. Branches:
+//   'parsed'      extractJson returned a value (whole-string OR recovered
+//                 candidate parsed) — not a failure
+//   'empty'       no text at all
+//   'no_brace'    text present, no '{'              -> (b) genuine prose
+//   'unbalanced'  '{' opened, never balanced/closed -> (a) truncated
+//   'parse_threw' balanced candidate, JSON.parse threw -> (c) malformed-
+//                 but-complete (AND the ambiguous bucket: prose with an
+//                 incidental balanced '{...}' also lands here — resolved
+//                 by the bounded-sample raw-text eyeball, audit-6 doc)
 
-export function extractJson(text) {
-  if (!text) return null;
+function _scan(text) {
+  if (!text) return { value: null, branch: 'empty' };
   let s = String(text).replace(/^```(?:json)?\s*/i, '').replace(/```\s*$/i, '').trim();
-  try { return JSON.parse(s); } catch (_) { /* fall */ }
+  try { return { value: JSON.parse(s), branch: 'parsed' }; } catch (_) { /* fall */ }
   const start = s.indexOf('{');
-  if (start === -1) return null;
+  if (start === -1) return { value: null, branch: 'no_brace' };
   let depth = 0;
   let inStr = false;
   let escape = false;
@@ -28,9 +46,21 @@ export function extractJson(text) {
       depth--;
       if (depth === 0) {
         const candidate = s.slice(start, i + 1);
-        try { return JSON.parse(candidate); } catch (_) { return null; }
+        try { return { value: JSON.parse(candidate), branch: 'parsed' }; }
+        catch (_) { return { value: null, branch: 'parse_threw' }; }
       }
     }
   }
-  return null;
+  return { value: null, branch: 'unbalanced' };
+}
+
+export function extractJson(text) {
+  return _scan(text).value;
+}
+
+// Audit-6 Option-0 diagnostic. Returns which `_scan` branch fired:
+// 'parsed' | 'empty' | 'no_brace' | 'unbalanced' | 'parse_threw'.
+// Pure, no side effects, zero raw-text retention.
+export function classifyExtractFailure(text) {
+  return _scan(text).branch;
 }

--- a/scripts/lib/judgeShapeValidator.mjs
+++ b/scripts/lib/judgeShapeValidator.mjs
@@ -17,7 +17,7 @@
 // See docs/AUDIT5_PRE_REGISTERED_GATE.md (committed before this module).
 // Unit contract: tests/chaosBotV4JudgeShapeValidator.test.js.
 
-import { extractJson } from './extractJson.mjs';
+import { extractJson, classifyExtractFailure } from './extractJson.mjs';
 
 // The SYS_DOCTOR_JUDGE contract is satisfied iff there is a boolean
 // app_answer_correct verdict. Everything else (null/extract-fail,
@@ -98,11 +98,18 @@ export async function judgeWithShapeRetry({
   // Still no boolean verdict. Close the silent-failure gap: emit a typed
   // parse-error mirroring the pick channel (chaos-doctor-bot-v4.mjs:462) so
   // B5 is observable post-run instead of vanishing into `{}`.
+  // Audit-6 Option-0: bucket on the ORIGINAL failure mode (`resp`, not
+  // the corrective `resp2`). `(first_stop_reason, first_branch)` is the
+  // 2×N grid the next bounded run buckets — truncation keyed off
+  // stop_reason==max_tokens (any branch); branch refines the end_turn
+  // rows only. Zero raw-text retention beyond the audit-5 200-char slice.
   log.bugs.push({
     at: stamp(),
     type: 'ai-parse-error',
     context: 'judge',
     text: String(resp2.text || '').slice(0, 200),
+    first_branch: classifyExtractFailure(resp.text),
+    first_stop_reason: resp.stopReason ?? null,
   });
   return {};
 }

--- a/scripts/lib/judgeShapeValidator.mjs
+++ b/scripts/lib/judgeShapeValidator.mjs
@@ -78,6 +78,19 @@ export async function judgeWithShapeRetry({
   let obj = extractJson(resp.text);
   if (validateJudgeShape(obj).ok) return obj;
 
+  // FIRST ATTEMPT FAILED. Audit-6 Option-0: the target is the UNDERLYING
+  // first-attempt failure composition (~26%), NOT the double-failure
+  // residual (~7%) that the terminal ai-parse-error log below samples.
+  // The corrective retry is a schema-restated re-ask with the SAME
+  // maxTokens budget — its recovery is class-dependent, so conditioning
+  // the (stop_reason, branch) sample on "retry also failed" is a biased
+  // estimator of the population the audit-6 decision tree consumes.
+  // Capture the first-failure signal NOW, unconditionally. `recovered`
+  // (set after the retry resolves) lets the bucketer derive BOTH the
+  // underlying population (all rows) and the residual (recovered:false).
+  const first_branch = classifyExtractFailure(resp.text);
+  const first_stop_reason = resp.stopReason ?? null;
+
   // Exactly ONE corrective retry (cap=1 — feedback_validator_before_prompt:
   // beyond 1 you are masking a prompt problem, not fixing shape adherence).
   let resp2;
@@ -86,6 +99,13 @@ export async function judgeWithShapeRetry({
       system, correctivePrompt(userPrompt, resp.text), { maxTokens },
     );
   } catch (e) {
+    // Retry threw (network/API). The first-attempt failure still occurred
+    // and is part of the measured population — emit it (recovered:false),
+    // then preserve audit-5's ai-error behavior (no shape retry, {}).
+    log.bugs.push({
+      at: stamp(), type: 'judge-shape-firstfail', context: 'judge',
+      first_branch, first_stop_reason, recovered: false,
+    });
     log.bugs.push({
       at: stamp(), type: 'ai-error', context: 'judge', message: e.message,
     });
@@ -93,23 +113,32 @@ export async function judgeWithShapeRetry({
   }
 
   const obj2 = extractJson(resp2.text);
-  if (validateJudgeShape(obj2).ok) return obj2;
+  const recovered = validateJudgeShape(obj2).ok;
 
-  // Still no boolean verdict. Close the silent-failure gap: emit a typed
-  // parse-error mirroring the pick channel (chaos-doctor-bot-v4.mjs:462) so
-  // B5 is observable post-run instead of vanishing into `{}`.
-  // Audit-6 Option-0: bucket on the ORIGINAL failure mode (`resp`, not
-  // the corrective `resp2`). `(first_stop_reason, first_branch)` is the
-  // 2×N grid the next bounded run buckets — truncation keyed off
-  // stop_reason==max_tokens (any branch); branch refines the end_turn
-  // rows only. Zero raw-text retention beyond the audit-5 200-char slice.
+  // Un-conditioned first-attempt-failure telemetry. Fires for EVERY first
+  // failure (the audit-6 ~26% underlying population), recovered or not.
+  // DISTINCT type from ai-parse-error — so audit-5's B5 double-failure
+  // contract and the 15-pin suite are byte-stable. recovered:true rows
+  // are telemetry (the validator+retry worked), NOT defects; downstream
+  // consumers discriminate by `type` (as audit-5 already does).
+  log.bugs.push({
+    at: stamp(), type: 'judge-shape-firstfail', context: 'judge',
+    first_branch, first_stop_reason, recovered,
+  });
+
+  if (recovered) return obj2;
+
+  // Both failed → audit-5 B5 terminal, mirroring the pick channel
+  // (chaos-doctor-bot-v4.mjs:462) so B5 stays observable. Shape
+  // UNCHANGED (text/at preserved); first_* kept for residual-view
+  // continuity. Zero raw-text retention beyond the 200-char slice.
   log.bugs.push({
     at: stamp(),
     type: 'ai-parse-error',
     context: 'judge',
     text: String(resp2.text || '').slice(0, 200),
-    first_branch: classifyExtractFailure(resp.text),
-    first_stop_reason: resp.stopReason ?? null,
+    first_branch,
+    first_stop_reason,
   });
   return {};
 }

--- a/tests/chaosBotV4BucketRule.test.js
+++ b/tests/chaosBotV4BucketRule.test.js
@@ -1,0 +1,119 @@
+// Audit-6 Option-0 (2026-05-18) — judge parse-failure BUCKETING RULE.
+//
+// This is the anti-drift guard. The rule below was re-derived/corrected
+// TWICE in review; pin it executably so a third drift can't happen:
+//
+//   TRUNCATION  == first_stop_reason === 'max_tokens'  (ANY branch).
+//                  The single direct length-cut signal. Fix: Geri-side
+//                  max_tokens bump / verdict-schema trim. ZERO Toranot.
+//   Within NOT-max_tokens (end_turn / null / other — a real adherence
+//   failure, not a length cut), branch refines:
+//     no_brace    -> 'genuine_prose'  (ONLY structured-output/Toranot leaf)
+//     parsed      -> 'wrong_shape'    (string-bool/missing-key -> prompt/schema)
+//     unbalanced  -> 'ambiguous'      (malformed-JSON | prose w/ stray '{')
+//     parse_threw -> 'ambiguous'      (malformed-complete | prose w/ {...})
+//     empty       -> 'empty'          (no text — degenerate/throw-adjacent)
+//
+// branch is NEVER a standalone truncation signal: (end_turn, unbalanced)
+// is NOT truncation — letting it sit in the truncation bucket inflates
+// the exact count that decides whether Toranot gets touched. The
+// bounded-sample raw-text eyeball set is the TWO non-no_brace end_turn
+// cells (both -> 'ambiguous'), NOT parse_threw alone.
+import { describe, it, expect } from 'vitest';
+import {
+  bucketJudgeFailure,
+  summarizeLedger,
+  EYEBALL_CATEGORY,
+} from '../scripts/lib/bucketParseFailures.mjs';
+
+const b = (first_stop_reason, first_branch) =>
+  bucketJudgeFailure({ first_stop_reason, first_branch });
+
+describe('truncation is keyed off stop_reason==max_tokens (ANY branch)', () => {
+  it('max_tokens + any branch -> truncation', () => {
+    for (const br of ['unbalanced', 'no_brace', 'parse_threw', 'parsed', 'empty']) {
+      expect(b('max_tokens', br)).toBe('truncation');
+    }
+  });
+
+  it('(end_turn, unbalanced) is NOT truncation -> ambiguous (the corrected cell)', () => {
+    // The regression the review caught: unbalanced@end_turn is malformed/
+    // prose, not a length-cut. Counting it as truncation inflates the
+    // Toranot-gating number.
+    expect(b('end_turn', 'unbalanced')).toBe('ambiguous');
+    expect(b('end_turn', 'unbalanced')).not.toBe('truncation');
+  });
+
+  it('null / unknown stop_reason is NOT truncation (no cut signal -> do not guess)', () => {
+    expect(b(null, 'unbalanced')).toBe('ambiguous');
+    expect(b(undefined, 'parse_threw')).toBe('ambiguous');
+    expect(b('refusal', 'no_brace')).toBe('genuine_prose');
+    expect(b(null, 'unbalanced')).not.toBe('truncation');
+  });
+});
+
+describe('branch refines the non-max_tokens rows', () => {
+  it('end_turn + no_brace -> genuine_prose (only Toranot leaf)', () => {
+    expect(b('end_turn', 'no_brace')).toBe('genuine_prose');
+  });
+  it('end_turn + parsed -> wrong_shape (prompt/schema, not Toranot)', () => {
+    expect(b('end_turn', 'parsed')).toBe('wrong_shape');
+  });
+  it('end_turn + parse_threw -> ambiguous', () => {
+    expect(b('end_turn', 'parse_threw')).toBe('ambiguous');
+  });
+  it('end_turn + empty -> empty', () => {
+    expect(b('end_turn', 'empty')).toBe('empty');
+  });
+});
+
+describe('eyeball set = exactly the two non-no_brace end_turn cells', () => {
+  it('only unbalanced/parse_threw at non-max_tokens map to the eyeball category', () => {
+    expect(EYEBALL_CATEGORY).toBe('ambiguous');
+    const eyeballPairs = [];
+    for (const sr of ['end_turn', null, 'refusal', 'max_tokens']) {
+      for (const br of ['no_brace', 'unbalanced', 'parse_threw', 'parsed', 'empty']) {
+        if (bucketJudgeFailure({ first_stop_reason: sr, first_branch: br }) === EYEBALL_CATEGORY) {
+          eyeballPairs.push(`${sr}|${br}`);
+        }
+      }
+    }
+    // exactly the non-max_tokens × {unbalanced,parse_threw} cells; never any max_tokens cell
+    expect(eyeballPairs.sort()).toEqual([
+      'end_turn|parse_threw', 'end_turn|unbalanced',
+      'null|parse_threw', 'null|unbalanced',
+      'refusal|parse_threw', 'refusal|unbalanced',
+    ].sort());
+    expect(eyeballPairs.some((p) => p.startsWith('max_tokens'))).toBe(false);
+  });
+});
+
+describe('summarizeLedger — filters + counts', () => {
+  it('counts only ai-parse-error/context=judge rows; buckets by the rule', () => {
+    const rows = [
+      { type: 'ai-parse-error', context: 'judge', first_stop_reason: 'max_tokens', first_branch: 'unbalanced' },
+      { type: 'ai-parse-error', context: 'judge', first_stop_reason: 'max_tokens', first_branch: 'parse_threw' },
+      { type: 'ai-parse-error', context: 'judge', first_stop_reason: 'end_turn', first_branch: 'no_brace' },
+      { type: 'ai-parse-error', context: 'judge', first_stop_reason: 'end_turn', first_branch: 'unbalanced' },
+      { type: 'ai-parse-error', context: 'judge', first_stop_reason: 'end_turn', first_branch: 'parse_threw' },
+      { type: 'ai-parse-error', context: 'judge', first_stop_reason: 'end_turn', first_branch: 'parsed' },
+      { type: 'ai-parse-error', context: 'pick', first_stop_reason: 'max_tokens', first_branch: 'unbalanced' }, // excluded (pick)
+      { type: 'ai-error', context: 'judge', message: 'x' },                                                    // excluded (not parse-error)
+      { type: 'ai-judge', app_answer_correct: true },                                                          // excluded (action)
+    ];
+    const s = summarizeLedger(rows);
+    expect(s.total).toBe(6);
+    expect(s.counts).toEqual({
+      truncation: 2, genuine_prose: 1, wrong_shape: 1, ambiguous: 2, empty: 0, unknown: 0,
+    });
+    expect(s.eyeball_total).toBe(2);                 // the 2 ambiguous end_turn rows
+    expect(s.fix_routing.truncation).toMatch(/max_tokens/i);
+    expect(s.fix_routing.genuine_prose).toMatch(/structured output|Toranot/i);
+  });
+
+  it('empty ledger -> all-zero, no throw', () => {
+    const s = summarizeLedger([]);
+    expect(s.total).toBe(0);
+    expect(s.eyeball_total).toBe(0);
+  });
+});

--- a/tests/chaosBotV4BucketRule.test.js
+++ b/tests/chaosBotV4BucketRule.test.js
@@ -88,32 +88,64 @@ describe('eyeball set = exactly the two non-no_brace end_turn cells', () => {
   });
 });
 
-describe('summarizeLedger — filters + counts', () => {
-  it('counts only ai-parse-error/context=judge rows; buckets by the rule', () => {
+describe('summarizeLedger — UNDERLYING population (judge-shape-firstfail), not the residual', () => {
+  it('buckets the un-conditioned first-attempt failures; residual + reconciliation are secondary', () => {
     const rows = [
-      { type: 'ai-parse-error', context: 'judge', first_stop_reason: 'max_tokens', first_branch: 'unbalanced' },
+      // The UNDERLYING population — every first-attempt failure, recovered or not.
+      { type: 'judge-shape-firstfail', context: 'judge', first_stop_reason: 'max_tokens', first_branch: 'unbalanced', recovered: true },
+      { type: 'judge-shape-firstfail', context: 'judge', first_stop_reason: 'max_tokens', first_branch: 'parse_threw', recovered: false },
+      { type: 'judge-shape-firstfail', context: 'judge', first_stop_reason: 'end_turn', first_branch: 'no_brace', recovered: true },
+      { type: 'judge-shape-firstfail', context: 'judge', first_stop_reason: 'end_turn', first_branch: 'unbalanced', recovered: false },
+      { type: 'judge-shape-firstfail', context: 'judge', first_stop_reason: 'end_turn', first_branch: 'parse_threw', recovered: false },
+      { type: 'judge-shape-firstfail', context: 'judge', first_stop_reason: 'end_turn', first_branch: 'parsed', recovered: true },
+      // The 3 terminal double-failures (audit-5 B5 log) — reconcile 1:1 with recovered:false above.
       { type: 'ai-parse-error', context: 'judge', first_stop_reason: 'max_tokens', first_branch: 'parse_threw' },
-      { type: 'ai-parse-error', context: 'judge', first_stop_reason: 'end_turn', first_branch: 'no_brace' },
       { type: 'ai-parse-error', context: 'judge', first_stop_reason: 'end_turn', first_branch: 'unbalanced' },
       { type: 'ai-parse-error', context: 'judge', first_stop_reason: 'end_turn', first_branch: 'parse_threw' },
-      { type: 'ai-parse-error', context: 'judge', first_stop_reason: 'end_turn', first_branch: 'parsed' },
-      { type: 'ai-parse-error', context: 'pick', first_stop_reason: 'max_tokens', first_branch: 'unbalanced' }, // excluded (pick)
-      { type: 'ai-error', context: 'judge', message: 'x' },                                                    // excluded (not parse-error)
-      { type: 'ai-judge', app_answer_correct: true },                                                          // excluded (action)
+      // Excluded noise.
+      { type: 'judge-shape-firstfail', context: 'pick', first_stop_reason: 'max_tokens', first_branch: 'unbalanced', recovered: false }, // pick, not judge
+      { type: 'ai-error', context: 'judge', message: 'x' },
+      { type: 'ai-judge', app_answer_correct: true },
     ];
     const s = summarizeLedger(rows);
+
+    // PRIMARY = the audit-6 decision input = ALL first-attempt failures.
     expect(s.total).toBe(6);
     expect(s.counts).toEqual({
       truncation: 2, genuine_prose: 1, wrong_shape: 1, ambiguous: 2, empty: 0, unknown: 0,
     });
-    expect(s.eyeball_total).toBe(2);                 // the 2 ambiguous end_turn rows
+    expect(s.eyeball_total).toBe(2);
+
+    // SECONDARY (diagnostic) = the residual = recovered:false subset
+    // (≡ the audit-5 double-failure population — quantifies the retry's
+    // class-dependent recovery, the bias the reviewer flagged).
+    expect(s.residual_counts).toEqual({
+      truncation: 1, genuine_prose: 0, wrong_shape: 0, ambiguous: 2, empty: 0, unknown: 0,
+    });
+
+    // RECONCILIATION invariant: residual (recovered:false) must equal the
+    // independent terminal ai-parse-error/judge count, or the instrument
+    // drifted.
+    expect(s.reconciliation).toEqual({
+      firstfail_unrecovered: 3, ai_parse_error: 3, match: true,
+    });
+
     expect(s.fix_routing.truncation).toMatch(/max_tokens/i);
     expect(s.fix_routing.genuine_prose).toMatch(/structured output|Toranot/i);
+  });
+
+  it('old ai-parse-error-only ledger -> underlying total 0 (cannot reconstruct; reviewer: no shortcut)', () => {
+    const s = summarizeLedger([
+      { type: 'ai-parse-error', context: 'judge', first_stop_reason: 'end_turn', first_branch: 'no_brace' },
+    ]);
+    expect(s.total).toBe(0);                           // no firstfail rows -> underlying unmeasurable
+    expect(s.reconciliation).toEqual({ firstfail_unrecovered: 0, ai_parse_error: 1, match: false });
   });
 
   it('empty ledger -> all-zero, no throw', () => {
     const s = summarizeLedger([]);
     expect(s.total).toBe(0);
     expect(s.eyeball_total).toBe(0);
+    expect(s.reconciliation.match).toBe(true); // 0 === 0
   });
 });

--- a/tests/chaosBotV4ExtractFailureClass.test.js
+++ b/tests/chaosBotV4ExtractFailureClass.test.js
@@ -1,0 +1,110 @@
+// Audit-6 Option-0 (2026-05-18) — extractJson failure-class classifier.
+//
+// WHY THIS EXISTS
+// ---------------
+// Audit-5 closed the B5 *silent-swallow* (judge JSON-parse failures now
+// logged + retried). Audit-6 STEP-0 (docs/AUDIT6_STEP0_scope_blocked...)
+// established the brief's "force structured output" frame is unsafe
+// UNTIL the failure-mode composition is measured: extractJson() returns
+// null on THREE structurally distinct branches, and only one of them
+// (genuine prose) is a cross-repo / structured-output conversation —
+// the other two are cheap Geri-side fixes:
+//
+//   unbalanced  -> (a) truncated mid-object        -> max_tokens bump
+//   parse_threw -> (c) complete-but-invalid JSON   -> lenient parse / prompt
+//   no_brace    -> (b) genuine prose, no JSON      -> structured output
+//
+// A single stop_reason boolean separates (a) from {(b),(c)} but cannot
+// split (b) from (c). classifyExtractFailure() exposes WHICH of
+// extractJson()'s `return null` branches fired — a free enum derived
+// from the SAME scan (no duplicated parser; DRY / audit-5
+// grep-existing-utility), so the next bounded chaos run emits
+// bucketable telemetry with zero raw-text retention.
+//
+// LOAD-BEARING REGRESSION: the refactor that adds the classifier MUST
+// NOT change extractJson()'s return value for ANY input — that return
+// contract is the audit-5 floor (tests/chaosBotV4JudgeShapeValidator
+// + the carried-forward c_accept oracle depend on it). The consistency
+// invariant test below pins exactly that.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import {
+  extractJson,
+  classifyExtractFailure,
+} from '../scripts/lib/extractJson.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIX = JSON.parse(
+  readFileSync(join(HERE, 'fixtures/judgeShapeFailures.json'), 'utf8'),
+);
+
+describe('classifyExtractFailure — branch enum', () => {
+  it('empty / falsy input -> "empty", extractJson null', () => {
+    for (const x of ['', null, undefined, 0, false]) {
+      expect(classifyExtractFailure(x)).toBe('empty');
+      expect(extractJson(x)).toBe(null);
+    }
+  });
+
+  it('genuine prose, no brace -> "no_brace" (class b)', () => {
+    const prose = 'Yes, the app answer is correct per Hazzard 8e.';
+    expect(classifyExtractFailure(prose)).toBe('no_brace');
+    expect(extractJson(prose)).toBe(null);
+  });
+
+  it('truncated mid-object (the literal B5 pin) -> "unbalanced" (class a)', () => {
+    expect(classifyExtractFailure('{"app_answer_correct":tr')).toBe('unbalanced');
+    expect(extractJson('{"app_answer_correct":tr')).toBe(null);
+    // longer truncation, braces still never close
+    expect(
+      classifyExtractFailure('{"app_answer_correct":true,"confidence":8'),
+    ).toBe('unbalanced');
+  });
+
+  it('complete-but-invalid JSON -> "parse_threw" (class c)', () => {
+    for (const bad of [
+      '{"app_answer_correct": True}',          // python bool
+      '{"app_answer_correct":false,}',         // trailing comma
+      '{app_answer_correct:false}',            // unquoted key
+      "{'app_answer_correct':false}",          // single quotes
+    ]) {
+      expect(classifyExtractFailure(bad)).toBe('parse_threw');
+      expect(extractJson(bad)).toBe(null);
+    }
+  });
+
+  it('valid / recoverable JSON -> "parsed", extractJson non-null', () => {
+    for (const good of [
+      '{"app_answer_correct":false,"confidence":80}',
+      '```json\n{"app_answer_correct":true}\n```',
+      'Verdict: {"app_answer_correct":true}',           // prose-then-json (recovered)
+      '{"app_answer_correct":"true"}',                  // valid JSON, wrong SHAPE (validator's job, not classifier's)
+      '[1,2,3]',                                        // valid non-object
+    ]) {
+      expect(classifyExtractFailure(good)).toBe('parsed');
+      expect(extractJson(good)).not.toBe(null);
+    }
+  });
+});
+
+describe('consistency invariant (refactor must not fork behavior)', () => {
+  it('classify==="parsed" iff extractJson!==null, across the audit-5 fixture', () => {
+    for (const s of FIX.samples) {
+      const parsedByClass = classifyExtractFailure(s.raw) === 'parsed';
+      const parsedByExtract = extractJson(s.raw) !== null;
+      expect(parsedByClass).toBe(parsedByExtract);
+    }
+  });
+
+  it('audit-5 literal pins preserved through the refactor', () => {
+    // Re-pinned here so a refactor regression is caught even if the
+    // sibling pinned suite is edited. Mirrors
+    // chaosBotV4JudgeShapeValidator.test.js:188-189.
+    expect(extractJson('{"app_answer_correct":tr')).toBe(null);
+    expect(
+      extractJson('Yes, the app answer is correct per Hazzard 8e.'),
+    ).toBe(null);
+  });
+});

--- a/tests/chaosBotV4ParseFailureTelemetry.test.js
+++ b/tests/chaosBotV4ParseFailureTelemetry.test.js
@@ -1,0 +1,155 @@
+// Audit-6 Option-0 (2026-05-18) — judge parse-failure TELEMETRY.
+//
+// Audit-5 closed the silent-swallow (failures now logged + retried).
+// Audit-6 STEP-0 established the fix-class depends on the UNMEASURED
+// failure-mode composition. This pins the persistent instrument
+// (stop_reason, first_branch) that makes the next bounded chaos run
+// bucketable.
+//
+// BUCKETING RULE — keyed off stop_reason FIRST; branch is a refinement
+// of the end_turn rows ONLY and is NEVER a standalone truncation signal
+// (unbalanced@end_turn is NOT truncation — a model can finish normally
+// and still emit an unmatched '{'; a max_tokens bump won't touch it):
+//   stop_reason == max_tokens             -> (a) TRUNCATION, any branch  -> Geri max_tokens bump / schema trim
+//   end_turn + no_brace                   -> (b) clean genuine prose     -> structured output (ONLY Toranot leaf)
+//   end_turn + unbalanced                 -> AMBIGUOUS (malformed-JSON | prose w/ stray '{') -> bounded-sample eyeball
+//   end_turn + parse_threw                -> AMBIGUOUS (malformed-complete | prose w/ {...})  -> bounded-sample eyeball
+//   end_turn + parsed                     -> wrong-shape (string-bool / missing-key) -> prompt/schema fix
+// Eyeball set = the TWO non-no_brace end_turn cells, not parse_threw alone.
+//
+// Two contracts:
+//  1. judgeWithShapeRetry enriches the final ai-parse-error judge log
+//     with first_branch (classifyExtractFailure of the FIRST response)
+//     and first_stop_reason (the FIRST response's stop_reason) — derived
+//     from the ORIGINAL failure, not the corrective re-ask. Zero raw-text
+//     retention beyond the audit-5 200-char `text` slice (unchanged).
+//  2. callClaude surfaces data.stop_reason (source-assertion — same way
+//     chaosBotV4ProxyMode.test.js verifies callClaude's header plumbing,
+//     since callClaude does a real fetch and is not unit-isolatable).
+//
+// MUST NOT regress: cap=1, exactly-2-calls symmetry, residual-{}, and the
+// existing `text`/`at` fields (the 15-test pinned suite stays byte-stable;
+// these are additive fields, asserted in a SEPARATE file).
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { judgeWithShapeRetry } from '../scripts/lib/judgeShapeValidator.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const BOT_SRC = readFileSync(
+  join(HERE, '../scripts/chaos-doctor-bot-v4.mjs'),
+  'utf8',
+);
+
+// callClaude-shaped stub that ALSO carries stopReason (the new contract).
+function makeStub(queue) {
+  let i = 0;
+  const calls = [];
+  const fn = async (system, userPrompt, opts) => {
+    calls.push({ system, userPrompt, opts });
+    const r = queue[Math.min(i, queue.length - 1)];
+    i += 1;
+    if (r instanceof Error) throw r;
+    // queue items: { text, stopReason } | string (legacy, no stopReason)
+    if (typeof r === 'string') return { text: r, inputTokens: 1, outputTokens: 1 };
+    return { text: r.text, stopReason: r.stopReason, inputTokens: 1, outputTokens: 1 };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const judgePE = (log) =>
+  log.bugs.filter((b) => b.type === 'ai-parse-error' && b.context === 'judge');
+
+describe('judge parse-failure log carries first_branch + first_stop_reason', () => {
+  it('(a) truncated first response -> first_branch=unbalanced, first_stop_reason=max_tokens', async () => {
+    const log = { bugs: [] };
+    const stub = makeStub([
+      { text: '{"app_answer_correct":tr', stopReason: 'max_tokens' },
+      { text: 'still {"app_answer_correct":fa', stopReason: 'max_tokens' },
+    ]);
+    const j = await judgeWithShapeRetry({
+      system: 'S', userPrompt: 'U', maxTokens: 400,
+      callJudge: stub, log, nowIso: () => 'T',
+    });
+    expect(Object.keys(j).length).toBe(0);          // residual {} unchanged
+    expect(stub.calls.length).toBe(2);              // cap=1 unchanged
+    const pe = judgePE(log);
+    expect(pe.length).toBe(1);
+    expect(pe[0].first_branch).toBe('unbalanced');  // (a) truncation class
+    expect(pe[0].first_stop_reason).toBe('max_tokens');
+    expect(pe[0]).toHaveProperty('text');           // audit-5 field preserved
+    expect(pe[0]).toHaveProperty('at');
+  });
+
+  it('(b) genuine prose first response -> first_branch=no_brace, first_stop_reason=end_turn', async () => {
+    const log = { bugs: [] };
+    const stub = makeStub([
+      { text: 'No — per Hazzard 8e the app answer is wrong.', stopReason: 'end_turn' },
+      { text: 'Still prose, no JSON here.', stopReason: 'end_turn' },
+    ]);
+    await judgeWithShapeRetry({
+      system: 'S', userPrompt: 'U', maxTokens: 400,
+      callJudge: stub, log, nowIso: () => 'T',
+    });
+    const pe = judgePE(log);
+    expect(pe.length).toBe(1);
+    expect(pe[0].first_branch).toBe('no_brace');    // (b) genuine prose
+    expect(pe[0].first_stop_reason).toBe('end_turn');
+  });
+
+  it('(c) malformed-but-complete first response -> first_branch=parse_threw', async () => {
+    const log = { bugs: [] };
+    const stub = makeStub([
+      { text: '{"app_answer_correct": True}', stopReason: 'end_turn' },
+      { text: '{still:bad,}', stopReason: 'end_turn' },
+    ]);
+    await judgeWithShapeRetry({
+      system: 'S', userPrompt: 'U', maxTokens: 400,
+      callJudge: stub, log, nowIso: () => 'T',
+    });
+    const pe = judgePE(log);
+    expect(pe.length).toBe(1);
+    expect(pe[0].first_branch).toBe('parse_threw'); // (c) + ambiguous bucket
+    expect(pe[0].first_stop_reason).toBe('end_turn');
+  });
+
+  it('legacy stub without stopReason -> first_stop_reason is null, no throw (backward compat)', async () => {
+    const log = { bugs: [] };
+    const stub = makeStub(['{"app_answer_correct":tr', 'still bad']); // strings = no stopReason
+    const j = await judgeWithShapeRetry({
+      system: 'S', userPrompt: 'U', maxTokens: 400,
+      callJudge: stub, log, nowIso: () => 'T',
+    });
+    expect(Object.keys(j).length).toBe(0);
+    const pe = judgePE(log);
+    expect(pe.length).toBe(1);
+    expect(pe[0].first_branch).toBe('unbalanced');
+    expect(pe[0].first_stop_reason).toBe(null);     // absent -> null, never undefined/throw
+  });
+
+  it('conforming-on-first fires no log (telemetry only on real failure)', async () => {
+    const log = { bugs: [] };
+    const stub = makeStub([
+      { text: '{"app_answer_correct":false,"confidence":80,"issue":null,"correct_letter_if_app_wrong":"C"}', stopReason: 'end_turn' },
+    ]);
+    const j = await judgeWithShapeRetry({
+      system: 'S', userPrompt: 'U', maxTokens: 400,
+      callJudge: stub, log, nowIso: () => 'T',
+    });
+    expect(typeof j.app_answer_correct).toBe('boolean');
+    expect(stub.calls.length).toBe(1);
+    expect(log.bugs.length).toBe(0);
+  });
+});
+
+describe('callClaude surfaces stop_reason (source-assertion)', () => {
+  it('callClaude return reads data.stop_reason and exposes it', () => {
+    // Same verification style as chaosBotV4ProxyMode.test.js (callClaude
+    // does a real fetch; the contract is pinned by source inspection).
+    expect(BOT_SRC).toMatch(/data\.stop_reason/);
+    // surfaced on the returned object alongside text/tokens
+    expect(BOT_SRC).toMatch(/return \{ text, inputTokens: inT, outputTokens: outT, stopReason/);
+  });
+});

--- a/tests/chaosBotV4ParseFailureTelemetry.test.js
+++ b/tests/chaosBotV4ParseFailureTelemetry.test.js
@@ -144,6 +144,88 @@ describe('judge parse-failure log carries first_branch + first_stop_reason', () 
   });
 });
 
+// The audit-6 target is the UNDERLYING first-attempt failure rate
+// (~26%), NOT the double-failure residual (~7%) that audit-5's terminal
+// ai-parse-error log samples. The retry is a schema-restated re-ask with
+// the SAME 400-token budget — its recovery is class-dependent, so the
+// double-failure histogram is a biased estimator of the underlying
+// composition. The instrument must emit on EVERY first-attempt failure
+// (recovered or not), via a distinct type so audit-5's B5 contract +
+// the 15-pin suite stay byte-stable.
+const judgeFF = (log) =>
+  log.bugs.filter((b) => b.type === 'judge-shape-firstfail' && b.context === 'judge');
+
+describe('un-conditioned first-attempt-failure population (the audit-6 target)', () => {
+  it('recovered-first-fail STILL leaves a firstfail trace (recovered:true), 0 ai-parse-error', async () => {
+    const log = { bugs: [] };
+    const stub = makeStub([
+      { text: '{"app_answer_correct":tr', stopReason: 'max_tokens' },              // first fails
+      { text: '{"app_answer_correct":false,"confidence":80,"issue":null,"correct_letter_if_app_wrong":"C"}', stopReason: 'end_turn' }, // retry recovers
+    ]);
+    const j = await judgeWithShapeRetry({
+      system: 'S', userPrompt: 'U', maxTokens: 400,
+      callJudge: stub, log, nowIso: () => 'T',
+    });
+    expect(typeof j.app_answer_correct).toBe('boolean'); // retry recovered
+    expect(stub.calls.length).toBe(2);                   // cap=1 unchanged
+    expect(judgePE(log).length).toBe(0);                 // residual view: nothing (the bug this fixes)
+    const ff = judgeFF(log);
+    expect(ff.length).toBe(1);                           // underlying view: the first failure IS recorded
+    expect(ff[0].first_branch).toBe('unbalanced');
+    expect(ff[0].first_stop_reason).toBe('max_tokens');
+    expect(ff[0].recovered).toBe(true);
+  });
+
+  it('double-fail emits firstfail(recovered:false) AND ai-parse-error; they reconcile 1:1', async () => {
+    const log = { bugs: [] };
+    const stub = makeStub([
+      { text: 'No — the app answer is wrong per Hazzard 8e.', stopReason: 'end_turn' },
+      { text: 'Still prose, no JSON.', stopReason: 'end_turn' },
+    ]);
+    await judgeWithShapeRetry({
+      system: 'S', userPrompt: 'U', maxTokens: 400,
+      callJudge: stub, log, nowIso: () => 'T',
+    });
+    const ff = judgeFF(log);
+    const pe = judgePE(log);
+    expect(ff.length).toBe(1);
+    expect(ff[0]).toMatchObject({ first_branch: 'no_brace', first_stop_reason: 'end_turn', recovered: false });
+    expect(pe.length).toBe(1);
+    // reconciliation invariant: residual == firstfail with recovered:false
+    expect(ff.filter((r) => r.recovered === false).length).toBe(pe.length);
+  });
+
+  it('conforming-on-first emits NO firstfail (success is not the population)', async () => {
+    const log = { bugs: [] };
+    const stub = makeStub([
+      { text: '{"app_answer_correct":true,"confidence":90,"issue":null,"correct_letter_if_app_wrong":null}', stopReason: 'end_turn' },
+    ]);
+    await judgeWithShapeRetry({
+      system: 'S', userPrompt: 'U', maxTokens: 400,
+      callJudge: stub, log, nowIso: () => 'T',
+    });
+    expect(judgeFF(log).length).toBe(0);
+  });
+
+  it('retry-throw: first failure still recorded (recovered:false) + ai-error, returns {}', async () => {
+    const log = { bugs: [] };
+    const stub = makeStub([
+      { text: '{"app_answer_correct": True}', stopReason: 'end_turn' },   // first fails (parse_threw)
+      new Error('Claude API 529: overloaded'),                            // retry throws
+    ]);
+    const j = await judgeWithShapeRetry({
+      system: 'S', userPrompt: 'U', maxTokens: 400,
+      callJudge: stub, log, nowIso: () => 'T',
+    });
+    expect(Object.keys(j).length).toBe(0);
+    const ff = judgeFF(log);
+    expect(ff.length).toBe(1);
+    expect(ff[0]).toMatchObject({ first_branch: 'parse_threw', first_stop_reason: 'end_turn', recovered: false });
+    expect(log.bugs.filter((b) => b.type === 'ai-error' && b.context === 'judge').length).toBe(1);
+    expect(judgePE(log).length).toBe(0); // retry never produced resp2 -> no terminal ai-parse-error
+  });
+});
+
 describe('callClaude surfaces stop_reason (source-assertion)', () => {
   it('callClaude return reads data.stop_reason and exposes it', () => {
     // Same verification style as chaosBotV4ProxyMode.test.js (callClaude


### PR DESCRIPTION
## Audit-6 Option 0 — the diagnostic instrument (not the paid sample, not §4)

Implements the converged Option-0 design from `docs/AUDIT6_STEP0_scope_blocked_2026-05-18.md` (PR #230, the append-only STEP-0 record — this is the separate code branch per pacing). Makes the next bounded chaos run emit **bucketable** judge-parse-failure telemetry so the ~26% malformation can be split into the ternary that decides whether the cross-repo Toranot proxy is even relevant.

### What ships
| Piece | File | Contract |
|---|---|---|
| 1 | `scripts/lib/extractJson.mjs` | Behavior-preserving refactor → internal `_scan`; `extractJson` byte-identical (audit-5 floor); new `classifyExtractFailure` (`parsed/empty/no_brace/unbalanced/parse_threw`) — no duplicated parser (DRY) |
| 2 | `scripts/chaos-doctor-bot-v4.mjs` | `callClaude` returns `stopReason: data.stop_reason\|\|null` |
| 3 | `scripts/lib/judgeShapeValidator.mjs` | final `ai-parse-error` judge log gains `first_branch` + `first_stop_reason` (from the **first** response — original failure mode). Additive: cap=1 / 2-call symmetry / residual-{} / audit-5 `text`/`at` untouched |
| 4 | `scripts/lib/bucketParseFailures.mjs` + `scripts/bucketJudgeParseFailures.mjs` | the corrected rule + free read-only CLI |

### The corrected bucketing rule (review-hardened, pinned)
**Truncation is a property of `stop_reason`, full stop.** `first_stop_reason === 'max_tokens'` ⟺ length-cut, for **any** branch. The extractJson null-branch is **never** a standalone truncation signal — a model can finish naturally (`end_turn`) and still emit an unmatched `{` (`unbalanced`); that's malformed/prose, not a cut. Counting `(end_turn, unbalanced)` as truncation would inflate the exact number that gates the Toranot decision. Branch refines the **not-`max_tokens`** rows only:

- `max_tokens`, any branch → **truncation** → Geri `max_tokens` bump. **Zero Toranot.**
- `end_turn`+`no_brace` → **genuine_prose** → structured output. **The only Toranot conversation** (then option 2 only).
- `end_turn`+`parsed` → **wrong_shape** → Geri prompt/schema. Zero Toranot.
- `end_turn`+`{unbalanced,parse_threw}` → **ambiguous** → bounded-sample raw-text eyeball (the TWO cells, not `parse_threw` alone).

### Scope discipline
- **Not** an autonomous paid run — the bounded sample stays a user-triggered `scripts/long-chaos-run.sh` op (cost discipline). This branch makes that run's output bucketable + ships the free analysis CLI.
- No trinity bump (bot infra; matches audit-5/6 precedent).
- audit-5 floor re-verified green; `extractJson` return contract byte-preserved.

### Verification
`npm run verify` GREEN: **75 files / 1421 passed + 7 skipped**; 7/7 pre-push checks; trinity untouched v10.64.130. New guards: `chaosBotV4ExtractFailureClass` (13, incl. consistency invariant), `chaosBotV4ParseFailureTelemetry` (6), `chaosBotV4BucketRule` (10, incl. the `(end_turn,unbalanced)≠truncation` regression pin).

Not self-merged. Independent of #230 (which stays the clean docs-only STEP-0 record).

🤖 Generated with [Claude Code](https://claude.com/claude-code)