### PR TITLE
feat(audit-8 prestep): two-sided stemHash identity instrument (no trinity bump)

### DIFF
--- a/docs/AUDIT8_PRESTEP_INSTRUMENT_GATE.md
+++ b/docs/AUDIT8_PRESTEP_INSTRUMENT_GATE.md
@@ -1,0 +1,285 @@
+# Audit-8 — instrument PRE-STEP (pick-channel + comparator stemHash identity) — GATE
+
+Append-only; do not retro-edit (`feedback_spec_provenance_append_only`).
+Lane: terminal, solo (`claude/term-audit8-prestep-stemhash`, cut from
+`origin/main` HEAD `7260bdb`). Trinity: **untouched** — `scripts/` +
+`tests/` + `docs/` only, **no bump** (mirrors audit-5's fix PR and the
+Option-0 instrument PR #231: an instrument precursor that ships no
+exam/product content does not bump the version trinity).
+
+**Binding pre-registration is NOT this doc.** It is the merged, locked
+`docs/AUDIT8_PRE_REGISTERED_GATE.md` (#233, `7260bdb`), authored before
+any run, whose **G0** + **DELTA D4** pre-registered *exactly* what this
+PRE-STEP must do. This doc is the PRE-STEP's execution record: STEP 0,
+the deterministic predicates G0/D4 are made literal as, the RESULT, and
+the cross-lane reconciliation the next (bounded-run) session inherits.
+The merged gate's own activation order is binding:
+**G0 PRE-STEP PR → re-pass STEP 0.2 → bounded run (G1–G5) → RESULT**.
+This session lands the PR; it does **not** run the bounded analysis (it
+cannot — the run is gated behind this PR being merged on `main` and a
+STEP 0.2 re-pass, and self-merge is forbidden).
+
+---
+
+## STEP 0 (distrust contract) — results
+
+- **0.1 State.** `git fetch --all`; `origin/main` HEAD = `7260bdb`
+  (#233 squash-merged — the AUDIT8 representativeness PRE-REGISTERED GATE
+  + the parked DROP-invariant ride-along). `docs/AUDIT8_PRE_REGISTERED_GATE.md`
+  present on `main`; `tests/chaosBotV4PickDropInvariant.test.js` present
+  on `main` (#233 ride-along). Local `main` fast-forwarded
+  `dac09e2 → 7260bdb` before branching (stale-local-main trap avoided).
+  Untracked `docs/AUDIT7_HORIZON1_kickoff.md` is a prior parked artifact
+  superseded by the merged AUDIT8 gate — **out of scope, left untouched,
+  not staged** (Working Rule 3). ✅
+
+- **0.2 Concurrent lane.** One open PR: **#234**
+  (`claude/web-rm-stale-supabase-migrations`) — the web lane's cosmetic
+  removal of the vestigial `supabase/migrations/` dir. It touches no bot
+  / `scripts/lib/` / test file. **Not collided with, not reinvented, not
+  merged** (other lane's). This PRE-STEP branch cut from `main`, not from
+  #234. → solo terminal lane; branch + PR, **no self-merge** (the
+  #230/#231 self-merge was a discrete explicit user instruction, not a
+  precedent — merged gate SHIP clause). ✅
+
+- **0.3 Baseline green (pre-edit).** Inherited from #233 close: full
+  suite green on `main`. The GUARD `tests/chaosBotV4PickDropInvariant.test.js`
+  re-confirmed **5/5 green after the instrument edits** (the load-bearing
+  re-run — the instrument adds fields to the `:466` drop row and the
+  `finding` object but does not touch the `disagrees` gate/compute, and
+  the GUARD proves it). ✅
+
+- **0.4 Inputs — supplied, not reconstructed.** The merged gate's append
+  (lines 431–437) named two fresh-eye-lane scripts as PRE-STEP **inputs**
+  ("not committed in this docs+test PR, and not pre-spec'd now"). At
+  session start they were absent from disk / all branches / stash /
+  gitignored paths (web lane's clone never synced). The user then
+  supplied four web-lane artifacts: `AUDIT8_PICK_REPRESENTATIVENESS_GATE.md`
+  (web-draft @ `fedf27e`), `INSTRUMENT_PATCH.md`, `build_stemhash_index.mjs`,
+  `analyze_pick_representativeness.mjs`. The web-draft gate doc (its line
+  5) explicitly assigns **terminal = fresh-eye reviewer, review required
+  before STEP 1** — this session performed that filesystem-grounded
+  review against the merged authoritative gate + live bot source + the
+  live corpus (workspace CLAUDE.md "Fresh-eye filesystem-grounded review"
+  default, fired as designed). Outcome of that review → §"Reconciliation"
+  below. None of the four web-lane artifacts is committed to the repo
+  (the merged gate's "Single doc — no second gate doc" warning; the
+  scripts are Phase-2 inputs, not PR artifacts). ✅
+
+---
+
+## The instrument gap (re-verified from source at `7260bdb`, deterministic — no run)
+
+The merged gate's STEP 0.2 + D4 established this; re-verified line-by-line:
+
+- `:450` `const stemHash = hashStem(q.stem)` — bot hashes the **full**
+  stem. djb2 is collision-free over the corpus (3586 distinct hashes =
+  3586 unique stems).
+- `:458` `ai-error/pick` (network/throw before parse) drop row, `:466`
+  `ai-parse-error/pick` (the ~11% drop this whole audit is about) drop
+  row — both `log.bugs.push` rows carried **no question identity** (`text`
+  on `:466` is the model's *failed response*, not the question).
+- pre-pick early return (`!q || q.options.length < 2`) — **no ledger row
+  at all**; `extractQuestion`→null was invisible.
+- `recordFinding`'s `finding` object (`:695-708`) stores
+  `stem: q.stem.slice(0,300)` **truncated**, **no stemHash**; 1713/3743
+  (46%) of stems exceed 300 chars (D4) — the truncated slice is *not* a
+  faithful join key and the full-stem hash is **not reconstructable**
+  from it. The appIdx-null methodology `recordFinding` (`:524`) likewise
+  had no stemHash.
+
+Consequence (merged gate G0): the dropped population's covariates are
+unrecoverable and the comparator's join key is fragile for ~46% of rows
+→ the representativeness run is **NOT runnable on the current instrument**.
+This PRE-STEP closes that gap on **both sides**, keyed on one identical
+hash.
+
+---
+
+## Fix class (pre-decided by merged gate G0 + D4; locked)
+
+Minimal two-sided identity instrument. Product code = `scripts/` +
+`tests/`; **no trinity bump**.
+
+1. **Shared single-source-of-truth hash** — new `scripts/lib/hashStem.mjs`
+   exporting `hashStem` (the bot's djb2, verbatim) + `normStem`
+   (whitespace-collapse). Bot imports it; the inline djb2 (old `:160-165`)
+   is deleted; both bot hash sites use `hashStem(normStem(q.stem))`.
+   **Rationale (load-bearing; the corpus fact the no-run merged gate G0
+   could not see — exactly the class its DELTAS mechanism absorbs):** the
+   bot hashes a DOM-scraped stem (`extractQuestion` → `.heb` innerText:
+   whitespace-collapsed, markup-dropped); the offline join hashes the
+   dataset `q` string. A raw djb2 of the two will **not** match → the
+   merged gate's D3 per-covariate determinate join (≥99%) is
+   *structurally impossible* without normalizing both sides. Sibling to
+   `scripts/lib/extractJson.mjs` / `optionResolver.mjs` (the repo's
+   established `scripts/lib/` shared-helper pattern). Stuck-refresh
+   semantics preserved (same stem → same normalized hash).
+2. **`:466` `ai-parse-error/pick` (PRIMARY)** — add `dropCtx:
+   'pick-parse-error'` + `stemHash` + `stem: q.stem.slice(0,300)` (mirrors
+   `recordFinding`) + `optCount: q.options.length`. Exactly the merged
+   gate G0 field set (the web `INSTRUMENT_PATCH.md` added `stemHash` only
+   — superseded; merged gate wins).
+3. **`:458` `ai-error/pick`** — add `stemHash` + distinct `dropCtx:
+   'pick-ai-error'` (merged gate G4.1: reported separately, not in the
+   parse-drop numerator).
+4. **Pre-pick early return** — add a distinct, **EXCLUDABLE** tagged row
+   `type:'pre-pick-skip', context:'pick', dropCtx: 'pre-pick-short-extract'
+   | 'pre-pick-no-question'` (merged gate G0: "Tag these with a distinct
+   sub-context so the analysis can *exclude*"). `type` deliberately ≠
+   `ai-*` so the analyzer's DROPPED filter (`type∈{ai-parse-error,ai-error}
+   ∧ context==='pick'`) excludes it by construction. Return shape
+   (`stemHash:null`) unchanged → stuck-refresh untouched (Working Rule 3).
+   Plus a `log.extractNull` denominator counter (web `INSTRUMENT_PATCH.md`
+   Change 6 — honest-denominator hygiene, not analyzed for bias).
+5. **`:524` appIdx-null `recordFinding`** — add `stemHash`. **Deliberate
+   one-row extension of D4's literal `:695-708` scope (Working Rule 1,
+   surfaced not buried):** this methodology row *passes* the `:465` pick
+   gate but never reaches the judge, so it is neither DROPPED nor JUDGED;
+   without `stemHash` it is analyzer-**unjoinable** and the merged gate
+   G4.1 exclusion bookkeeping degrades **silently**. One identical field;
+   removes a silent-degradation class. (Advisor-endorsed.)
+6. **`:697` main `finding`** — add `stemHash` (merged gate D4 comparator
+   side).
+
+---
+
+## THE DETERMINISTIC PREDICATES (made literal from merged gate G0/D4)
+
+### P1 — Shared hash determinism + normalization
+`scripts/lib/hashStem.mjs`: `hashStem('')==='5381'`, `hashStem('a')==='177670'`
+(hand-verified djb2), unicode-stable, idempotent; `normStem` collapses
+whitespace so a DOM-scraped stem and the dataset `q` hash equal;
+`normStem` is null/undefined-safe (never throws). **TARGET: all vectors
+exact.**
+
+### P2 — Two-sided field presence (source-pinned to the producer)
+DROP side: `:466` row carries `dropCtx:'pick-parse-error'` + `stemHash`
++ `stem(0,300)` + `optCount`; `:458` row carries `dropCtx:'pick-ai-error'`
++ `stemHash`; pre-pick row is a distinct excludable type with both
+`pre-pick-*` sub-contexts + the `extractNull` counter wired. JUDGED side:
+the `finding` object and the appIdx-null `recordFinding` both carry
+`stemHash`. Bot imports `hashStem`/`normStem` from the shared module and
+the inline djb2 is gone; every bot stem hash is `hashStem(normStem(q.stem))`
+(no raw `hashStem(q.stem)` survives). Pinned by
+`tests/chaosBotV4PickIdentityInstrument.test.js`. **TARGET: all
+assertions green.**
+
+### P3 — Regression integrity (additive-change proof)
+The GUARD `tests/chaosBotV4PickDropInvariant.test.js` stays **5/5** (the
+`disagrees` gate/compute is untouched). Full `chaosBotV4*` family green
+(judge/bucket-rule shapes unperturbed — only `context:'pick'` rows
+edited). Full `npm run verify` green; **trinity untouched** (no bump).
+
+### Guard-regex widening (in-PR, documented — not a silent loosen)
+The GUARD's `INVALID_PICK_GATE` body bound was `[\s\S]{0,200}?`. The
+G0-mandated `:466` field set grew the gate body from a measured **120 →
+215** chars (the fields were minted *after* that assert was written).
+Widened **200 → 300** in the same PR, with the rationale inline in the
+test: the invariant the regex pins is **lexical ordering** (the gate's
+early `return` precedes the `disagrees` compute — assert 2 enforces the
+ordering independently via offset comparison), **not** body length; 300
+covers 215 with margin while still tripping on a genuinely large logic
+insertion between gate and return. This is a *documented bound
+adjustment to preserve the load-bearing invariant under a pre-registered
+field addition*, not a post-hoc predicate loosening.
+
+## TRIP CONDITION
+If P1 vectors are inexact, **or** any P2 assertion is absent, **or** P3
+regresses (GUARD ≠ 5/5, any `chaosBotV4*` red, `npm run verify` red, or a
+trinity bump) → **STOP and report.** Do not ship a partial; do not loosen
+a predicate post-hoc.
+
+---
+
+## Reconciliation surfaced for the bounded-run session (inherit, don't re-derive)
+
+The four web-lane inputs were authored at `fedf27e`, **before** #233's
+DELTAS locked the spec. They diverge from the merged authoritative gate.
+**The merged `AUDIT8_PRE_REGISTERED_GATE.md` (#233) is binding; the
+web-lane artifacts are adaptable inputs. Where they diverge, the merged
+gate wins** (brief: "run against [the merged gate], do not re-litigate
+it"; gate: "the data does not get to reshape it").
+
+**A. PRE-STEP scope (resolved this session — merged G0 implemented):**
+`INSTRUMENT_PATCH.md` added `stemHash`-only on `:466` and a plain counter
+on the pre-pick path. Merged gate G0 requires `stem`+`optCount` on `:466`
+and a *tagged distinct sub-context* (excludable) on pre-pick / `:458`.
+This PRE-STEP implements the **merged G0** set (the patch's
+`normStem`/shared-module idea is kept — it is the one load-bearing thing
+the no-run merged gate missed).
+
+**B. Bounded-run analysis (Phase 2 — NOT this session; scripts need
+adaptation before STEP 0.2 re-pass authorizes the run):** the supplied
+`build_stemhash_index.mjs` + `analyze_pick_representativeness.mjs`
+implement the *superseded* web-draft G4, not merged G4. Concretely:
+
+| Axis | Merged gate (BINDING — #233 G4 + D1/D2/D3) | Web-draft scripts (superseded input) |
+|---|---|---|
+| Covariates | **6**: `stem_len`, `topic`(12 TOPIC_GROUPS), `bilingual`, **`year`=`t` categorical** (D1, χ² + <5 pooling), `c_accept`, `broken` (+`N_broken_served` vacuity check) | **5**: `stem_length_tercile`, `bilingual`, `c_accept`, `broken`, **`chapter`**; `year` **dropped**; no topic-groups |
+| `stem_len` test | Mann–Whitney U + **Cliff's δ** (floor \|δ\|≥0.15) | tercile → χ² |
+| Categorical floors | **Cramér's V ≥ 0.10** effect-size floor (G4.4) | none |
+| Verdict | **4-way** (BIASED / DETECTABLE-BUT-NEGLIGIBLE / REPRESENTATIVE / INCONCLUSIVE) + logistic **sensitivity** | 3-way (YES / NO / INCONCLUSIVE) |
+| Join (G3) | **per-covariate determinate ≥99%** (D3) | global ≥90% |
+| Min-N (G2) | **N_drop≥80 ∧ N_retain≥200** | DROPPED≥100 |
+| Run cfg (G2) | 1 worker, `claude-sonnet-4-6`, `CHAOS_USE_PROXY=1`, 8 h, `CHAOS_COST_CAP_USD=20`, fresh `chaos-reports/v4-long/audit8_<ts>/` | (web-draft equivalents, mostly aligned) |
+
+Phase-2 work: adapt the two scripts to the merged G4 (add `topic`-12 +
+`year`=`t`-categorical, drop or demote `chapter` to descriptive,
+swap stem_len to MW-U + Cliff's δ, add the V≥0.10 / |δ|≥0.15 floors +
+4-way verdict + logistic sensitivity, per-covariate ≥99% join, the
+80/200 N gate, `N_broken_served` vacuity). The proxy secret is fetched
+per session (workspace CLAUDE.md — never hard-code; it rotates). This is
+a "major workstream verdict"-shaped artifact → workspace fresh-eye
+filesystem-grounded review applies to the bounded-run RESULT.
+
+## OUT OF SCOPE (handed off untouched)
+
+- **The bounded run itself** — gated behind this PR merged on `main` +
+  STEP 0.2 re-pass. Separate session.
+- Committing any web-lane artifact to the repo (the merged gate's
+  "single doc" discipline; scripts are Phase-2 inputs).
+- Horizon **item 2** (Geri-side judge `max_tokens` bump) — moot if the
+  bounded run returns BIASED; its own session/gate.
+- **B4 content adjudication.** No `q.c` flip, `broken` change, distractor
+  regen. Toranot untouched.
+- PR #234 (web lane's cosmetic `supabase/migrations/` cleanup).
+
+<!-- RESULT appended post-implementation, append-only, below. -->
+
+---
+
+## [2026-05-18, appended post-implementation] RESULT — all 3 predicates met, TRIP NOT met
+
+Append-only. Instrument: `scripts/lib/hashStem.mjs` (new shared SSOT);
+`scripts/chaos-doctor-bot-v4.mjs` (inline djb2 deleted → shared import;
+`hashStem(normStem(q.stem))` both paths; `dropCtx`+`stemHash` on
+`:458`/`:466`, `stem(300)`+`optCount` on `:466`; distinct excludable
+pre-pick row + `log.extractNull`; `stemHash` on the `:524` and `:697`
+`recordFinding` objects). Guard widened 200→300 (documented). Pin:
+`tests/chaosBotV4PickIdentityInstrument.test.js` (15 assertions).
+
+- **P1 — MET.** djb2 vectors exact (`''→5381`, `'a'→177670`),
+  unicode-stable, idempotent; `normStem` whitespace-collapse +
+  null/undefined-safe.
+- **P2 — MET.** Two-sided field presence source-pinned: `:466`
+  `dropCtx:'pick-parse-error'`+`stemHash`+`stem(0,300)`+`optCount`;
+  `:458` `dropCtx:'pick-ai-error'`+`stemHash`; distinct excludable
+  `pre-pick-skip` row (both `pre-pick-*` sub-contexts) + `extractNull`
+  counter; `finding` + appIdx-null `recordFinding` both carry `stemHash`;
+  shared-module import present, inline djb2 gone, no raw
+  `hashStem(q.stem)` survives.
+- **P3 — MET (additive).** GUARD `chaosBotV4PickDropInvariant` **5/5**
+  green post-edit (the `disagrees` gate/compute is untouched — verified
+  by the GUARD, not asserted). Full `chaosBotV4*` family **11 files /
+  122 tests** green (judge/bucket-rule shapes unperturbed). Full
+  `npm run verify`: **77 files / 1441 passed + 7 skipped**, all 7
+  non-vitest checks green; **trinity untouched at v10.64.130** (no bump
+  — scripts/tests/docs only, correctly mirrors audit-5).
+
+**TRIP CONDITION NOT MET.** No predicate failed; no falsification. Clean
+instrument-precursor ship. The bounded run remains **gated** behind this
+PR merging to `main` + a STEP 0.2 re-pass per the merged gate's binding
+activation order — it is the explicit next session, with the §
+"Reconciliation B" Phase-2 script adaptation as its inherited starting
+context.

--- a/scripts/chaos-doctor-bot-v4.mjs
+++ b/scripts/chaos-doctor-bot-v4.mjs
@@ -47,6 +47,7 @@ import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { extractJson } from './lib/extractJson.mjs';
+import { hashStem, normStem } from './lib/hashStem.mjs';
 import { judgeWithShapeRetry } from './lib/judgeShapeValidator.mjs';
 import {
   resolveAppVerdict,
@@ -157,12 +158,9 @@ const rand = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min;
 const pick = (xs) => xs[rand(0, xs.length - 1)];
 const nowIso = () => new Date().toISOString();
 
-function hashStem(s) {
-  // Simple djb2 — deterministic across workers, no crypto cost.
-  let h = 5381;
-  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
-  return String(h);
-}
+// hashStem + normStem moved to scripts/lib/hashStem.mjs (single source of
+// truth; the offline audit-8 join must hash with the IDENTICAL function).
+// See docs/AUDIT8_PRESTEP_INSTRUMENT_GATE.md.
 
 // ============================================================
 // Anthropic API helper (unchanged from v3)
@@ -445,9 +443,25 @@ async function tryClick(locator, timeoutMs) {
 
 async function doctorOneQuestion(page, workerId, log) {
   const q = await extractQuestion(page);
-  if (!q || q.options.length < 2) return { advanced: false, stemHash: null };
+  if (!q || q.options.length < 2) {
+    // Pre-pick DOM/extraction failure. NOT a pick-parse event — AUDIT8
+    // pre-registers this EXCLUDED from the pick-parse universe (gate
+    // G0 / G4.1). Tagged with a distinct `dropCtx` so the offline
+    // analyzer keys the exclusion on it; counted for an honest
+    // denominator. Return shape (stemHash:null) is unchanged so the
+    // worker-loop stuck-refresh semantics are preserved; the recoverable
+    // identity lives on the bug row only. See
+    // docs/AUDIT8_PRESTEP_INSTRUMENT_GATE.md.
+    log.extractNull = (log.extractNull || 0) + 1;
+    log.bugs.push({
+      at: nowIso(), type: 'pre-pick-skip', context: 'pick',
+      dropCtx: q ? 'pre-pick-short-extract' : 'pre-pick-no-question',
+      stemHash: q && q.stem ? hashStem(normStem(q.stem)) : null,
+    });
+    return { advanced: false, stemHash: null };
+  }
 
-  const stemHash = hashStem(q.stem);
+  const stemHash = hashStem(normStem(q.stem));
   await sleep(rand(2000, 4500)); // read pause
 
   // 1) Pick
@@ -455,7 +469,7 @@ async function doctorOneQuestion(page, workerId, log) {
   let pickResp;
   try { pickResp = await callClaude(SYS_DOCTOR_PICK, userPrompt1, { maxTokens: 250 }); }
   catch (e) {
-    log.bugs.push({ at: nowIso(), type: 'ai-error', context: 'pick', message: e.message });
+    log.bugs.push({ at: nowIso(), type: 'ai-error', context: 'pick', dropCtx: 'pick-ai-error', message: e.message, stemHash });
     return { advanced: false, stemHash };
   }
   const pickJson = extractJson(pickResp.text) || {};
@@ -463,7 +477,7 @@ async function doctorOneQuestion(page, workerId, log) {
   const aiIdx = LETTER_TO_IDX[aiLetter];
   log.actions.push({ at: nowIso(), type: 'ai-pick', letter: aiLetter, idx: aiIdx, conf: pickJson.confidence });
   if (aiIdx == null || aiIdx < 0 || aiIdx >= q.options.length) {
-    log.bugs.push({ at: nowIso(), type: 'ai-parse-error', context: 'pick', text: pickResp.text.slice(0, 200) });
+    log.bugs.push({ at: nowIso(), type: 'ai-parse-error', context: 'pick', dropCtx: 'pick-parse-error', text: pickResp.text.slice(0, 200), stemHash, stem: q.stem.slice(0, 300), optCount: q.options.length });
     return { advanced: false, stemHash };
   }
 
@@ -522,7 +536,7 @@ async function doctorOneQuestion(page, workerId, log) {
   if (appIdx == null) {
     log.bugs.push({ at: nowIso(), type: 'methodology', context: 'appIdx-null-post-check', stemHash });
     recordFinding({
-      workerId, stem: q.stem.slice(0, 300),
+      workerId, stemHash, stem: q.stem.slice(0, 300),
       options: q.options.map((o) => o.text.slice(0, 120)),
       aiLetter, aiIdx, aiWhy: pickJson.why || null, aiConf: pickJson.confidence,
       appIdx: null, disagrees: null, judge: null, source: null, citation: null,
@@ -694,6 +708,7 @@ Is the current q.ref a faithful display of the audit-grade chapter assignment, c
 
   const finding = {
     workerId,
+    stemHash,
     stem: q.stem.slice(0, 300),
     options: q.options.map((o) => o.text.slice(0, 120)),
     optionCanonicalIdx: null,
@@ -890,7 +905,7 @@ async function runWorker(browser, workerId, stopAt, report) {
   });
   context.setDefaultTimeout(CONFIG.actionTimeoutMs);
   const page = await context.newPage();
-  const log = { workerId, actions: [], bugs: [], qsAnswered: 0 };
+  const log = { workerId, actions: [], bugs: [], qsAnswered: 0, extractNull: 0 };
 
   page.on('pageerror', async (error) => {
     let shotPath = null;

--- a/scripts/lib/hashStem.mjs
+++ b/scripts/lib/hashStem.mjs
@@ -1,0 +1,26 @@
+// Stem hash + normalization — SINGLE SOURCE OF TRUTH.
+// scripts/chaos-doctor-bot-v4.mjs (runtime) and the offline audit-8 join
+// (scripts/build_stemhash_index.mjs, supplied as a Phase-2 input) both
+// import this. Do NOT inline a second copy of djb2 — two copies drift
+// silently and break the stemHash join the AUDIT8 representativeness run
+// depends on (docs/AUDIT8_PRESTEP_INSTRUMENT_GATE.md).
+//
+// Why normStem: the bot hashes a DOM-scraped stem (extractQuestion ->
+// `.heb` innerText, which collapses whitespace and drops markup); the
+// offline index hashes the dataset `q` string. A raw djb2 of the two
+// will NOT match, so both sides hash a NORMALIZED stem. Whitespace
+// collapse only for now; if the PRE-STEP / bounded-run join match-rate
+// is low, strengthen this (e.g. strip markdown) and rebuild the index —
+// never weaken the gate.
+
+export function normStem(s) {
+  return String(s == null ? '' : s).replace(/\s+/g, ' ').trim();
+}
+
+// djb2 — deterministic across workers, no crypto cost. Returns a string
+// so it round-trips through JSON ledgers without precision loss.
+export function hashStem(s) {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  return String(h);
+}

--- a/tests/chaosBotV4PickDropInvariant.test.js
+++ b/tests/chaosBotV4PickDropInvariant.test.js
@@ -40,8 +40,18 @@ const SRC = readFileSync(
 
 // `aiIdx == null` is unique to the invalid-pick validity gate, so this
 // does not collide with the other `return { advanced: false }` sites.
+// Body-length bound widened 200 -> 300 by the AUDIT8 instrument PRE-STEP
+// (docs/AUDIT8_PRESTEP_INSTRUMENT_GATE.md). The invariant THIS regex pins
+// is *lexical ordering* — the invalid-pick gate's early `return {
+// advanced: false }` precedes the `disagrees` compute (assert 2 enforces
+// the ordering independently via offset comparison). The 200 was incidental
+// headroom, not the load-bearing property; the gate body legitimately grew
+// because G0 mandates `stemHash` + `stem` + `optCount` + `dropCtx` on the
+// `ai-parse-error/pick` drop row, all minted after this assert was written.
+// 300 covers the measured 215-char post-instrument body with margin while
+// still tripping on a genuinely large logic insertion between gate and return.
 const INVALID_PICK_GATE =
-  /if\s*\(\s*aiIdx\s*==\s*null[^)]*\)\s*\{[\s\S]{0,200}?return\s*\{\s*advanced:\s*false/;
+  /if\s*\(\s*aiIdx\s*==\s*null[^)]*\)\s*\{[\s\S]{0,300}?return\s*\{\s*advanced:\s*false/;
 const DISAGREES_DECL = /\b(?:const|let|var)\s+disagrees\s*=/g;
 // the canonical gated compute (spans two lines in source).
 const CANONICAL_COMPUTE =

--- a/tests/chaosBotV4PickIdentityInstrument.test.js
+++ b/tests/chaosBotV4PickIdentityInstrument.test.js
@@ -1,0 +1,113 @@
+// AUDIT8 instrument PRE-STEP — pick-channel + comparator identity.
+// Pins the join key the AUDIT8 representativeness bounded run depends on
+// (docs/AUDIT8_PRESTEP_INSTRUMENT_GATE.md). This is the test STEP 0.2
+// re-evaluates before the paid bounded run is authorized.
+//
+// Two-sided instrument (merged gate G0 + D4):
+//   DROP side  — :466 ai-parse-error/pick (PRIMARY, the ~11% drop) gets
+//                stemHash + stem(300) + optCount + dropCtx; :458
+//                ai-error/pick gets stemHash + dropCtx; the pre-pick
+//                early return gets a distinct, EXCLUDABLE tagged row.
+//   JUDGED side — the recordFinding `finding` object and the appIdx-null
+//                methodology recordFinding both get stemHash, keyed on the
+//                IDENTICAL hashStem(normStem(...)) the offline join uses.
+//
+// Source-pinned to the producer (mirrors chaosBotV4PickDropInvariant) +
+// shared-module determinism vectors.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { hashStem, normStem } from '../scripts/lib/hashStem.mjs';
+
+const BOT = readFileSync(
+  fileURLToPath(new URL('../scripts/chaos-doctor-bot-v4.mjs', import.meta.url)),
+  'utf8',
+);
+
+describe('AUDIT8 instrument: shared hashStem/normStem (single source of truth)', () => {
+  it('hashStem is deterministic and matches the pinned djb2 vectors', () => {
+    // Hand-verified djb2 (h0=5381): "" -> 5381 ;
+    // "a" (97) -> ((5381<<5)+5381+97)|0 = 177670.
+    expect(hashStem('')).toBe('5381');
+    expect(hashStem('a')).toBe('177670');
+    expect(hashStem('abc')).toBe(hashStem('abc'));      // deterministic
+    expect(hashStem('שאלה גריאטרית')).toBe(hashStem('שאלה גריאטרית')); // unicode-stable
+  });
+
+  it('normStem collapses whitespace so a DOM-scraped stem and the dataset `q` hash equal', () => {
+    expect(normStem('  a   b\n c ')).toBe('a b c');
+    expect(normStem('a\t\tb')).toBe('a b');
+    expect(hashStem(normStem('a  b'))).toBe(hashStem(normStem('a b')));
+    expect(hashStem(normStem('שאלה\n\nכאן'))).toBe(hashStem(normStem('שאלה כאן')));
+  });
+
+  it('normStem is null/undefined-safe (never throws on a missing stem)', () => {
+    expect(normStem(null)).toBe('');
+    expect(normStem(undefined)).toBe('');
+    expect(() => hashStem(normStem(null))).not.toThrow();
+  });
+});
+
+describe('AUDIT8 instrument: bot is source-pinned to the shared, normalized key', () => {
+  it('hashStem is imported from the shared module, NOT re-inlined (no drift)', () => {
+    expect(BOT).toMatch(
+      /import\s*\{[^}]*\bhashStem\b[^}]*\bnormStem\b[^}]*\}\s*from\s*'\.\/lib\/hashStem\.mjs'/,
+    );
+    // the inline djb2 (old :160-165) must be gone — two copies drift.
+    expect(/function\s+hashStem\s*\(/.test(BOT)).toBe(false);
+  });
+
+  it('every stem hash in the bot is the NORMALIZED hash (both code paths)', () => {
+    // main path (was :450) + pre-pick path must both hash normStem(q.stem).
+    const norm = [...BOT.matchAll(/hashStem\(\s*normStem\(\s*q\.stem\s*\)\s*\)/g)];
+    expect(norm.length).toBeGreaterThanOrEqual(2);
+    // no raw hashStem(q.stem) without normStem (would break the join).
+    expect(/hashStem\(\s*q\.stem\s*\)/.test(BOT)).toBe(false);
+  });
+});
+
+describe('AUDIT8 instrument: DROP side carries recoverable identity', () => {
+  it('the ai-parse-error/pick PRIMARY drop row carries dropCtx + stemHash + stem(300) + optCount', () => {
+    const m = BOT.match(/type:\s*'ai-parse-error'\s*,\s*context:\s*'pick'[^}]*}/);
+    expect(m, 'ai-parse-error/pick push not found').toBeTruthy();
+    expect(m[0]).toMatch(/dropCtx:\s*'pick-parse-error'/);
+    expect(m[0]).toMatch(/\bstemHash\b/);
+    expect(m[0]).toMatch(/stem:\s*q\.stem\.slice\(\s*0\s*,\s*300\s*\)/);
+    expect(m[0]).toMatch(/optCount:\s*q\.options\.length/);
+  });
+
+  it('the ai-error/pick drop row carries dropCtx + stemHash', () => {
+    const m = BOT.match(/type:\s*'ai-error'\s*,\s*context:\s*'pick'[^}]*}/);
+    expect(m, 'ai-error/pick push not found').toBeTruthy();
+    expect(m[0]).toMatch(/dropCtx:\s*'pick-ai-error'/);
+    expect(m[0]).toMatch(/\bstemHash\b/);
+  });
+
+  it('the pre-pick early return is a DISTINCT, EXCLUDABLE tagged row (not a pick-parse event)', () => {
+    const m = BOT.match(/type:\s*'pre-pick-skip'[\s\S]*?\}\)/);
+    expect(m, 'pre-pick-skip push not found').toBeTruthy();
+    // distinct type so the analyzer DROPPED filter
+    // (type in {ai-parse-error,ai-error} AND context==='pick') EXCLUDES it.
+    // dropCtx is a ternary over the two excludable pre-pick sub-contexts.
+    expect(m[0]).toMatch(/dropCtx:/);
+    expect(m[0]).toMatch(/'pre-pick-short-extract'/);
+    expect(m[0]).toMatch(/'pre-pick-no-question'/);
+    // honest denominator counter wired alongside it.
+    expect(BOT).toMatch(/log\.extractNull\s*=\s*\(log\.extractNull\s*\|\|\s*0\)\s*\+\s*1/);
+    expect(BOT).toMatch(/const log = \{[^}]*extractNull:\s*0/);
+  });
+});
+
+describe('AUDIT8 instrument: JUDGED/comparator side carries the same key', () => {
+  it('the main recordFinding `finding` object carries stemHash', () => {
+    const m = BOT.match(/const finding = \{[\s\S]*?\};/);
+    expect(m, 'finding object not found').toBeTruthy();
+    expect(m[0]).toMatch(/\bstemHash\b/);
+  });
+
+  it('the appIdx-null methodology recordFinding object carries stemHash', () => {
+    const m = BOT.match(/recordFinding\(\{[\s\S]*?methodology:\s*'appIdx-null-post-check'/);
+    expect(m, 'appIdx-null recordFinding not found').toBeTruthy();
+    expect(m[0]).toMatch(/\bstemHash\b/);
+  });
+});


### PR DESCRIPTION
**AUDIT8 horizon item 1 — G0/D4 instrument PRE-STEP.** Precursor PR that
gates the bounded representativeness run (mirrors the Option-0 instrument
PR #231 → audit-7). Authoritative spec: merged `docs/AUDIT8_PRE_REGISTERED_GATE.md`
(#233) **G0 + DELTA D4**. Trinity **untouched** (scripts/tests/docs only).

### What & why
The dropped pick population carried zero recoverable question identity,
and the judged comparator's join key (`stem.slice(0,300)`) is
truncation-fragile for ~46% of stems → the representativeness run was
**not runnable**. This instruments **both sides** on one identical,
normalized full-stem djb2 hash.

- **`scripts/lib/hashStem.mjs`** (new SSOT) — `hashStem` (djb2 verbatim)
  + `normStem`. Inline djb2 deleted from the bot; both hash sites →
  `hashStem(normStem(q.stem))`. Normalization is load-bearing: bot
  scrapes DOM innerText (whitespace-collapsed) vs index hashing dataset
  `q` — D3's ≥99% per-covariate determinate join is structurally
  impossible without it (the one corpus fact the no-run merged G0
  missed; its DELTAS mechanism is designed to absorb exactly this).
- **`:466`** ai-parse-error/pick (PRIMARY ~11% drop): `dropCtx` +
  `stemHash` + `stem(0,300)` + `optCount` (full merged-G0 set).
- **`:458`** ai-error/pick: `dropCtx:'pick-ai-error'` + `stemHash`.
- **pre-pick** early return: distinct **excludable** tagged row
  (`type:'pre-pick-skip'`) + `log.extractNull` counter.
- **`:524`** appIdx-null + **`:697`** finding `recordFinding`: `stemHash`
  (D4; `:524` a documented one-row extension — unjoinable without it).
- **GUARD `chaosBotV4PickDropInvariant`: 5/5 green post-edit** (the
  `disagrees` gate/compute is untouched — proven by the GUARD). Its
  regex body bound widened 200→300, documented in-test (invariant pinned
  = lexical ordering, not body length; G0 fields minted after the assert
  grew the body 120→215).
- **`tests/chaosBotV4PickIdentityInstrument.test.js`** (new) — the test
  STEP 0.2 re-runs before authorizing the paid bounded run.

### Verification
- `npm run verify` green — **77 files / 1441 passed + 7 skipped**, all 7
  non-vitest checks pass.
- Full `chaosBotV4*` family **122/122** (judge/bucket-rule shapes
  unperturbed — only `context:'pick'` rows edited).
- **Trinity untouched at v10.64.130** (no bump — correctly mirrors
  audit-5: an instrument precursor ships no exam content).

### Reconciliation surfaced (Phase 2, inherited — see gate doc)
The four web-lane inputs were authored @`fedf27e`, before #233's DELTAS
locked the spec. PRE-STEP scope reconciled this session (merged G0
implemented; web `INSTRUMENT_PATCH.md` `stemHash`-only superseded). The
**bounded-run scripts** (`build_stemhash_index.mjs`,
`analyze_pick_representativeness.mjs`) implement the *superseded*
web-draft G4 (5 covariates, χ²-tercile, ≥90% join, 3-way verdict) and
must be adapted to **merged G4** (6 covariates incl. topic-12 +
`year`=`t`-categorical, MW-U + Cliff's δ, effect-size floors, 4-way
verdict + logistic sensitivity, ≥99% per-cov join, N_drop≥80 ∧
N_retain≥200) before the run. Full table in
`docs/AUDIT8_PRESTEP_INSTRUMENT_GATE.md`.

### Activation order (binding, per merged gate)
`G0 PRE-STEP PR → re-pass STEP 0.2 → bounded run (G1–G5) → RESULT`. This
PR is the PRE-STEP. **Do not self-merge** (normal PR discipline; #230/#231
self-merge was a discrete explicit instruction, not a precedent). The
bounded run is the explicit next session, gated behind this merging to
`main` + a STEP 0.2 re-pass. Does not collide with PR #234 (web lane's
cosmetic `supabase/migrations/` cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)