### PR TITLE
feat(audit-8): frozen pick-representativeness analysis tooling (pre-registration; no trinity bump)

### DIFF
--- a/docs/AUDIT8_ANALYSIS_TOOLING_CROSSWALK.md
+++ b/docs/AUDIT8_ANALYSIS_TOOLING_CROSSWALK.md
@@ -1,0 +1,128 @@
+# Audit-8 — analysis tooling ⇄ gate crosswalk (PRE-REGISTRATION FREEZE RECORD)
+
+**THIS IS NOT A GATE.** The single binding pre-registration is the merged,
+on-`main` `docs/AUDIT8_PRE_REGISTERED_GATE.md` (#233, G0–G5 + DELTAS
+D1–D4) plus its execution record `docs/AUDIT8_PRESTEP_INSTRUMENT_GATE.md`
+(#235). This document re-derives **no** threshold, test, covariate, or
+verdict rule. It transcribes each locked clause to the exact code site
+that implements it, with file:line, so the web-lane fresh-eye reviewer
+can check faithfulness against the gate **before any paid run**. If this
+doc and the on-main gate ever disagree, **the gate wins and this doc is
+the bug** (gate SHIP: "the data does not get to reshape it"; prestep
+Reconciliation: "where they diverge, the merged gate wins").
+
+Append-only (`feedback_spec_provenance_append_only`). Authored on
+`claude/term-audit8-bounded-run` (cut from `origin/main` `cc85f91`),
+**blind to any run data** — the bounded run has not been executed and
+MUST NOT be until this tooling is merged and STEP 0.2 re-passes
+(activation order is binding: G0 PRE-STEP PR → re-pass STEP 0.2 →
+bounded run → RESULT). Trinity: **untouched** — `scripts/` + `tests/` +
+`docs/` only, no bump (mirrors audit-5/6/7 + the #235 PRE-STEP).
+
+The set-aside web-draft scripts (`build_stemhash_index.mjs`,
+`analyze_pick_representativeness.mjs`) are **not on disk** in this tree
+(prior instance pushed nothing; they were never committed here). They
+are NOT used as a base. The tooling below is rebuilt from the on-main
+gate clause-by-clause; only domain-neutral numerical methods (regularized
+incomplete-gamma χ² tail, Fisher exact hypergeometric, Mann–Whitney U
+normal approx, IRLS logistic) are implemented from standard references,
+unit-pinned against hand-computed constants — nothing carried from the
+set-aside criterion-swapped artifact.
+
+---
+
+## Files (locked product code; `scripts/` + `tests/`; no trinity bump)
+
+| File | Role |
+|---|---|
+| `scripts/lib/audit8Stats.mjs` | Pure, side-effect-free numerical methods. Unit-pinned. |
+| `scripts/build_stemhash_index.mjs` | Offline join index from `data/questions.json` — the path `scripts/lib/hashStem.mjs:3` already forward-references. |
+| `scripts/analyze_pick_representativeness.mjs` | Frozen analyzer: G4.1 universe → G3 join → 6-cov family → Holm → floors → logistic sensitivity → G2 → G4.5 verdict. Reads a ledger dir; emits a structured report. **No data-dependent branch beyond the pre-registered ones.** |
+| `tests/audit8Stats.test.js` | Stats vs known reference values (scipy-equivalent hand constants). |
+| `tests/audit8AnalyzeRepresentativeness.test.js` | Universe/exclusion/join/verdict logic vs **synthetic** fixtures only — never real run data (pre-registration). |
+
+---
+
+## Clause ⇄ implementation crosswalk (binding source = on-main gate)
+
+### Universe & outcome — gate **G4.1**
+
+| Locked clause | Implementation |
+|---|---|
+| DROPPED (=1) = "dropped at the `:465` pick gate" = the invalid-parsed-pick path | rows where `type==='ai-parse-error' && context==='pick'` (instrumented `dropCtx:'pick-parse-error'`, bot `:480`). |
+| RETAINED (=0) = "reached the judge" | `recordFinding` `finding` objects (bot `:709–724`); carry `disagrees` + full-stem `stemHash` (D4 / #235 item 6). |
+| EXCLUDE pre-pick DOM/short-extract (`:448` class) — "not pick-parse events" | rows where `type==='pre-pick-skip'` (bot `:457`, `dropCtx:'pre-pick-short-extract'|'pre-pick-no-question'`). **Keyed on `type`, never on `context:'pick'` alone** (prestep P2: pre-pick shares `context:'pick'` with real drops). Counted via `log.extractNull` for an honest denominator; **not** analyzed for bias. |
+| `:458` `ai-error/pick` network throws — "distinct path, reported separately, NOT in the parse-drop numerator" | rows where `type==='ai-error' && context==='pick'` (`dropCtx:'pick-ai-error'`, bot `:472`). Emitted as a **separate count**; excluded from the binary outcome's DROPPED cell. |
+| `appIdx-null` `recordFinding` (passes pick gate, never reaches judge) | `context==='appIdx-null-post-check'` — neither DROPPED nor RETAINED; separate count (prestep item 5 gave it `stemHash` to keep this bookkeeping non-silent). |
+| G3 join failures | counted, excluded, never imputed (G3). |
+
+### Join fidelity — gate **G3 as superseded by D3**
+
+| Locked clause | Implementation |
+|---|---|
+| Primary key = exact full-stem `stemHash`, "re-hash each `questions.json` stem with the bot's djb2" | `hashStem(normStem(q))` via the on-main SSOT `scripts/lib/hashStem.mjs` (imported, **not** re-implemented — the SSOT module exists to prevent a second drifting djb2). Also index `hashStem(normStem(q_en))` when `q_en` present, so a bilingual-toggled DOM extraction still joins; covariate values are variant-invariant and `stem_len` is **always** canonical `q` length per G4.2 (the matched variant never changes a covariate). |
+| Fallback (2) = whitespace/BIDI-normalized stem-slice containment | normalized containment of the ledger row's `stem` slice (≤300) against `normStem(q)`/`normStem(q_en)`. |
+| D3: global ≥95% is structurally unsatisfiable (3586/3743=95.81% ceiling; 157 byte-identical groups; `allow_dup`=936 **SANCTIONED — do NOT dedupe**) | no dedupe. Dup rows grouped by byte-identical `q`. |
+| D3 new invariant: **per-covariate determinate-join rate ≥ 99%** after collapsing covariate-invariant dup groups; only covariate-**discordant** dup cells dropped | per covariate: a dup group all-agreeing on X joins determinately to X regardless of which member a row maps to; discordant groups drop **only that covariate's** cell (D3-verified discord: `broken` 2/157, `topic` 13/157, others 0). Each covariate's determinate-join rate computed and gated ≥99% independently; below 99% on a covariate ⇒ STOP+report for that covariate (D3 replaces the global-≥95% STOP). |
+
+### Covariate family — gate **G4.2 as superseded by D1 + D2 → 6**
+
+| # | Covariate | Operationalization (locked) | Primary test | Effect size / floor |
+|---|---|---|---|---|
+| 1 | `stem_len` | char length of canonical joined `q` | **Mann–Whitney U** (dropped vs retained) | **Cliff's δ**, floor \|δ\|≥**0.15** |
+| 2 | `topic` | `ti` → repo's **12 `TOPIC_GROUPS`** (parsed from `shlav-a-mega.html:5082`, not hard-copied); expected-cell-<5 groups pooled to "other" **before** the test (locked) | **χ²** independence 2×k | **Cramér's V**, floor ≥**0.10** |
+| 3 | `bilingual` | presence of `q_en` | **Fisher exact** 2×2 | **Cramér's V (φ)**, floor ≥**0.10** |
+| 4 | `t` (was `year`) | **D1**: `t` field as **categorical** (18 levels), **same expected-cell-<5 pooling rule as `topic`** — NOT the superseded binary real-IMA-vs-AI Fisher | **χ²** independence 2×k | **Cramér's V**, floor ≥**0.10** |
+| 5 | `c_accept` | **D2**: binary, non-empty `c_accept[]` | **Fisher exact** 2×2 | **Cramér's V (φ)**, floor ≥**0.10** |
+| 6 | `broken` | **D2**: binary, `broken===true`. **Vacuity contingency**: analyzer computes `N_broken_served` over the joined universe; if `0`, `broken` is **vacuous → dropped from the family → Holm over 5**. (Empirical from the sample, NOT assumed from memory — `feedback_verify_simulator_findings`.) | **Fisher exact** 2×2 | **Cramér's V (φ)**, floor ≥**0.10** |
+
+### Test family & sensitivity — gate **G4.3**
+
+| Locked clause | Implementation |
+|---|---|
+| The marginal tests are the PRIMARY family; two-sided, α=0.05, **Holm–Bonferroni** across all | Holm over the 6 (or 5 if `broken` vacuous) marginal p-values; ordering + step-down per Holm (1979). |
+| Joint logistic = **locked SENSITIVITY only**; **verdict NEVER keyed on the logistic** (locked to remove the post-hoc "which model" DOF) | logistic reported as sensitivity; the G4.5 verdict reads **only** the primary marginal family + floors. |
+| **SURFACED REASONED RECONCILIATION (the one judgment call, non-apologetic per Working Rule 1).** G4.3's written formula `dropped ~ z(stem_len)+bilingual+C(topic_group)+ai_generated` is the **4-covariate-era** model; D1/D2 expanded the *family* to 6 and explicitly "supersede the G4.2 covariate table". The logistic's locked *purpose* is "whether a marginal signal survives **mutual adjustment**" — that purpose requires the adjusting set = the family, else it cannot adjust for `c_accept`/`broken`/`t` and the stated confound example generalizes. Faithful realization: the sensitivity model = the **locked family**: `dropped ~ z(stem_len) + bilingual + c_accept + broken + C(topic_group) + C(t_pooled)` (`t_pooled`/`topic` use the same <5 pooling as their marginal tests; `broken` dropped from the model too if vacuous). This **mirrors the gate's own D1/D2 precedent** (reconcile toward the authoritative/locked set, surface non-apologetically) and is **verdict-neutral** (G4.3 locks the verdict off the logistic). Recorded here and in the PR so the trail shows *why* the model is 6-term: faithful extension of a locked sensitivity purpose under D1/D2's family expansion — not scope creep, not a verdict lever. |
+
+### Effect-size floors — gate **G4.4** (verbatim)
+bias signal iff primary test **Holm-significant AND** effect ≥ floor:
+Cliff's \|δ\|≥**0.15** (`stem_len`); Cramér's V≥**0.10** (every categorical).
+Holm-sig but below floor = *detectable-but-negligible*.
+
+### Verdict — gate **G4.5** (4-way, verbatim; stands per reconciliation)
+
+| Condition | Verdict |
+|---|---|
+| ≥1 covariate is a bias signal (Holm-sig **and** ≥floor) | **BIASED** |
+| ≥1 Holm-sig but **all** such <floor | **DETECTABLE-BUT-NEGLIGIBLE** |
+| **0** Holm-sig **and** G2 min-N met | **REPRESENTATIVE** |
+| **0** Holm-sig **and** G2 min-N **not** met | **INCONCLUSIVE** |
+
+### Power / run-validity — gate **G2** (analyzer-side only)
+`N_drop ≥ 80` **and** `N_retain ≥ 200` after the G3 join → "adequately
+powered". Either unmet → under-powered → feeds the G4.5 INCONCLUSIVE
+branch. `N_drop == 0` while the instrument is live → drop-rate-collapsed
+**finding → STOP, report** (not an expected branch). The G1 budget /
+G2 run-config ($20 cap, 1 worker, `claude-sonnet-4-6`, proxy, 8 h,
+fresh `chaos-reports/v4-long/audit8_<ts>/`) is the **bounded-run
+session's** concern — the analyzer only consumes the produced ledger.
+
+---
+
+## Pre-registration invariants the tooling enforces on itself
+
+1. **Frozen before run.** No CLI flag, env var, or code path tunes a
+   test, threshold, covariate, or verdict from observed data. The only
+   data-conditional behavior is the **pre-registered** ones: `broken`
+   vacuity (N_broken_served==0), expected-cell-<5 pooling, dup-group
+   covariate-discord drop, join-fail exclusion, G2 power branch.
+2. **Determinism.** Same ledger + same `data/questions.json` ⇒ identical
+   verdict. No randomness, no time, no network.
+3. **Read-only.** The analyzer flips no `q.c`, changes no `broken`,
+   touches no Toranot file, appends **no** RESULT to the gate doc (the
+   RESULT is appended by the bounded-run session per the gate's SHIP
+   clause). It writes only its own report file.
+4. **Verdict isolation.** The 4-way verdict function takes only the
+   primary marginal family + floors + G2 N's. The logistic result is
+   passed to the *report*, never to the verdict function (G4.3 lock,
+   enforced by signature).

--- a/scripts/analyze_pick_representativeness.mjs
+++ b/scripts/analyze_pick_representativeness.mjs
@@ -1,0 +1,445 @@
+// Audit-8 — FROZEN pick-channel representativeness analyzer.
+//
+// Binding spec: docs/AUDIT8_PRE_REGISTERED_GATE.md (#233 G2/G3/G4/G5 +
+// DELTAS D1–D4). Clause⇄code map: docs/AUDIT8_ANALYSIS_TOOLING_CROSSWALK.md.
+//
+// PRE-REGISTRATION INVARIANT: authored blind to run data. No flag/env/code
+// path tunes a test, threshold, covariate, or verdict from observed data.
+// The only data-conditional behavior is the PRE-REGISTERED set: `broken`
+// vacuity (N_broken_served==0 → drop from family), expected-cell-<5
+// pooling, dup-group covariate-discord drop, join-fail exclusion, the G2
+// power branch, the N_drop==0 STOP. Deterministic, read-only: flips no
+// `q.c`, changes no `broken`, touches no Toranot file, appends NO RESULT
+// to the gate doc (the bounded-run session does that per the gate SHIP
+// clause) — writes only its own report file.
+
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { hashStem, normStem } from './lib/hashStem.mjs';
+import { buildIndex } from './build_stemhash_index.mjs';
+import {
+  chiSquareIndependence,
+  fisherExact2x2,
+  mannWhitneyAndCliffs,
+  holmBonferroni,
+  logisticRegressionIRLS,
+  zscore,
+} from './lib/audit8Stats.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+const ALPHA = 0.05;
+const FLOOR_DELTA = 0.15;   // G4.4: Cliff's |δ| floor (stem_len)
+const FLOOR_V = 0.10;       // G4.4: Cramér's V floor (categoricals)
+const MIN_N_DROP = 80;      // G2
+const MIN_N_RETAIN = 200;   // G2
+const JOIN_DETERMINATE_MIN = 0.99; // D3: per-covariate determinate-join rate
+
+const CATEGORICAL = ['topic_group', 't', 'bilingual', 'c_accept', 'broken'];
+const ALL_COVS = ['stem_len', ...CATEGORICAL];
+
+// ---- ledger ingestion ------------------------------------------------
+
+function loadLedger(reportDir) {
+  const files = readdirSync(reportDir);
+  const summaries = files.filter((f) => /^chaos-doctor-v4-.*\.json$/.test(f));
+  const jsonl = files.filter((f) => f === 'medical_findings_ai_v4.jsonl');
+  if (!summaries.length) {
+    throw new Error(`No chaos-doctor-v4-*.json summary in ${reportDir} — cannot recover the drop rows (gate G4.1 numerator).`);
+  }
+  const bugs = [];
+  let extractNull = 0;
+  for (const s of summaries) {
+    const rep = JSON.parse(readFileSync(path.join(reportDir, s), 'utf-8'));
+    for (const w of rep.workers || []) {
+      extractNull += Number(w.extractNull || 0);
+      for (const b of w.bugs || []) bugs.push(b);
+    }
+  }
+  const findings = [];
+  for (const j of jsonl) {
+    const txt = readFileSync(path.join(reportDir, j), 'utf-8');
+    for (const line of txt.split('\n')) {
+      const t = line.trim();
+      if (!t) continue;
+      try { findings.push(JSON.parse(t)); } catch { /* skip a torn final line */ }
+    }
+  }
+  return { bugs, findings, extractNull };
+}
+
+// ---- G4.1 universe classification -----------------------------------
+
+function classifyUniverse({ bugs, findings, extractNull }) {
+  // DROPPED (=1): the ~11% invalid-parsed-pick at the :465 gate.
+  const dropped = bugs.filter((b) => b.type === 'ai-parse-error' && b.context === 'pick');
+  // Separate (NOT numerator): network/throw before parse — G4.1.
+  const aiErrorPick = bugs.filter((b) => b.type === 'ai-error' && b.context === 'pick');
+  // Excluded: pre-pick DOM/short-extract — keyed on TYPE, never on
+  // context:'pick' alone (it shares context:'pick' with real drops).
+  const prePickSkip = bugs.filter((b) => b.type === 'pre-pick-skip');
+  // RETAINED (=0): reached the judge — main finding carries a judge
+  // verdict + boolean `disagrees`.
+  const retained = findings.filter((f) => f.judge != null && typeof f.disagrees === 'boolean');
+  // appIdx-null: passed the pick gate, never reached the judge — neither
+  // DROPPED nor RETAINED (separate count; carries stemHash so the
+  // bookkeeping is non-silent, prestep item 5).
+  const appIdxNull = findings.filter((f) => f.methodology === 'appIdx-null-post-check'
+    || (f.judge == null && f.disagrees === null));
+  return { dropped, retained, aiErrorPick, prePickSkip, appIdxNull, extractNull };
+}
+
+// ---- G3 / D3 join ----------------------------------------------------
+
+// Returns, per row, a map covariate→value where DETERMINATE, else the
+// covariate is absent (D3: a dup group agreeing on X joins determinately
+// to X; only covariate-discordant dup cells are dropped — per covariate,
+// not whole-row). `joined:false` ⇒ no hash/containment match at all
+// (G3 join failure: counted, excluded, never imputed).
+function joinRow(stemHashVal, stemSlice, index, qNorm) {
+  let bucket = stemHashVal != null ? index.byHash[String(stemHashVal)] : undefined;
+  let via = 'stemHash';
+  if (!bucket || !bucket.length) {
+    // Fallback (2): normalized stem-slice containment.
+    if (!stemSlice) return { joined: false };
+    const needle = normStem(stemSlice);
+    if (!needle) return { joined: false };
+    const hits = [];
+    for (let i = 0; i < qNorm.length; i++) {
+      const hay = qNorm[i];
+      if (hay && (hay.includes(needle) || needle.includes(hay))) hits.push(i);
+      if (hits.length > 8) break; // ambiguous enough; treated as a dup bucket
+    }
+    if (!hits.length) return { joined: false };
+    bucket = hits;
+    via = 'containment';
+  }
+  const covs = {};
+  for (const c of ALL_COVS) {
+    const v0 = JSON.stringify(index.rows[bucket[0]][c]);
+    const agree = bucket.every((i) => JSON.stringify(index.rows[i][c]) === v0);
+    if (agree) covs[c] = index.rows[bucket[0]][c]; // determinate for X
+    // else: covariate-discordant dup cell → omit X for this row (D3)
+  }
+  return { joined: true, via, bucketSize: bucket.length, covs };
+}
+
+function buildQNorm(index, questionsPath) {
+  // For the containment fallback we need the normalized canonical text.
+  // Re-read questions.json so the index stays lean and questions.json is
+  // the single source for stem text.
+  const QZ = JSON.parse(readFileSync(questionsPath, 'utf-8'));
+  return QZ.map((r) => normStem(String(r.q == null ? '' : r.q)));
+}
+
+// ---- main analysis ---------------------------------------------------
+
+function analyze({ reportDir, index, questionsPath }) {
+  const ledger = loadLedger(reportDir);
+  const u = classifyUniverse(ledger);
+  const qNorm = buildQNorm(index, questionsPath);
+
+  // Join every dropped + retained row; per-covariate determinate tallies.
+  const joinTally = {};       // cov → {determinate, attempted}
+  for (const c of ALL_COVS) joinTally[c] = { determinate: 0, attempted: 0 };
+  let joinFailDrop = 0;
+  let joinFailRetain = 0;
+
+  function project(rows, isDrop) {
+    // → { byCov: {cov:[values]}, _rows:[per-row determinate covmap], nJoined }
+    const byCov = {};
+    for (const c of ALL_COVS) byCov[c] = [];
+    const _rows = [];
+    let nJoined = 0;
+    for (const r of rows) {
+      const j = joinRow(r.stemHash, r.stem, index, qNorm);
+      if (!j.joined) { if (isDrop) joinFailDrop++; else joinFailRetain++; continue; }
+      nJoined++;
+      _rows.push(j.covs); // determinate-only covariate map for this row
+      for (const c of ALL_COVS) {
+        joinTally[c].attempted++;
+        if (c in j.covs) {
+          joinTally[c].determinate++;
+          byCov[c].push(j.covs[c]);
+        }
+      }
+    }
+    return { byCov, _rows, nJoined };
+  }
+  const D = project(u.dropped, true);
+  const R = project(u.retained, false);
+
+  const Ndrop = D.nJoined;
+  const Nretain = R.nJoined;
+
+  // Pre-registered STOP: instrument live but the drop population is empty
+  // is NOT an expected branch (G2).
+  if (u.dropped.length === 0) {
+    return stopReport('N_drop==0 — drop-rate-collapsed finding (not a verdict). '
+      + 'Instrument is live (STEP 0.2 re-passed) yet zero ai-parse-error/pick rows. '
+      + 'Per G2 this is itself a finding → STOP, report.', { ledger: summarize(u), Ndrop, Nretain });
+  }
+
+  // D3: per-covariate determinate-join rate ≥ 99%. A covariate below the
+  // floor is join-unreliable → dropped from the family + flagged; if ANY
+  // is violated the analyzer refuses to route a verdict (D3 "do not
+  // route" intent — replaces the unsatisfiable global ≥95% STOP).
+  const joinRates = {};
+  const joinViolations = [];
+  for (const c of ALL_COVS) {
+    const t = joinTally[c];
+    const rate = t.attempted ? t.determinate / t.attempted : 0;
+    joinRates[c] = { rate, ...t };
+    if (rate < JOIN_DETERMINATE_MIN) joinViolations.push(c);
+  }
+
+  // ---- the 6-covariate marginal family (G4.2 + D1 + D2) -------------
+  // broken vacuity (D2): N_broken_served over the joined universe.
+  const brokenServed =
+    D.byCov.broken.filter((v) => v === true).length +
+    R.byCov.broken.filter((v) => v === true).length;
+  const brokenVacuous = brokenServed === 0;
+
+  const tests = {}; // cov → {test, stat, p, effect, effectName, floor, ...}
+
+  // stem_len — Mann–Whitney U + Cliff's δ
+  if (!joinViolations.includes('stem_len')) {
+    const mw = mannWhitneyAndCliffs(D.byCov.stem_len, R.byCov.stem_len);
+    tests.stem_len = {
+      test: 'mann-whitney-u', U: mw.U, z: mw.z, p: mw.p,
+      effectName: "cliff's-delta", effect: mw.delta, floor: FLOOR_DELTA,
+      nDrop: mw.n1, nRetain: mw.n2,
+    };
+  }
+
+  // categorical χ² (topic_group, t) with locked <5 pooling
+  for (const c of ['topic_group', 't']) {
+    if (joinViolations.includes(c)) continue;
+    const levels = [...new Set([...D.byCov[c], ...R.byCov[c]].map(String))].sort();
+    const cntD = levels.map((L) => D.byCov[c].filter((v) => String(v) === L).length);
+    const cntR = levels.map((L) => R.byCov[c].filter((v) => String(v) === L).length);
+    const x = chiSquareIndependence(cntD, cntR, levels);
+    tests[c] = {
+      test: 'chi-square-2xk', chi2: x.chi2, df: x.df, p: x.p,
+      effectName: "cramers-v", effect: x.cramersV, floor: FLOOR_V,
+      levelsAfterPooling: x.pooledLevels.length,
+    };
+  }
+
+  // binary Fisher exact (bilingual, c_accept, broken[unless vacuous])
+  for (const c of ['bilingual', 'c_accept', 'broken']) {
+    if (joinViolations.includes(c)) continue;
+    if (c === 'broken' && brokenVacuous) continue;
+    const a = D.byCov[c].filter((v) => v === true).length;
+    const b = D.byCov[c].filter((v) => v === false).length;
+    const cc = R.byCov[c].filter((v) => v === true).length;
+    const d = R.byCov[c].filter((v) => v === false).length;
+    const f = fisherExact2x2([[a, b], [cc, d]]);
+    tests[c] = {
+      test: 'fisher-exact-2x2', table: [[a, b], [cc, d]], p: f.p,
+      effectName: "cramers-v(phi)", effect: Math.abs(f.phi), floor: FLOOR_V,
+    };
+  }
+
+  // ---- G4.3 Holm across the PRIMARY marginal family ----------------
+  const family = Object.keys(tests);
+  const holm = holmBonferroni(family.map((k) => ({ key: k, p: tests[k].p })), ALPHA);
+  const holmByKey = Object.fromEntries(holm.map((h) => [h.key, h]));
+  for (const k of family) {
+    tests[k].pAdj = holmByKey[k].pAdj;
+    tests[k].holmReject = holmByKey[k].reject;
+    const meetsFloor = Math.abs(tests[k].effect) >= tests[k].floor;
+    tests[k].meetsFloor = meetsFloor;
+    tests[k].biasSignal = holmByKey[k].reject && meetsFloor; // G4.4
+  }
+
+  // ---- G4.3 logistic SENSITIVITY (surfaced reconciliation: the family,
+  // not the 4-era formula — verdict-NEUTRAL; see crosswalk) -----------
+  const logistic = runLogisticSensitivity(D, R, brokenVacuous, joinViolations);
+
+  // ---- G4.5 verdict (keyed ONLY on the primary marginal family) -----
+  const anyBiasSignal = family.some((k) => tests[k].biasSignal);
+  const anyHolmSig = family.some((k) => tests[k].holmReject);
+  const powered = Ndrop >= MIN_N_DROP && Nretain >= MIN_N_RETAIN;
+
+  let verdict;
+  if (joinViolations.length) {
+    verdict = 'STOP-JOIN-INTEGRITY'; // D3: do not route on an unreliable join
+  } else if (anyBiasSignal) {
+    verdict = 'BIASED';
+  } else if (anyHolmSig) {
+    verdict = 'DETECTABLE-BUT-NEGLIGIBLE';
+  } else if (powered) {
+    verdict = 'REPRESENTATIVE';
+  } else {
+    verdict = 'INCONCLUSIVE';
+  }
+
+  return {
+    schema: 'audit8-representativeness-result/1',
+    generatedBy: 'scripts/analyze_pick_representativeness.mjs',
+    boundOnMainGate: 'docs/AUDIT8_PRE_REGISTERED_GATE.md (#233 G4 + D1–D4)',
+    verdict,
+    g2: { Ndrop, Nretain, MIN_N_DROP, MIN_N_RETAIN, powered },
+    g3d3: {
+      perCovariateDeterminateJoinRate: joinRates,
+      threshold: JOIN_DETERMINATE_MIN,
+      violations: joinViolations,
+      joinFailDrop, joinFailRetain,
+    },
+    family,
+    brokenVacuous, brokenServed,
+    tests,
+    logisticSensitivity: logistic,
+    ledger: summarize(u),
+    g5route: g5RouteFor(verdict),
+  };
+}
+
+function runLogisticSensitivity(D, R, brokenVacuous, joinViolations) {
+  // dropped ~ z(stem_len) + bilingual + c_accept + broken? + C(topic_group) + C(t_pooled)
+  // (the locked family — see crosswalk's surfaced reconciliation; this is
+  // SENSITIVITY only, the G4.5 verdict never reads it.)
+  const usable = ['stem_len', 'topic_group', 't', 'bilingual', 'c_accept', 'broken']
+    .filter((c) => !joinViolations.includes(c))
+    .filter((c) => !(c === 'broken' && brokenVacuous));
+  // Build a row only when ALL usable covariates are determinate for it,
+  // so the design matrix is rectangular and honest (no imputation).
+  const rows = [];
+  const y = [];
+  const collect = (P, label) => {
+    for (let i = 0; i < P._rows.length; i++) {
+      const rec = P._rows[i];
+      if (usable.every((c) => c in rec)) { rows.push(rec); y.push(label); }
+    }
+  };
+  if (!D._rows || !R._rows) return { skipped: 'per-row covariate vectors unavailable' };
+  collect(D, 1); collect(R, 0);
+  if (rows.length < 30 || new Set(y).size < 2) {
+    return { skipped: `insufficient complete-case rows (n=${rows.length})` };
+  }
+  // Categorical dummies (drop-first) for topic_group and t.
+  const catLevels = {};
+  for (const c of ['topic_group', 't']) {
+    if (!usable.includes(c)) continue;
+    catLevels[c] = [...new Set(rows.map((r) => String(r[c])))].sort();
+  }
+  const stemZ = zscore(rows.map((r) => r.stem_len));
+  const X = rows.map((r, i) => {
+    const xr = [];
+    if (usable.includes('stem_len')) xr.push(stemZ[i]);
+    if (usable.includes('bilingual')) xr.push(r.bilingual ? 1 : 0);
+    if (usable.includes('c_accept')) xr.push(r.c_accept ? 1 : 0);
+    if (usable.includes('broken')) xr.push(r.broken ? 1 : 0);
+    for (const c of ['topic_group', 't']) {
+      if (!usable.includes(c)) continue;
+      const lv = catLevels[c];
+      for (let k = 1; k < lv.length; k++) xr.push(String(r[c]) === lv[k] ? 1 : 0);
+    }
+    return xr;
+  });
+  const fit = logisticRegressionIRLS(X, y, { maxIter: 100, tol: 1e-9 });
+  // Label the non-intercept terms in order.
+  const terms = ['(intercept)'];
+  if (usable.includes('stem_len')) terms.push('z(stem_len)');
+  if (usable.includes('bilingual')) terms.push('bilingual');
+  if (usable.includes('c_accept')) terms.push('c_accept');
+  if (usable.includes('broken')) terms.push('broken');
+  for (const c of ['topic_group', 't']) {
+    if (!usable.includes(c)) continue;
+    const lv = catLevels[c];
+    for (let k = 1; k < lv.length; k++) terms.push(`${c}=${lv[k]}`);
+  }
+  return {
+    note: 'SENSITIVITY ONLY — G4.3 locks the verdict OFF the logistic. '
+      + 'Model = the locked 6-cov family (crosswalk surfaced reconciliation), not the 4-era formula.',
+    n: rows.length, converged: fit.converged, reason: fit.reason,
+    terms,
+    coef: fit.coef, se: fit.se, z: fit.z, p: fit.p,
+  };
+}
+
+function summarize(u) {
+  return {
+    N_dropped_ai_parse_error_pick: u.dropped.length,
+    N_ai_error_pick_separate: u.aiErrorPick.length,
+    N_pre_pick_skip_excluded: u.prePickSkip.length,
+    N_extractNull_counter: u.extractNull,
+    N_retained_judged: u.retained.length,
+    N_appIdxNull_excluded: u.appIdxNull.length,
+  };
+}
+
+function g5RouteFor(verdict) {
+  switch (verdict) {
+    case 'REPRESENTATIVE':
+      return 'G5: disagrees population unbiased on tested axes; close the pick-channel '
+        + 'representativeness horizon; horizon item 2 (Geri judge max_tokens) UNBLOCKED '
+        + '(own session+gate). No retroactive re-adjudication.';
+    case 'DETECTABLE-BUT-NEGLIGIBLE':
+      return 'G5: route as REPRESENTATIVE for the horizon (item 2 unblocked) PLUS a recorded '
+        + 'caveat stating the bounded bias magnitude (below-floor effect sizes + CIs). No re-run.';
+    case 'BIASED':
+      return 'G5: biased subsample on the named axis/axes. Triggers (each own session/gate, '
+        + 'none in this lane): (a) pick-side robustness hardening; (b) retroactive-reach '
+        + 'characterization (DOCUMENT, do not auto-rerun; no q.c flip, no broken change); '
+        + '(c) horizon item 2 stays gated behind the de-bias.';
+    case 'INCONCLUSIVE':
+      return 'G5: report histogram + power analysis; recommend a specifically sized larger '
+        + 'bounded run (state target N_drop); force NO verdict; trigger NO downstream; '
+        + 'item 2 remains blocked.';
+    case 'STOP-JOIN-INTEGRITY':
+      return 'D3: ≥1 covariate determinate-join rate < 99% → do NOT route a verdict. '
+        + 'Report the offending covariate(s); the bounded run/instrument join must be '
+        + 'repaired (e.g. strengthen normStem) before a representativeness verdict stands.';
+    default:
+      return 'unknown';
+  }
+}
+
+function stopReport(reason, extra) {
+  return { schema: 'audit8-representativeness-result/1', verdict: 'STOP', reason, ...extra };
+}
+
+// ---- CLI -------------------------------------------------------------
+function parseArgs() {
+  const a = process.argv;
+  const get = (flag, def) => { const i = a.indexOf(flag); return i !== -1 ? a[i + 1] : def; };
+  return {
+    reportDir: get('--report-dir', null),
+    indexPath: get('--index', null),
+    out: get('--out', null),
+    questionsPath: get('--questions', path.join(REPO_ROOT, 'data', 'questions.json')),
+    htmlPath: get('--html', path.join(REPO_ROOT, 'shlav-a-mega.html')),
+  };
+}
+
+export { analyze, classifyUniverse, joinRow, loadLedger };
+
+const isMain = process.argv[1] && process.argv[1].endsWith('analyze_pick_representativeness.mjs');
+if (isMain) {
+  const args = parseArgs();
+  if (!args.reportDir) {
+    console.error('usage: node scripts/analyze_pick_representativeness.mjs --report-dir <dir> [--index <idx.json>] [--out <result.json>]');
+    process.exit(2);
+  }
+  const index = args.indexPath
+    ? JSON.parse(readFileSync(args.indexPath, 'utf-8'))
+    : buildIndex({ questionsPath: args.questionsPath, htmlPath: args.htmlPath });
+  const result = analyze({ reportDir: args.reportDir, index, questionsPath: args.questionsPath });
+  const out = args.out || path.join(args.reportDir, 'audit8_representativeness_result.json');
+  writeFileSync(out, JSON.stringify(result, null, 2));
+  console.log('═══ AUDIT-8 pick-channel representativeness ═══');
+  console.log('VERDICT:', result.verdict);
+  if (result.reason) console.log('reason :', result.reason);
+  if (result.g2) console.log('G2     :', JSON.stringify(result.g2));
+  if (result.ledger) console.log('ledger :', JSON.stringify(result.ledger));
+  if (result.g3d3) console.log('join   : violations=' + JSON.stringify(result.g3d3.violations));
+  if (result.g5route) console.log('G5     :', result.g5route);
+  console.log('wrote  :', out);
+  console.log('NOTE: this analyzer produces the verdict only. The RESULT section is appended '
+    + 'to docs/AUDIT8_PRE_REGISTERED_GATE.md by the bounded-run session (gate SHIP clause), '
+    + 'after web-lane fresh-eye review.');
+}

--- a/scripts/build_stemhash_index.mjs
+++ b/scripts/build_stemhash_index.mjs
@@ -1,0 +1,140 @@
+// Audit-8 — offline stemHash → covariate join index from
+// data/questions.json. Forward-referenced by scripts/lib/hashStem.mjs:3.
+//
+// Binding spec: docs/AUDIT8_PRE_REGISTERED_GATE.md (#233 G3/D3 + G4.2/D1/D2).
+// Crosswalk: docs/AUDIT8_ANALYSIS_TOOLING_CROSSWALK.md.
+//
+// Rebuilt clause-by-clause from the on-main gate — NOT derived from the
+// set-aside web-draft `build_stemhash_index.mjs` (which is not on disk and
+// implements the superseded 5-covariate `chapter` set; merged G4 wins).
+//
+// Deterministic, read-only. Hashes BOTH `q` and `q_en` (bilingual toggle:
+// the bot may DOM-extract either variant; covariates are variant-invariant
+// and stem_len is ALWAYS canonical `q` length per G4.2, so the matched
+// variant never changes a covariate value — D3 join determinacy).
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { hashStem, normStem } from './lib/hashStem.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+// Parse the canonical 12 TOPIC_GROUPS straight from the monolith so this
+// tool can never drift from the app's own grouping (the exact hazard
+// scripts/lib/hashStem.mjs warns about for djb2 — same discipline here).
+export function parseTopicGroups(htmlPath) {
+  const html = readFileSync(htmlPath, 'utf-8');
+  const m = html.match(/const\s+TOPIC_GROUPS\s*=\s*\[([\s\S]*?)\];/);
+  if (!m) throw new Error('build_stemhash_index: TOPIC_GROUPS block not found in ' + htmlPath);
+  const body = m[1];
+  const groups = [];
+  // Each entry: {title:'…', emoji:'…', tis:[…]},
+  const entryRe = /\{[^}]*?title:\s*'([^']*)'[^}]*?tis:\s*\[([^\]]*)\][^}]*?\}/g;
+  let e;
+  while ((e = entryRe.exec(body)) !== null) {
+    const title = e[1];
+    const tis = e[2]
+      .split(',')
+      .map((s) => parseInt(s.trim(), 10))
+      .filter((n) => Number.isInteger(n));
+    groups.push({ title, tis });
+  }
+  if (groups.length !== 12) {
+    throw new Error(
+      `build_stemhash_index: expected 12 TOPIC_GROUPS, parsed ${groups.length} (gate G4.2 locks the repo's 12)`,
+    );
+  }
+  const tiToGroup = {};
+  groups.forEach((g, gi) => g.tis.forEach((ti) => { tiToGroup[ti] = gi; }));
+  return { groups, tiToGroup };
+}
+
+function covariatesFor(row, tiToGroup) {
+  const q = String(row.q == null ? '' : row.q);
+  const ti = Number.isInteger(row.ti) ? row.ti : -1;
+  return {
+    // G4.2: stem_len = char length of the CANONICAL `q` (joined), always
+    // — never the q_en variant, even when the join matched via q_en.
+    stem_len: q.length,
+    ti,
+    topic_group: ti in tiToGroup ? tiToGroup[ti] : '__ungrouped__',
+    bilingual: !!(row.q_en && String(row.q_en).trim().length), // G4.2/D2
+    t: String(row.t == null ? '__missing__' : row.t),          // D1: categorical
+    c_accept: Array.isArray(row.c_accept) && row.c_accept.length > 0, // D2
+    broken: row.broken === true,                                // D2
+  };
+}
+
+export function buildIndex(opts = {}) {
+  const questionsPath = opts.questionsPath || path.join(REPO_ROOT, 'data', 'questions.json');
+  const htmlPath = opts.htmlPath || path.join(REPO_ROOT, 'shlav-a-mega.html');
+  const QZ = JSON.parse(readFileSync(questionsPath, 'utf-8'));
+  if (!Array.isArray(QZ)) throw new Error('questions.json is not an array');
+  const { groups, tiToGroup } = parseTopicGroups(htmlPath);
+
+  const rows = QZ.map((row) => covariatesFor(row, tiToGroup));
+  const byHash = Object.create(null);
+  const add = (h, idx) => {
+    if (h == null) return;
+    (byHash[h] || (byHash[h] = [])).push(idx);
+  };
+  QZ.forEach((row, idx) => {
+    add(hashStem(normStem(String(row.q == null ? '' : row.q))), idx);
+    if (row.q_en && String(row.q_en).trim().length) {
+      add(hashStem(normStem(String(row.q_en))), idx);
+    }
+  });
+
+  // D3 corpus sanity: unique stems, dup groups, per-covariate
+  // within-dup-group agreement (so the analyzer's per-covariate
+  // determinate-join logic is auditable against these counts).
+  const COVS = ['stem_len', 'topic_group', 'bilingual', 't', 'c_accept', 'broken'];
+  const qHashGroups = Object.create(null); // hash of `q` only → idx[]
+  QZ.forEach((row, idx) => {
+    const h = hashStem(normStem(String(row.q == null ? '' : row.q)));
+    (qHashGroups[h] || (qHashGroups[h] = [])).push(idx);
+  });
+  const dupGroups = Object.values(qHashGroups).filter((g) => g.length > 1);
+  const perCovAgreement = {};
+  for (const c of COVS) {
+    let agree = 0;
+    for (const g of dupGroups) {
+      const v0 = JSON.stringify(rows[g[0]][c]);
+      if (g.every((i) => JSON.stringify(rows[i][c]) === v0)) agree++;
+    }
+    perCovAgreement[c] = { agree, of: dupGroups.length };
+  }
+
+  return {
+    meta: {
+      schema: 'audit8-stemhash-index/1',
+      n: QZ.length,
+      uniqueQStemHashes: Object.keys(qHashGroups).length,
+      dupGroupCount: dupGroups.length,
+      perCovariateWithinDupGroupAgreement: perCovAgreement,
+      builtFrom: path.relative(REPO_ROOT, questionsPath),
+      topicGroupsFrom: path.relative(REPO_ROOT, htmlPath),
+    },
+    topicGroups: groups,
+    tiToGroup,
+    byHash,   // full-stem djb2 (q AND q_en) → question idx[]
+    rows,     // covariates aligned to questions.json index
+  };
+}
+
+// CLI
+const isMain = process.argv[1] && process.argv[1].endsWith('build_stemhash_index.mjs');
+if (isMain) {
+  const outArg = process.argv.indexOf('--out');
+  const out = outArg !== -1 ? process.argv[outArg + 1]
+    : path.join(REPO_ROOT, 'chaos-reports', 'v4-long', '_stemhash_index.json');
+  const idx = buildIndex();
+  writeFileSync(out, JSON.stringify(idx, null, 2));
+  const a = idx.meta.perCovariateWithinDupGroupAgreement;
+  console.log(`[build_stemhash_index] n=${idx.meta.n} uniqueQ=${idx.meta.uniqueQStemHashes} dupGroups=${idx.meta.dupGroupCount}`);
+  console.log(`[build_stemhash_index] within-dup-group agreement: ` +
+    Object.entries(a).map(([k, v]) => `${k} ${v.agree}/${v.of}`).join(', '));
+  console.log(`[build_stemhash_index] wrote ${out}`);
+}

--- a/scripts/lib/audit8Stats.mjs
+++ b/scripts/lib/audit8Stats.mjs
@@ -1,0 +1,416 @@
+// Audit-8 — pure numerical methods for the pick-channel representativeness
+// analyzer. NO domain logic, NO I/O, NO randomness, NO time, NO network.
+// Every export is a deterministic pure function. Standard methods only
+// (Numerical Recipes / Abramowitz–Stegun / Holm 1979); nothing carried
+// from the set-aside web-draft scripts. Unit-pinned in
+// tests/audit8Stats.test.js against hand/scipy-known constants.
+//
+// Binding spec: docs/AUDIT8_PRE_REGISTERED_GATE.md (#233 G4 + D1–D4).
+// Crosswalk: docs/AUDIT8_ANALYSIS_TOOLING_CROSSWALK.md.
+
+// ----------------------------------------------------------------------
+// Special functions
+// ----------------------------------------------------------------------
+
+// ln Γ(x) — Lanczos approximation, g=7, n=9. Accurate to ~1e-13 for x>0.
+const LANCZOS_G = 7;
+const LANCZOS_C = [
+  0.99999999999980993, 676.5203681218851, -1259.1392167224028,
+  771.32342877765313, -176.61502916214059, 12.507343278686905,
+  -0.13857109526572012, 9.9843695780195716e-6, 1.5056327351493116e-7,
+];
+export function lnGamma(x) {
+  if (!Number.isFinite(x)) return NaN;
+  if (x < 0.5) {
+    // Reflection: Γ(x)Γ(1-x) = π / sin(πx)
+    return Math.log(Math.PI / Math.sin(Math.PI * x)) - lnGamma(1 - x);
+  }
+  x -= 1;
+  let a = LANCZOS_C[0];
+  const t = x + LANCZOS_G + 0.5;
+  for (let i = 1; i < LANCZOS_G + 2; i++) a += LANCZOS_C[i] / (x + i);
+  return 0.5 * Math.log(2 * Math.PI) + (x + 0.5) * Math.log(t) - t + Math.log(a);
+}
+
+// Regularized lower incomplete gamma P(s,x) via series (x < s+1) /
+// upper Q(s,x) via Lentz continued fraction (x >= s+1). NR §6.2.
+export function regularizedGammaP(s, x) {
+  if (x < 0 || s <= 0) return NaN;
+  if (x === 0) return 0;
+  if (x < s + 1) {
+    // Series
+    let ap = s;
+    let sum = 1 / s;
+    let del = sum;
+    for (let n = 0; n < 1000; n++) {
+      ap += 1;
+      del *= x / ap;
+      sum += del;
+      if (Math.abs(del) < Math.abs(sum) * 1e-15) break;
+    }
+    return sum * Math.exp(-x + s * Math.log(x) - lnGamma(s));
+  }
+  return 1 - regularizedGammaQ(s, x);
+}
+export function regularizedGammaQ(s, x) {
+  if (x < 0 || s <= 0) return NaN;
+  if (x === 0) return 1;
+  if (x < s + 1) return 1 - regularizedGammaP(s, x);
+  // Lentz continued fraction
+  const TINY = 1e-300;
+  let b = x + 1 - s;
+  let c = 1 / TINY;
+  let d = 1 / b;
+  let h = d;
+  for (let i = 1; i < 1000; i++) {
+    const an = -i * (i - s);
+    b += 2;
+    d = an * d + b;
+    if (Math.abs(d) < TINY) d = TINY;
+    c = b + an / c;
+    if (Math.abs(c) < TINY) c = TINY;
+    d = 1 / d;
+    const del = d * c;
+    h *= del;
+    if (Math.abs(del - 1) < 1e-15) break;
+  }
+  return Math.exp(-x + s * Math.log(x) - lnGamma(s)) * h;
+}
+
+// erf via the exact identity erf(x) = sign(x)·P(½, x²), reusing the
+// high-accuracy regularized lower incomplete gamma above (~1e-15) — the
+// same routine the χ² tail is pinned on. Sharper than the A&S 7.1.26
+// rational approx; one fewer numerical method for the reviewer to trust.
+export function erf(z) {
+  if (z === 0) return 0;
+  const s = z < 0 ? -1 : 1;
+  return s * regularizedGammaP(0.5, z * z);
+}
+export function normalCdf(z) {
+  return 0.5 * (1 + erf(z / Math.SQRT2));
+}
+// Two-sided p from a z-score.
+export function twoSidedZP(z) {
+  return 2 * (1 - normalCdf(Math.abs(z)));
+}
+
+// ----------------------------------------------------------------------
+// χ² test of independence (2×k) with the locked expected-cell-<5
+// column-pooling rule applied BEFORE the test (gate G4.2 topic/D1 t).
+// rows = [groupA counts per level, groupB counts per level].
+// Returns chi2, df, p, cramersV, and the post-pool level labels.
+// ----------------------------------------------------------------------
+export function chiSquareIndependence(countsA, countsB, levels) {
+  if (countsA.length !== countsB.length || countsA.length !== levels.length) {
+    throw new Error('chiSquareIndependence: ragged inputs');
+  }
+  // Build column totals; pool any column whose MIN expected cell < 5
+  // into a single "other" column. Locked rule: pool BEFORE the test.
+  const grand =
+    countsA.reduce((s, v) => s + v, 0) + countsB.reduce((s, v) => s + v, 0);
+  const totA = countsA.reduce((s, v) => s + v, 0);
+  const totB = countsB.reduce((s, v) => s + v, 0);
+  if (grand === 0) return { chi2: 0, df: 0, p: 1, cramersV: 0, pooledLevels: [] };
+
+  const keep = [];
+  let poolA = 0;
+  let poolB = 0;
+  let pooledAny = false;
+  for (let j = 0; j < levels.length; j++) {
+    const colTot = countsA[j] + countsB[j];
+    const eA = (totA * colTot) / grand;
+    const eB = (totB * colTot) / grand;
+    if (colTot > 0 && Math.min(eA, eB) >= 5) {
+      keep.push(j);
+    } else {
+      poolA += countsA[j];
+      poolB += countsB[j];
+      pooledAny = true;
+    }
+  }
+  const finA = keep.map((j) => countsA[j]);
+  const finB = keep.map((j) => countsB[j]);
+  const finLevels = keep.map((j) => levels[j]);
+  if (pooledAny && poolA + poolB > 0) {
+    finA.push(poolA);
+    finB.push(poolB);
+    finLevels.push('__other__');
+  }
+  const k = finA.length;
+  if (k < 2) {
+    // Degenerate after pooling — not testable; report null result.
+    return { chi2: 0, df: 0, p: 1, cramersV: 0, pooledLevels: finLevels };
+  }
+  let chi2 = 0;
+  for (let j = 0; j < k; j++) {
+    const colTot = finA[j] + finB[j];
+    const eA = (totA * colTot) / grand;
+    const eB = (totB * colTot) / grand;
+    if (eA > 0) chi2 += (finA[j] - eA) ** 2 / eA;
+    if (eB > 0) chi2 += (finB[j] - eB) ** 2 / eB;
+  }
+  const df = k - 1; // (2-1)*(k-1)
+  const p = regularizedGammaQ(df / 2, chi2 / 2);
+  // Cramér's V; for a 2×k table min(r,c)-1 = 1.
+  const cramersV = Math.sqrt(chi2 / (grand * 1));
+  return { chi2, df, p, cramersV, pooledLevels: finLevels };
+}
+
+// ----------------------------------------------------------------------
+// Fisher exact 2×2, two-sided (sum of all tables, fixed margins, whose
+// hypergeometric prob <= prob(observed) * (1 + 1e-7) tolerance). φ /
+// Cramér's V for 2×2 = |φ|.  table = [[a,b],[c,d]].
+// ----------------------------------------------------------------------
+function lnHypergeom(a, b, c, d) {
+  const n = a + b + c + d;
+  return (
+    lnGamma(a + b + 1) +
+    lnGamma(c + d + 1) +
+    lnGamma(a + c + 1) +
+    lnGamma(b + d + 1) -
+    lnGamma(a + 1) -
+    lnGamma(b + 1) -
+    lnGamma(c + 1) -
+    lnGamma(d + 1) -
+    lnGamma(n + 1)
+  );
+}
+export function fisherExact2x2(table) {
+  const [[a, b], [c, d]] = table;
+  const r1 = a + b;
+  const r2 = c + d;
+  const c1 = a + c;
+  const n = a + b + c + d;
+  if (n === 0) return { p: 1, phi: 0, cramersV: 0 };
+  const lpObs = lnHypergeom(a, b, c, d);
+  const tol = Math.log(1 + 1e-7);
+  // a ranges over max(0, c1-r2) .. min(r1, c1)
+  const aMin = Math.max(0, c1 - r2);
+  const aMax = Math.min(r1, c1);
+  let p = 0;
+  for (let ai = aMin; ai <= aMax; ai++) {
+    const bi = r1 - ai;
+    const ci = c1 - ai;
+    const di = r2 - ci;
+    const lp = lnHypergeom(ai, bi, ci, di);
+    if (lp <= lpObs + tol) p += Math.exp(lp);
+  }
+  p = Math.min(1, p);
+  const denom = Math.sqrt((a + b) * (c + d) * (a + c) * (b + d));
+  const phi = denom === 0 ? 0 : (a * d - b * c) / denom;
+  return { p, phi, cramersV: Math.abs(phi) };
+}
+
+// ----------------------------------------------------------------------
+// Mann–Whitney U + tie-corrected normal-approx two-sided p, and Cliff's
+// δ — both from one O((n+m) log(n+m)) rank pass over the pooled sample,
+// so U and δ are guaranteed mutually consistent (δ = 2U/(n*m) - 1).
+// ----------------------------------------------------------------------
+export function mannWhitneyAndCliffs(aRaw, bRaw) {
+  const a = aRaw.filter(Number.isFinite);
+  const b = bRaw.filter(Number.isFinite);
+  const n1 = a.length;
+  const n2 = b.length;
+  if (n1 === 0 || n2 === 0) {
+    return { U: NaN, z: NaN, p: NaN, delta: NaN, n1, n2 };
+  }
+  const pooled = [];
+  for (const v of a) pooled.push({ v, g: 0 });
+  for (const v of b) pooled.push({ v, g: 1 });
+  pooled.sort((x, y) => x.v - y.v);
+  // Average ranks with tie handling.
+  const ranks = new Array(pooled.length);
+  let i = 0;
+  let tieSum = 0; // sum of (t^3 - t) for tie correction
+  while (i < pooled.length) {
+    let j = i;
+    while (j + 1 < pooled.length && pooled[j + 1].v === pooled[i].v) j++;
+    const avg = (i + j) / 2 + 1; // ranks are 1-based
+    for (let k = i; k <= j; k++) ranks[k] = avg;
+    const t = j - i + 1;
+    if (t > 1) tieSum += t * t * t - t;
+    i = j + 1;
+  }
+  let rankSumA = 0;
+  for (let k = 0; k < pooled.length; k++) if (pooled[k].g === 0) rankSumA += ranks[k];
+  const U1 = rankSumA - (n1 * (n1 + 1)) / 2; // U for group A
+  const N = n1 + n2;
+  const muU = (n1 * n2) / 2;
+  // Tie-corrected variance.
+  const varU =
+    (n1 * n2 / 12) *
+    (N + 1 - tieSum / (N * (N - 1)));
+  let z = 0;
+  if (varU > 0) {
+    // Continuity correction toward the mean.
+    const diff = U1 - muU;
+    const cc = diff === 0 ? 0 : Math.sign(diff) * 0.5;
+    z = (diff - cc) / Math.sqrt(varU);
+  }
+  const p = varU > 0 ? twoSidedZP(z) : 1;
+  // Cliff's δ = (#A>B - #A<B)/(n1 n2) = 2U1/(n1 n2) - 1 when U1 counts
+  // A-over-B with ties contributing 0.5 (the average-rank U does exactly
+  // this), so this identity holds under ties too.
+  const delta = (2 * U1) / (n1 * n2) - 1;
+  return { U: U1, z, p, delta, n1, n2 };
+}
+
+// ----------------------------------------------------------------------
+// Holm–Bonferroni step-down across a family. Input: array of {key,p}.
+// Returns same order with {key, p, pAdj, reject} at α. Monotone pAdj.
+// ----------------------------------------------------------------------
+export function holmBonferroni(tests, alpha = 0.05) {
+  const m = tests.length;
+  if (m === 0) return [];
+  const idx = tests.map((t, k) => k).sort((x, y) => tests[x].p - tests[y].p);
+  const out = tests.map((t) => ({ key: t.key, p: t.p, pAdj: NaN, reject: false }));
+  let stillRejecting = true;
+  let runningMax = 0;
+  for (let rank = 0; rank < m; rank++) {
+    const k = idx[rank];
+    const factor = m - rank;
+    const adj = Math.min(1, Math.max(runningMax, tests[k].p * factor));
+    runningMax = adj;
+    out[k].pAdj = adj;
+    if (stillRejecting && tests[k].p <= alpha / factor) {
+      out[k].reject = true;
+    } else {
+      stillRejecting = false;
+    }
+  }
+  return out;
+}
+
+// ----------------------------------------------------------------------
+// Logistic regression via IRLS (Newton–Raphson). X = array of feature
+// rows (NO intercept column — added here). y ∈ {0,1}. Returns coef
+// (index 0 = intercept), Wald se/z/p, convergence flag. Honest about
+// non-convergence (separation) — does NOT silently regularize; the
+// analyzer reports `converged:false` rather than fabricate estimates.
+// ----------------------------------------------------------------------
+function solveLinearSystem(Araw, braw) {
+  // Gaussian elimination with partial pivoting. Returns null if singular.
+  const n = braw.length;
+  const A = Araw.map((row, i) => [...row, braw[i]]);
+  for (let col = 0; col < n; col++) {
+    let piv = col;
+    for (let r = col + 1; r < n; r++) {
+      if (Math.abs(A[r][col]) > Math.abs(A[piv][col])) piv = r;
+    }
+    if (Math.abs(A[piv][col]) < 1e-12) return null;
+    [A[col], A[piv]] = [A[piv], A[col]];
+    for (let r = 0; r < n; r++) {
+      if (r === col) continue;
+      const f = A[r][col] / A[col][col];
+      for (let c = col; c <= n; c++) A[r][c] -= f * A[col][c];
+    }
+  }
+  // Elimination above+below leaves a diagonal system: x[i] = A[i][n]/A[i][i].
+  return A.map((row, i) => row[n] / row[i]);
+}
+function matInvSym(Araw) {
+  // Invert via Gauss–Jordan; returns null if singular. Used for the
+  // Wald covariance (XᵀWX)⁻¹.
+  const n = Araw.length;
+  const A = Araw.map((row) => [...row]);
+  const I = Array.from({ length: n }, (_, i) =>
+    Array.from({ length: n }, (_, j) => (i === j ? 1 : 0)),
+  );
+  for (let col = 0; col < n; col++) {
+    let piv = col;
+    for (let r = col + 1; r < n; r++) {
+      if (Math.abs(A[r][col]) > Math.abs(A[piv][col])) piv = r;
+    }
+    if (Math.abs(A[piv][col]) < 1e-12) return null;
+    [A[col], A[piv]] = [A[piv], A[col]];
+    [I[col], I[piv]] = [I[piv], I[col]];
+    const d = A[col][col];
+    for (let c = 0; c < n; c++) {
+      A[col][c] /= d;
+      I[col][c] /= d;
+    }
+    for (let r = 0; r < n; r++) {
+      if (r === col) continue;
+      const f = A[r][col];
+      for (let c = 0; c < n; c++) {
+        A[r][c] -= f * A[col][c];
+        I[r][c] -= f * I[col][c];
+      }
+    }
+  }
+  return I;
+}
+export function logisticRegressionIRLS(X, y, opts = {}) {
+  const maxIter = opts.maxIter ?? 50;
+  const tol = opts.tol ?? 1e-8;
+  const nObs = y.length;
+  if (nObs === 0 || X.length !== nObs) {
+    return { coef: [], se: [], z: [], p: [], converged: false, iterations: 0, reason: 'empty' };
+  }
+  const k = X[0].length; // feature count (no intercept)
+  const d = k + 1;
+  const design = X.map((row) => [1, ...row]);
+  let beta = new Array(d).fill(0);
+  let converged = false;
+  let iter = 0;
+  for (iter = 1; iter <= maxIter; iter++) {
+    // Build XᵀWX and Xᵀ(y-μ)
+    const XtWX = Array.from({ length: d }, () => new Array(d).fill(0));
+    const Xtz = new Array(d).fill(0);
+    let maxW = 0;
+    for (let i = 0; i < nObs; i++) {
+      let eta = 0;
+      for (let j = 0; j < d; j++) eta += design[i][j] * beta[j];
+      const mu = 1 / (1 + Math.exp(-eta));
+      const w = Math.max(mu * (1 - mu), 1e-10);
+      maxW = Math.max(maxW, w);
+      const resid = y[i] - mu;
+      for (let j = 0; j < d; j++) {
+        Xtz[j] += design[i][j] * resid;
+        for (let l = 0; l < d; l++) XtWX[j][l] += design[i][j] * w * design[i][l];
+      }
+    }
+    const step = solveLinearSystem(XtWX, Xtz);
+    if (!step) {
+      return { coef: beta, se: [], z: [], p: [], converged: false, iterations: iter, reason: 'singular-information-matrix' };
+    }
+    let maxDelta = 0;
+    for (let j = 0; j < d; j++) {
+      beta[j] += step[j];
+      maxDelta = Math.max(maxDelta, Math.abs(step[j]));
+    }
+    if (!beta.every(Number.isFinite)) {
+      return { coef: beta, se: [], z: [], p: [], converged: false, iterations: iter, reason: 'diverged-separation' };
+    }
+    if (maxDelta < tol) {
+      converged = true;
+      break;
+    }
+  }
+  // Wald covariance = (XᵀWX)⁻¹ at the MLE.
+  const XtWX = Array.from({ length: d }, () => new Array(d).fill(0));
+  for (let i = 0; i < nObs; i++) {
+    let eta = 0;
+    for (let j = 0; j < d; j++) eta += design[i][j] * beta[j];
+    const mu = 1 / (1 + Math.exp(-eta));
+    const w = Math.max(mu * (1 - mu), 1e-10);
+    for (let j = 0; j < d; j++)
+      for (let l = 0; l < d; l++) XtWX[j][l] += design[i][j] * w * design[i][l];
+  }
+  const cov = matInvSym(XtWX);
+  const se = cov ? beta.map((_, j) => Math.sqrt(Math.max(cov[j][j], 0))) : new Array(d).fill(NaN);
+  const z = beta.map((bj, j) => (se[j] > 0 ? bj / se[j] : NaN));
+  const p = z.map((zj) => (Number.isFinite(zj) ? twoSidedZP(zj) : NaN));
+  return { coef: beta, se, z, p, converged, iterations: iter, reason: converged ? 'ok' : 'max-iter' };
+}
+
+// Standardize a numeric vector (z-score) — for the logistic stem_len term.
+export function zscore(arr) {
+  const v = arr.filter(Number.isFinite);
+  const n = v.length;
+  if (n === 0) return arr.map(() => 0);
+  const mean = v.reduce((s, x) => s + x, 0) / n;
+  const sd =
+    Math.sqrt(v.reduce((s, x) => s + (x - mean) ** 2, 0) / Math.max(1, n - 1)) || 1;
+  return arr.map((x) => (Number.isFinite(x) ? (x - mean) / sd : 0));
+}

--- a/tests/audit8AnalyzeRepresentativeness.test.js
+++ b/tests/audit8AnalyzeRepresentativeness.test.js
@@ -1,0 +1,214 @@
+// Audit-8 analyzer logic pins — SYNTHETIC fixtures ONLY. Per the
+// pre-registration invariant the analyzer is frozen blind to run data;
+// these fixtures are hand-constructed, never a real chaos ledger. They
+// exercise: G4.1 universe classification, G3/D3 join (exact-hash,
+// dup-group covariate-discord drop, containment fallback, join-fail),
+// `broken` vacuity, and every G4.5 verdict branch + the STOP branches.
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { hashStem, normStem } from '../scripts/lib/hashStem.mjs';
+import { buildIndex } from '../scripts/build_stemhash_index.mjs';
+import { analyze, classifyUniverse, joinRow } from '../scripts/analyze_pick_representativeness.mjs';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const HTML = path.join(REPO_ROOT, 'shlav-a-mega.html'); // real 12 TOPIC_GROUPS
+
+let TMP;
+beforeAll(() => { TMP = mkdtempSync(path.join(os.tmpdir(), 'audit8-')); });
+afterAll(() => { rmSync(TMP, { recursive: true, force: true }); });
+
+let caseSeq = 0;
+// Build a synthetic questions.json + a report dir, return analyze() result.
+function runCase({ questions, dropSpecs, retainSpecs, aiErr = 0, prePick = 0, extractNull = 0, appIdxNull = 0 }) {
+  const dir = path.join(TMP, `c${caseSeq++}`);
+  mkdirSync(dir, { recursive: true });
+  const qPath = path.join(dir, 'questions.json');
+  writeFileSync(qPath, JSON.stringify(questions));
+  const idx = buildIndex({ questionsPath: qPath, htmlPath: HTML });
+
+  const sh = (i) => hashStem(normStem(String(questions[i].q)));
+  const bugs = [];
+  dropSpecs.forEach((qi) => bugs.push({
+    at: 't', type: 'ai-parse-error', context: 'pick', dropCtx: 'pick-parse-error',
+    stemHash: sh(qi), stem: String(questions[qi].q).slice(0, 300), optCount: 4,
+  }));
+  for (let i = 0; i < aiErr; i++) bugs.push({ at: 't', type: 'ai-error', context: 'pick', dropCtx: 'pick-ai-error', stemHash: sh(0) });
+  for (let i = 0; i < prePick; i++) bugs.push({ at: 't', type: 'pre-pick-skip', context: 'pick', dropCtx: 'pre-pick-no-question', stemHash: null });
+
+  const summary = { config: {}, startedAt: 't', finishedAt: 't', workers: [{ workerId: 1, qsAnswered: dropSpecs.length + retainSpecs.length, actions: [], bugs, extractNull }] };
+  writeFileSync(path.join(dir, 'chaos-doctor-v4-TEST.json'), JSON.stringify(summary));
+
+  const jl = [];
+  retainSpecs.forEach((qi) => jl.push(JSON.stringify({
+    at: 't', schema: 'v4', workerId: 1, stemHash: sh(qi),
+    stem: String(questions[qi].q).slice(0, 300), disagrees: false, judge: { app_answer_correct: true },
+  })));
+  for (let i = 0; i < appIdxNull; i++) jl.push(JSON.stringify({
+    at: 't', schema: 'v4', workerId: 1, stemHash: sh(0), stem: 'x',
+    disagrees: null, judge: null, methodology: 'appIdx-null-post-check',
+  }));
+  writeFileSync(path.join(dir, 'medical_findings_ai_v4.jsonl'), jl.join('\n') + '\n');
+
+  return analyze({ reportDir: dir, index: idx, questionsPath: qPath });
+}
+
+// covariate-varied question pool (ti maps into real TOPIC_GROUPS)
+function pool(n, fn) {
+  return Array.from({ length: n }, (_, i) => {
+    const o = { q: `synthetic stem number ${i} ` + 'x'.repeat(20), o: ['a', 'b', 'c', 'd'], c: 0, ti: i % 12, t: `S${i % 4}` };
+    return fn ? fn(o, i) : o;
+  });
+}
+
+describe('G4.1 universe classification', () => {
+  it('partitions DROPPED / RETAINED / ai-error / pre-pick / appIdx-null', () => {
+    const u = classifyUniverse({
+      bugs: [
+        { type: 'ai-parse-error', context: 'pick' },
+        { type: 'ai-parse-error', context: 'pick' },
+        { type: 'ai-error', context: 'pick' },
+        { type: 'pre-pick-skip', context: 'pick' },
+        { type: 'action-error', context: 'doctor-pick' }, // ignored
+      ],
+      findings: [
+        { judge: { x: 1 }, disagrees: true },
+        { judge: { x: 1 }, disagrees: false },
+        { judge: null, disagrees: null, methodology: 'appIdx-null-post-check' },
+      ],
+      extractNull: 7,
+    });
+    expect(u.dropped.length).toBe(2);
+    expect(u.aiErrorPick.length).toBe(1);
+    expect(u.prePickSkip.length).toBe(1);
+    expect(u.retained.length).toBe(2);
+    expect(u.appIdxNull.length).toBe(1);
+    expect(u.extractNull).toBe(7);
+  });
+});
+
+describe('G3/D3 join', () => {
+  const index = {
+    byHash: { H1: [0], DUP: [1, 2] },
+    rows: [
+      { stem_len: 10, ti: 0, topic_group: 0, bilingual: false, t: 'A', c_accept: false, broken: false },
+      { stem_len: 20, ti: 1, topic_group: 1, bilingual: true, t: 'B', c_accept: false, broken: true },
+      { stem_len: 20, ti: 1, topic_group: 1, bilingual: true, t: 'B', c_accept: false, broken: false }, // disagrees on `broken` only
+    ],
+  };
+  const qNorm = ['unique alpha stem', 'shared beta stem', 'shared beta stem'];
+
+  it('exact stemHash, single bucket → all covariates determinate', () => {
+    const j = joinRow('H1', null, index, qNorm);
+    expect(j.joined).toBe(true);
+    expect(j.via).toBe('stemHash');
+    expect(j.covs.broken).toBe(false);
+    expect(Object.keys(j.covs).sort()).toEqual(['bilingual', 'broken', 'c_accept', 'stem_len', 't', 'topic_group']);
+  });
+  it('dup bucket: agreeing covariates determinate, discordant one DROPPED (D3)', () => {
+    const j = joinRow('DUP', null, index, qNorm);
+    expect(j.joined).toBe(true);
+    expect(j.covs.topic_group).toBe(1);   // agree → determinate
+    expect('broken' in j.covs).toBe(false); // discordant → omitted
+  });
+  it('no hash → containment fallback on the stem slice', () => {
+    const j = joinRow('NOPE', 'unique alpha', index, qNorm);
+    expect(j.joined).toBe(true);
+    expect(j.via).toBe('containment');
+  });
+  it('no hash, no containment → join failure (never imputed)', () => {
+    const j = joinRow('NOPE', 'totally absent text', index, qNorm);
+    expect(j.joined).toBe(false);
+  });
+});
+
+describe('G4.5 verdict branches (synthetic)', () => {
+  it('STOP when N_drop==0 (instrument live, drop-rate collapsed)', () => {
+    const q = pool(30);
+    const r = runCase({ questions: q, dropSpecs: [], retainSpecs: q.map((_, i) => i) });
+    expect(r.verdict).toBe('STOP');
+    expect(r.reason).toMatch(/drop-rate-collapsed|N_drop==0/);
+  });
+
+  it('REPRESENTATIVE — same covariate distribution, powered, broken vacuous', () => {
+    // drop & retain reference the SAME cyclic multiset (counts are exact
+    // multiples of pool size) → identical relative covariate distribution.
+    const q = pool(50, (o, i) => ({ ...o, q_en: i % 2 ? 'en' : undefined }));
+    const drop = Array.from({ length: 100 }, (_, i) => i % 50); // 2× each
+    const ret = Array.from({ length: 250 }, (_, i) => i % 50);  // 5× each
+    const r = runCase({ questions: q, dropSpecs: drop, retainSpecs: ret });
+    expect(r.brokenVacuous).toBe(true);          // no broken served → dropped from family
+    expect(r.family).not.toContain('broken');
+    expect(r.g2.powered).toBe(true);
+    expect(r.verdict).toBe('REPRESENTATIVE');
+  });
+
+  it('INCONCLUSIVE — same distribution but under-powered (N_drop<80)', () => {
+    const q = pool(10, (o, i) => ({ ...o, q_en: i % 2 ? 'en' : undefined }));
+    const drop = Array.from({ length: 20 }, (_, i) => i % 10);  // 2× each, <80
+    const ret = Array.from({ length: 220 }, (_, i) => i % 10);  // 22× each
+    const r = runCase({ questions: q, dropSpecs: drop, retainSpecs: ret });
+    expect(r.g2.powered).toBe(false);
+    expect(r.verdict).toBe('INCONCLUSIVE');
+  });
+
+  it('BIASED — strong stem_len separation (|δ|=1, Holm-sig)', () => {
+    // short-stem questions 0..24, long-stem 25..49
+    const q = Array.from({ length: 50 }, (_, i) => ({
+      q: i < 25 ? `short ${i}` : `long ${i} ` + 'y'.repeat(600),
+      o: ['a', 'b'], c: 0, ti: i % 12, t: `S${i % 3}`,
+    }));
+    const drop = Array.from({ length: 90 }, (_, i) => 25 + (i % 25)); // all long
+    const ret = Array.from({ length: 220 }, (_, i) => i % 25);        // all short
+    const r = runCase({ questions: q, dropSpecs: drop, retainSpecs: ret });
+    expect(r.tests.stem_len.biasSignal).toBe(true);
+    expect(Math.abs(r.tests.stem_len.effect)).toBeGreaterThanOrEqual(0.15);
+    expect(r.verdict).toBe('BIASED');
+  });
+
+  it('DETECTABLE-BUT-NEGLIGIBLE — bilingual Holm-sig but |φ|<0.10 at large N', () => {
+    // two question variants: bilingual vs not; everything else identical.
+    // equal-length stems (differ by one trailing char only) so stem_len
+    // is non-significant and ONLY `bilingual` carries the small signal.
+    const q = [
+      { q: 'variant stem A', o: ['a', 'b'], c: 0, ti: 0, t: 'A', q_en: 'en' }, // idx0 bilingual=true
+      { q: 'variant stem B', o: ['a', 'b'], c: 0, ti: 0, t: 'A' },             // idx1 bilingual=false
+    ];
+    // drop: 50% bilingual; retain: 56% bilingual → small φ, tiny p at N=1500
+    const drop = Array.from({ length: 1500 }, (_, i) => (i % 2 === 0 ? 0 : 1));
+    const ret = Array.from({ length: 1500 }, (_, i) => (i % 25 < 14 ? 0 : 1)); // 14/25 = 56%
+    const r = runCase({ questions: q, dropSpecs: drop, retainSpecs: ret });
+    expect(r.tests.bilingual.holmReject).toBe(true);
+    expect(r.tests.bilingual.meetsFloor).toBe(false);
+    expect(r.tests.bilingual.biasSignal).toBe(false);
+    expect(r.verdict).toBe('DETECTABLE-BUT-NEGLIGIBLE');
+  });
+
+  it('STOP-JOIN-INTEGRITY — a covariate determinate-join rate < 99% (D3)', () => {
+    // idx0 & idx1 are byte-identical `q` (same stemHash, a dup group) but
+    // disagree on `broken` only → every routed row is broken-indeterminate.
+    const q = [
+      { q: 'identical dup stem text', o: ['a', 'b'], c: 0, ti: 0, t: 'A', broken: true },
+      { q: 'identical dup stem text', o: ['a', 'b'], c: 0, ti: 0, t: 'A' }, // broken:false
+    ];
+    const drop = Array.from({ length: 100 }, () => 0);
+    const ret = Array.from({ length: 250 }, () => 0);
+    const r = runCase({ questions: q, dropSpecs: drop, retainSpecs: ret });
+    expect(r.g3d3.violations).toContain('broken');
+    expect(r.verdict).toBe('STOP-JOIN-INTEGRITY');
+  });
+});
+
+describe('logistic sensitivity is verdict-neutral', () => {
+  it('present in the result but the verdict never reads it', () => {
+    const q = pool(50, (o, i) => ({ ...o, q_en: i % 2 ? 'en' : undefined }));
+    const drop = Array.from({ length: 100 }, (_, i) => i % 50);
+    const ret = Array.from({ length: 250 }, (_, i) => i % 50);
+    const r = runCase({ questions: q, dropSpecs: drop, retainSpecs: ret });
+    expect(r).toHaveProperty('logisticSensitivity');
+    // REPRESENTATIVE reached purely on the marginal family + G2 N.
+    expect(r.verdict).toBe('REPRESENTATIVE');
+  });
+});

--- a/tests/audit8Stats.test.js
+++ b/tests/audit8Stats.test.js
@@ -1,0 +1,129 @@
+// Audit-8 pure-stats pins. Reference constants are scipy / hand-computed
+// (Numerical Recipes, Wikipedia logistic example, Holm 1979). If any of
+// these drift the representativeness verdict is untrustworthy — this file
+// is the falsifier for scripts/lib/audit8Stats.mjs.
+import { describe, it, expect } from 'vitest';
+import {
+  lnGamma, regularizedGammaQ, regularizedGammaP, erf, normalCdf, twoSidedZP,
+  chiSquareIndependence, fisherExact2x2, mannWhitneyAndCliffs,
+  holmBonferroni, logisticRegressionIRLS, zscore,
+} from '../scripts/lib/audit8Stats.mjs';
+
+const near = (a, b, tol = 1e-4) => expect(Math.abs(a - b)).toBeLessThan(tol);
+
+describe('special functions', () => {
+  it('lnGamma matches known values', () => {
+    near(lnGamma(5), Math.log(24), 1e-7);          // Γ(5)=4!=24
+    near(lnGamma(0.5), Math.log(Math.sqrt(Math.PI)), 1e-7); // Γ(½)=√π
+    near(lnGamma(1), 0, 1e-9);
+  });
+  it('regularized incomplete gamma = χ² survival at the canonical crit values', () => {
+    near(regularizedGammaQ(0.5, 3.841 / 2), 0.05, 1e-3); // χ²=3.841 df=1
+    near(regularizedGammaQ(1, 5.991 / 2), 0.05, 1e-3);   // χ²=5.991 df=2
+    near(regularizedGammaQ(0.5, 10.828 / 2), 0.001, 5e-4); // χ²=10.828 df=1
+    expect(regularizedGammaQ(0.5, 0)).toBe(1);
+    near(regularizedGammaP(1, 1) + regularizedGammaQ(1, 1), 1, 1e-12);
+  });
+  it('erf / normalCdf / twoSidedZP', () => {
+    near(erf(0), 0, 1e-9);
+    near(erf(1), 0.8427007, 1e-5);
+    near(normalCdf(0), 0.5, 1e-9);
+    near(normalCdf(1.959964), 0.975, 1e-3);
+    near(twoSidedZP(1.959964), 0.05, 1e-3);
+    near(erf(2), 0.99532227, 1e-6);
+    near(twoSidedZP(0), 1, 1e-9);
+  });
+});
+
+describe('chi-square 2×k with locked <5 pooling', () => {
+  it('no-pooling table: known χ², df, Cramér V, p', () => {
+    const r = chiSquareIndependence([10, 20], [20, 10], ['x', 'y']);
+    near(r.chi2, 6.6667, 1e-3);
+    expect(r.df).toBe(1);
+    near(r.cramersV, 0.33333, 1e-4);
+    near(r.p, 0.00982, 1e-3); // scipy chi2.sf(6.6667,1)
+  });
+  it('sparse column is pooled into __other__ BEFORE the test', () => {
+    const r = chiSquareIndependence([10, 20, 1], [20, 10, 0], ['x', 'y', 'z']);
+    expect(r.pooledLevels).toContain('__other__');
+    expect(r.pooledLevels).not.toContain('z');
+  });
+});
+
+describe('Fisher exact 2×2 two-sided', () => {
+  it('lady-tasting-tea [[3,1],[1,3]] → p≈0.4857, φ=0.5', () => {
+    const f = fisherExact2x2([[3, 1], [1, 3]]);
+    near(f.p, 0.4857142857, 1e-4);
+    near(f.phi, 0.5, 1e-9);
+    near(f.cramersV, 0.5, 1e-9);
+  });
+  it('perfect separation [[10,0],[0,10]] → tiny p, |φ|=1', () => {
+    const f = fisherExact2x2([[10, 0], [0, 10]]);
+    expect(f.p).toBeLessThan(1e-4);
+    near(Math.abs(f.phi), 1, 1e-9);
+  });
+});
+
+describe('Mann–Whitney U + Cliff δ (one consistent rank pass)', () => {
+  it('complete separation a<b → U=0, δ=-1', () => {
+    const m = mannWhitneyAndCliffs([1, 2, 3], [4, 5, 6]);
+    expect(m.U).toBe(0);
+    near(m.delta, -1, 1e-12);
+  });
+  it('complete separation a>b → δ=+1', () => {
+    const m = mannWhitneyAndCliffs([4, 5, 6], [1, 2, 3]);
+    near(m.delta, 1, 1e-12);
+  });
+  it('identical samples → δ=0, p=1', () => {
+    const m = mannWhitneyAndCliffs([1, 2, 3], [1, 2, 3]);
+    near(m.delta, 0, 1e-12);
+    near(m.p, 1, 1e-9);
+  });
+  it('δ = 2U/(n1 n2) - 1 identity holds', () => {
+    const a = [3, 1, 4, 1, 5, 9, 2, 6];
+    const b = [2, 7, 1, 8, 2, 8];
+    const m = mannWhitneyAndCliffs(a, b);
+    near(m.delta, (2 * m.U) / (a.length * b.length) - 1, 1e-12);
+  });
+});
+
+describe('Holm–Bonferroni step-down', () => {
+  it('classic step-down: only the smallest passes', () => {
+    const h = holmBonferroni([{ key: 'a', p: 0.001 }, { key: 'b', p: 0.04 }, { key: 'c', p: 0.03 }]);
+    const by = Object.fromEntries(h.map((x) => [x.key, x]));
+    expect(by.a.reject).toBe(true);
+    expect(by.b.reject).toBe(false);
+    expect(by.c.reject).toBe(false);
+    near(by.a.pAdj, 0.003, 1e-9);
+  });
+  it('all tiny → all reject; pAdj monotone & ≤1', () => {
+    const h = holmBonferroni([{ key: 'a', p: 0.001 }, { key: 'b', p: 0.001 }]);
+    expect(h.every((x) => x.reject)).toBe(true);
+    expect(h.every((x) => x.pAdj <= 1)).toBe(true);
+  });
+});
+
+describe('logistic IRLS', () => {
+  it('Wikipedia hours-studied dataset → published MLE', () => {
+    const hours = [0.5, 0.75, 1, 1.25, 1.5, 1.75, 1.75, 2, 2.25, 2.5, 2.75, 3, 3.25, 3.5, 4, 4.25, 4.5, 4.75, 5, 5.5];
+    const pass = [0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1];
+    const fit = logisticRegressionIRLS(hours.map((h) => [h]), pass, { maxIter: 100, tol: 1e-10 });
+    expect(fit.converged).toBe(true);
+    near(fit.coef[0], -4.0777, 0.02);  // intercept
+    near(fit.coef[1], 1.5046, 0.02);   // slope
+  });
+  it('reports non-convergence honestly on perfect separation (no silent regularize)', () => {
+    const x = [[-3], [-2], [-1], [1], [2], [3]];
+    const y = [0, 0, 0, 1, 1, 1];
+    const fit = logisticRegressionIRLS(x, y, { maxIter: 25 });
+    expect(fit.converged).toBe(false);
+  });
+});
+
+describe('zscore', () => {
+  it('mean→0, sample-sd scaling', () => {
+    const z = zscore([1, 2, 3, 4, 5]);
+    near(z.reduce((s, v) => s + v, 0) / z.length, 0, 1e-12);
+    near(z[0], -1.2649, 1e-3);
+  });
+});


### PR DESCRIPTION
## What

Pre-registration **freeze** of the AUDIT8 bounded-run analysis tooling, authored **blind to run data**, per the binding on-main `docs/AUDIT8_PRE_REGISTERED_GATE.md` (#233 G2/G3/G4/G5 + DELTAS D1–D4). Implements "Reconciliation B" handed off by the #235 PRE-STEP record. **scripts/tests/docs only — no trinity bump** (mirrors audit-5 / the #235 PRE-STEP).

The set-aside web-draft scripts (`build_stemhash_index.mjs`, `analyze_pick_representativeness.mjs`) are **not on disk** in this tree and were **not** used as a base — rebuilt clause-by-clause from the on-main gate (the condensed-rewrite criterion-swap trap avoided structurally).

## Files
- `scripts/lib/audit8Stats.mjs` — pure, unit-pinned numerical methods (regularized-incomplete-gamma χ² tail, Fisher exact 2×2, Mann–Whitney U + Cliff's δ from one consistent rank pass, Cramér's V, Holm step-down, IRLS logistic with honest non-convergence).
- `scripts/build_stemhash_index.mjs` — `q ∪ q_en` djb2 join index via the on-main SSOT `scripts/lib/hashStem.mjs`; parses the canonical **12 TOPIC_GROUPS** from the monolith (no hard-copy); emits D3 dup-group covariate-agreement stats.
- `scripts/analyze_pick_representativeness.mjs` — **FROZEN** analyzer: G4.1 universe (DROPPED = `ai-parse-error/pick`; `ai-error` & `pre-pick-skip` keyed on **`type`**, excluded/separate; `appIdx-null` separate), G3/D3 per-covariate determinate join ≥99%, the locked **6-covariate** family (D1 `t`-categorical, D2 `c_accept`/`broken` + `N_broken_served` vacuity), Holm, G4.4 floors, G4.5 **4-way** verdict, G2 min-N, logistic **SENSITIVITY** (verdict-neutral by signature).
- `docs/AUDIT8_ANALYSIS_TOOLING_CROSSWALK.md` — clause⇄code crosswalk, **explicitly NOT a gate**; re-derives no threshold.

## The one surfaced reasoned reconciliation (Working Rule 1, non-apologetic)
G4.3's written logistic formula is the **4-covariate-era** model; D1/D2 expanded the locked *family* to 6. The logistic's locked *purpose* ("survives **mutual adjustment**") requires the adjusting set = the family. The sensitivity model is therefore the **locked 6-cov family**, mirroring the gate's own D1/D2 reconcile-toward-authoritative precedent. **Verdict-neutral** — G4.3 locks the verdict off the logistic; enforced by the verdict function's signature (it never receives the logistic result).

## Verification
- `npm run verify` green: **79 files / 1469 passed / 7 skipped / 0 failed**; all 7 non-vitest checks pass; **trinity untouched at v10.64.130**.
- New tests: stats vs published constants (scipy/Wikipedia/Holm); analyzer vs **synthetic fixtures only** (every G4.5 verdict + STOP branch; D3 dup-discord; containment fallback) — never real run data (pre-registration).
- Free **stratified** join sanity (step 4, replay of 4 prior ledgers, 2768 DOM stems): overall join **99.5%**; **bilingual / broken / bidi strata all 100%** → the gate's D3 covariate-correlated-join-failure worst case does **not** materialize; `normStem` needs no strengthening. (Honest caveat: replay exact-hash is depressed by truncated pre-#235 stems; the real run hashes the full stem.)

## Activation order (binding) — do NOT self-merge
This PR merges → re-pass STEP 0.2 → **then** the bounded run (G1–G5, `CHAOS_COST_CAP_USD=20`, locked G2 config) → RESULT appended by the run session (gate SHIP clause). **No self-merge** (gate SHIP). The web lane reviews this frozen tooling against the on-main gate **before any spend**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)