### PR TITLE
chore(lint): explanatory comment for shared/install-promo.js empty catch (parity with IM #119 / FM #65)

### DIFF
--- a/shared/install-promo.js
+++ b/shared/install-promo.js
@@ -79,7 +79,7 @@
     } catch { return { sessions: 0, engagedSec: 0, dismissedAt: 0, installedAt: 0 }; }
   }
   function writeState() {
-    try { localStorage.setItem(STORE_KEY, JSON.stringify(state)); } catch {}
+    try { localStorage.setItem(STORE_KEY, JSON.stringify(state)); } catch { /* best-effort: localStorage may throw (quota / private mode / disabled); promo-state persistence is non-essential */ }
   }
 
   // Bump session counter once per page load


### PR DESCRIPTION
1-line comment in the lone empty catch at `shared/install-promo.js:82` (best-effort localStorage write). Clears eslint `no-empty` in IM/FM (rule stays live — comment, not `allowEmptyCatch`). Geri runs no eslint so this leg is **parity-only**: keeps the sibling-shared file byte-identical (LF md5 `dd4cf215`) across Geri/IM/FM — without it, main is parity-broken (IM/FM new, Geri old). ZERO behaviour change, NO trinity bump (version-sync passes on equality). `npm run verify` green locally (79 files / 1469 / 7 skipped). Per Geri CLAUDE.md solo-lane: CI gates, then **user merges** (not self-merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)