### PR TITLE
feat(audit-8 g5 r1): RED probe + findings-only RESULT (no fix)

### DIFF
--- a/docs/AUDIT8_G5_REPAIR_GATE.md
+++ b/docs/AUDIT8_G5_REPAIR_GATE.md
@@ -310,3 +310,249 @@ verify every corpus claim and the §"Hypotheses" separation against disk) →
 un-hold trigger.
 
 <!-- R1/R2/R3 RESULT sections appended append-only below by their sessions. -->
+
+---
+
+## R1 RESULT — findings-only; the steady-state frame is contradicted by disk (2026-05-20)
+
+Session: terminal, solo, `claude/audit8-g5-r1-extraction` cut from `origin/main`
+HEAD `655953b`. Trinity: **untouched** — scripts + docs only. **No fix in this
+PR.** This RESULT is appended append-only per
+`feedback_spec_provenance_append_only`; it does not retro-edit R1's
+pre-registered procedure, it documents what executing that procedure on disk
+returned.
+
+### STEP 0 — distrust contract (verified)
+
+- `origin/main` HEAD = `655953b` (`docs(claude): single-lane operating model
+  (#240)`). Branch cut clean; no collision with any other `claude/audit8-g5-r1-*`
+  branch (none exist). No concurrent lane (the per-repo CLAUDE.md "single lane
+  from 2026-05-19" applies).
+- Anchors verified on disk: `extractQuestion` at
+  `scripts/chaos-doctor-bot-v4.mjs:231`, `ensureOnPracticeQuiz` at `:817`;
+  `showHelp` at `shlav-a-mega.html:8217`, `closeTopModal` at `:8285`.
+- Vitest baseline isolated to the chaos-bot pin trio
+  (`chaosBotV4PickDropInvariant.test.js`, `chaosBotV4ModalDismiss.test.js`,
+  `chaosBotV4PickIdentityInstrument.test.js`) — **21/21 passed** before and
+  after the minimal `export` keyword added to `extractQuestion` and
+  `ensureOnPracticeQuiz` (needed so the probe can import the real extractor
+  per R1.0's "no proxy" rule). The chaosBotV4ModalDismiss regex-grep tests
+  still match (the `async function` prefix is preserved).
+
+### R1.0 — RED probe (built; ran; did NOT reproduce)
+
+- Probe shipped at `scripts/audit8/r1RedProbe.mjs`. Uses the **real**
+  `extractQuestion` + `ensureOnPracticeQuiz` from
+  `scripts/chaos-doctor-bot-v4.mjs` (import-from-source, not re-implementation
+  — kickoff §1.0's "no proxy" constraint). Configurable URL + N; default
+  100 attempts × ~2.5s pacing; advances between attempts via
+  `[aria-label="Next question"]` (pick + check + next), zero Claude API
+  calls. Forensic-mode classifier records `no-heb` / `stem-throw` /
+  `short-stem` / `no-qo` / `empty-options` / `modal-blocked` / `other` and
+  captures the first N forensic snapshots.
+- Run against current `main` (live URL
+  `https://eiasash.github.io/Geriatrics/`) at **N=100**:
+  - `total` = 100, `extractedOk` = 100, `extractionFailures` = 0,
+    `failureRate` = 0.000, `RED` = false.
+  - All `perMode` counters zero. `ensureOnQuizFailures` = 0.
+- **RED criterion (failure ≥ 0.85) NOT met.** Kickoff §6 bail #1 reads:
+  "RED probe does NOT reproduce against current main → regression already
+  silently fixed downstream; document and surface, do not fabricate a fix."
+  The "silently fixed" frame, however, is contradicted by §R1.1 below: there
+  is no commit to credit, because there is no commit that could have caused
+  a regression in the bisect window. The bail's *action* is correct
+  (document and surface); its *narrative* needs the bifurcation correction
+  below.
+
+### R1.0b — refutation control: structurally moot on disk
+
+The pre-registered refutation control is a static-fixture comparison against
+a pre-regression commit. On disk:
+
+- `git log --oneline dac09e2..4a66ed8 -- shlav-a-mega.html` is **empty**
+  (zero commits to the monolith in the audit-7→audit-8 window).
+- `git log --oneline dac09e2..main -- shlav-a-mega.html` is **also empty**
+  (no monolith changes through current `main`).
+- `git log --oneline dac09e2..4a66ed8 -- scripts/chaos-doctor-bot-v4.mjs
+  scripts/lib/` has exactly **two** commits: `cc85f91` (#235 PRE-STEP
+  stemHash instrument) and `edfa433` (#236 frozen analyzer tooling).
+- Neither of those commits touches `extractQuestion`. `extractQuestion`'s
+  full git history (`git log --all -S "extractQuestion"`) is a single
+  commit `f0ac470` (the Geri-native v4 port, well before audit-7).
+
+A static-fixture comparison would compare byte-identical HTML on both sides
+and byte-identical extractor logic. The control collapses to a no-op: H1
+(live-DOM drift in the window) and the implicit alternative
+(bot-extractor regression in the window) are **both** structurally
+unavailable as causes — neither codebase changed.
+
+### R1.1 — bisect: no candidate commit exists in the pre-registered window
+
+Bisect was scoped (kickoff §1.1) to "the audit-7→audit-8 commit window" on
+the named codebase. With **zero** candidate commits on either side of the
+window (monolith: empty; bot extractor: never touched; only stemHash
+instrument + analyzer changed, and `git show cc85f91` confirms cc85f91 is
+the commit that **added** the `pre-pick-skip` telemetry — see below), the
+bisect has no oracle-tunable axis. Skipping it is **not** a procedure
+violation; it is the procedure's empty-set output.
+
+### The bifurcation finding — disk re-analysis of the audit-8 RESULT ledger
+
+The kickoff's frame (`docs/AUDIT8_G5_REPAIR_GATE.md` §0.2: "Extraction
+reached-pick fraction ≈ 509 / (509+3800) ≈ **11.8 %**") is a **time-pooled
+rate**. The per-minute distribution in
+`chaos-reports/v4-long/audit8_20260518T191705Z/chaos-doctor-v4-2026-05-19T03-17-08-116Z.json`
++ `medical_findings_ai_v4.jsonl` shows a **sharp bifurcation**, not a
+steady-state ~88 % failure (numbers from disk, deterministic — re-runnable
+by anyone with the ledger):
+
+- **Phase 1** (`19:17` → `22:30` Jerusalem, ≈ 3 h 14 min): **0**
+  `pre-pick-skip` events; **2–3** successful Qs per minute, steady.
+- **Transition** (`22:29:27` last ok → `22:31:07` first `pre-pick-skip`):
+  ~1 m 40 s gap. **Zero** `pageerror` / `requestfailed` / `console:error` /
+  `http >=400` / `methodology` events at the transition or in the preceding
+  10 min. The trigger has **no telemetry footprint**.
+- **Phase 2** (`22:31` → end-of-run `03:17`, ≈ 4 h 46 min): **13–14**
+  `pre-pick-skip` events per minute, **zero** successful Qs. Mean delta
+  between consecutive `pre-pick-skip` events 4.52 s (min 3.51, median 4.52,
+  max 5.53; 3799/3799 deltas in the 2–10 s bucket) — consistent with the
+  worker loop's short-path `ensureOnPracticeQuiz` (≈ 1.5 s) +
+  `extractQuestion` timeout accumulation (4 × `.innerText({ timeout: 500 })`
+  ≈ 2–3 s). dropCtx is **100 % `pre-pick-no-question`** — `extractQuestion`
+  returned `null` (not the short-extract variant).
+- **Recovery did NOT occur.** The 6 `stuck-refresh` events all fire in
+  Phase 1 (`19:25`, `19:42`, `20:01`, `20:21`, `20:47`, `21:38`); none fire
+  in Phase 2. The bot's `stuckCount` mechanism increments only when
+  `result.stemHash` is non-null AND equal to `lastStemHash`; failed
+  extractions return `stemHash: null`, so `stuckCount` never accumulates
+  during Phase 2, and the page is never reloaded. **The bot is structurally
+  unable to recover from Phase 2** with its current stuck-refresh contract.
+
+### Cross-check — audit-7 ledger (same instrument family, 4 h vs 8 h)
+
+`chaos-reports/v4-long/audit7_2026-05-18/chaos-doctor-v4-2026-05-18T09-29-42-226Z.json`:
+
+- Duration 4 h, 1 worker, 569 `qsAnswered`.
+- Per-15-min buckets across the full run: **flat at 32–40 successful Qs
+  per 15-min window**. No tail-off in the final 30 min (32, 36, 38, 36, 37
+  → last partial minute 1). Audit-7 **did not** hit the Phase-2 collapse.
+- Audit-7 ran *before* `cc85f91` (PRE-STEP): the `pre-pick-skip` bug-type
+  did not exist in its bot (`git show cc85f91 -- scripts/chaos-doctor-bot-v4.mjs`
+  shows the row being **added**; before #235 the same condition was a
+  silent `return { advanced: false, stemHash: null }`). So audit-7's ledger
+  cannot disprove that *some* extractions failed; it can only show that the
+  bot kept producing successful Qs at a flat rate to the end.
+
+The 4 h window puts the Phase-2 onset somewhere in `[3.2 h, > 4 h]`. It is
+not 0 % steady-state ("88 % extraction failure"), and not deterministically
+4 h either — it is a duration-gated, intermittent state corruption with no
+visible trigger in the available telemetry.
+
+### What this means for R1's locked procedure
+
+- **Hypothesis 2** (gate §"HYPOTHESES" item 2): "Something regressed
+  between audit-7 (4 h) and audit-8 (8 h)" was a "bisect signal, not a
+  measured regression magnitude." Disk evidence promotes it from
+  *unverified* to **structurally refuted**: the bisect window has no
+  monolith changes and the only relevant bot change was *adding the
+  telemetry*. The 4× G2 shortfall (30 vs the projected 110–130) is
+  consistent with audit-8 having spent ~4.7 h of its 8 h budget in a
+  failure mode that audit-7's 4 h budget never entered, not with a
+  per-question extraction regression.
+- **Hypothesis 1** (gate §0.3): "live-DOM / practice-surface drift"
+  is **not testable** by R1.0b on disk evidence — both sides of the
+  pre-registered comparison are byte-identical.
+- **R1.2 GREEN criterion** (gate §1.2): projects N_drop from a short
+  (≈ 15 min) post-fix probe via *reached-pick rate × drop-fraction*. A
+  short probe **systematically samples Phase 1 only** (Phase-2 onset is
+  ≥ 3.2 h). The projection is therefore not honest for a fix that targets
+  Phase-2 — it would over-state the recovered yield. This is exactly the
+  REV1.1 "denominator-shrink / criterion-swap-by-silence in the likely
+  branch" trap, applied to the rate-projection side.
+
+### Why no fix is shipped in this PR
+
+The smallest plausible scoped fix — a `null-stemHash`-aware consecutive
+`pre-pick-skip` counter that triggers `page.reload()` after N (5? 10?)
+events — would bound the blast radius of Phase-2 (Phase-2 events ride at
+~4.5 s each, so N=10 → ~45 s lost before recovery) without addressing the
+unknown trigger. That is a legitimate option, but adopting it inside this
+PR has two problems:
+
+1. **GREEN criterion math becomes structurally non-validating.** A 15-min
+   probe never enters Phase 2, so cannot witness the recovery-on-reload
+   path firing; "rate × duration projection from a non-representative
+   window" is the spec-provenance trap REV1.1 calls out
+   (`feedback_pre_commit_diagnostic_gates`).
+2. **Trigger remains unknown.** Without a reproducible trigger, the fix is
+   resilience-only, not causal — and the gate's R1 is *named* "extraction-
+   yield repair," not "bot resilience patch." Re-naming silently inside R1
+   would be the same provenance violation, just on a different axis.
+
+The honest action under §6 bail #1 (whose *action* is "document and
+surface, do not fabricate a fix") is to ship the probe + appended RESULT
+and let the gate author decide between two pre-registered branches (open
+question §below).
+
+### What this PR ships
+
+- `scripts/chaos-doctor-bot-v4.mjs`: minimal `export` keyword added to
+  `extractQuestion` and `ensureOnPracticeQuiz`. Regex-grep tests
+  (`chaosBotV4ModalDismiss.test.js`) still match — `async function` prefix
+  preserved. Bot CLI behavior unchanged (still gated by `isMain`).
+- `scripts/audit8/r1RedProbe.mjs`: the R1.0 RED probe, configurable via
+  `R1_PROBE_URL` / `R1_PROBE_N` / `R1_PROBE_HEADLESS` / `R1_PROBE_OUT` /
+  `R1_PROBE_LABEL` / `R1_PROBE_READ_PAUSE_MS` / `R1_PROBE_FORENSIC_SAMPLES`.
+  Default-emits JSON to `chaos-reports/r1RedProbe/<label>-<ts>.json`
+  (gitignored path; output is forensic, regenerable by re-running the
+  probe).
+- This appended R1 RESULT.
+- **Not shipped:** no fix to the bot, no fix to the monolith, no new test
+  pin (no fix → nothing to pin; the existing 21 chaosBotV4 tests stay
+  green).
+
+### Open question for the gate author (binding routing decision)
+
+Two pre-registered branches, neither selected here:
+
+- **Option A — close R1 findings-only.** R1's locked procedure (RED →
+  bisect → fix) is empirically empty given the disk evidence above.
+  Author an R1.5 (its own gate) re-registering a procedure that targets
+  the actual failure mode — a long-duration probe (≥ 4 h) with
+  screenshot-on-`pre-pick-skip`-streak + `pageerror`/`console` capture +
+  DOM-state dump on the *first* `pre-pick-skip` after a successful Q
+  (the transition itself), to give the next session telemetry the trigger
+  currently lacks. R2 and R3 stay blocked behind R1.5 closing.
+- **Option B — accept a scoped bot resilience patch as R1's fix.**
+  Add a `null-stemHash` consecutive-skip counter + `page.reload()` to
+  `runWorker`. Trinity untouched (bot-only, mirrors #235). Acknowledge in
+  R1.2 RESULT that the GREEN criterion is **not** rate-projection-validated
+  (the short probe cannot witness Phase 2); validation is via (a) unit
+  test of the new counter+reload contract, (b) projection from audit-8's
+  *Phase-1* rate × 8 h (2.5 Qs / min × 480 min ≈ 1200 reach-pick;
+  with audit-8's 5.9 % `ai-parse-error/pick` drop fraction ≈ **71 drops**
+  — still under G2's 80, **option B is not on its own a green outcome**,
+  it is a precondition for a follow-up surface that lifts drop-rate
+  separately or a longer R3). Re-naming the gate's R1 silently to "bot
+  resilience" is forbidden; the doc must say so.
+
+**The session author cannot select between A and B inside R1's
+pre-registered scope — it requires the gate author's call** (this is
+exactly the `feedback_design_gate_option_3_bias` carve-out applied to a
+gate-level routing decision, not a tactical implementation choice).
+
+### Trinity + verify
+
+- `npm run verify` green on this branch (`shlav-a-mega.html` + `sw.js` +
+  `package.json` untouched; the 6 non-vitest checks dominate before the
+  vitest tail; the chaos-bot test trio is the most-relevant slice and is
+  21/21 green).
+- No `verify-deploy.sh` post-merge: this is a docs + scripts PR, no
+  monolith change, no Pages cache to verify.
+
+### Provenance
+
+Append-only addition under the gate's pre-registered HTML-comment marker.
+R1 section above this line: **not edited**. R2 / R3 sections: still
+pending their own session's appended RESULT block.
+

--- a/scripts/audit8/r1RedProbe.mjs
+++ b/scripts/audit8/r1RedProbe.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+// AUDIT-8 G5 R1.0 RED probe — extraction-yield reproduction.
+//
+// Mission: deterministically reproduce the ≈88% pre-pick-skip rate the
+// AUDIT-8 8h bounded run logged on `4a66ed8` (#238 RESULT), using the
+// REAL chaos-doctor-bot-v4 extractor (`extractQuestion`) + entry path
+// (`ensureOnPracticeQuiz`) against the REAL practice surface — no proxy,
+// no hand-rolled imitation. The RED criterion is failure ≥ 0.85 over
+// ≥ 100 attempts (kickoff §1.0).
+//
+// Cost: free. No Claude API calls — extraction is pure DOM parsing.
+//
+// Env knobs (all optional):
+//   R1_PROBE_URL          live URL (default https://eiasash.github.io/Geriatrics/)
+//   R1_PROBE_N            attempts (default 100)
+//   R1_PROBE_HEADLESS     0 to run headed
+//   R1_PROBE_OUT          output JSON path (default chaos-reports/r1RedProbe/<ts>.json)
+//   R1_PROBE_LABEL        free-form label embedded in the report
+//   R1_PROBE_READ_PAUSE_MS    delay between attempts to mirror bot pacing (default 2500)
+//   R1_PROBE_FORENSIC_SAMPLES capture forensic snapshots for first N failures (default 10)
+//
+// Output: JSON file with { total, extractedOk, extractionFailures, failureRate,
+// RED, perMode{...}, samples[...], config{...} } and a one-line stdout summary.
+
+import { chromium } from 'playwright';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { extractQuestion, ensureOnPracticeQuiz } from '../chaos-doctor-bot-v4.mjs';
+
+const URL_DEFAULT = 'https://eiasash.github.io/Geriatrics/';
+
+const CONFIG = {
+  url: process.env.R1_PROBE_URL || URL_DEFAULT,
+  attempts: Math.max(10, Number(process.env.R1_PROBE_N || 100)),
+  headless: process.env.R1_PROBE_HEADLESS !== '0',
+  outPath: process.env.R1_PROBE_OUT || null,
+  label: process.env.R1_PROBE_LABEL || 'live-main',
+  readPauseMs: Math.max(100, Number(process.env.R1_PROBE_READ_PAUSE_MS || 2500)),
+  forensicSamples: Math.max(0, Number(process.env.R1_PROBE_FORENSIC_SAMPLES || 10)),
+  redThreshold: 0.85,
+};
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const nowIso = () => new Date().toISOString();
+
+async function classifyFailure(page) {
+  // Reproduce the extractor's null-paths so we can distinguish:
+  //   - no-heb         : 0 .heb elements on page (page hasn't rendered the stem)
+  //   - stem-throw     : .heb exists but innerText threw (rare)
+  //   - short-stem     : .heb exists but text < 20 chars
+  //   - no-qo          : button.qo count < 2
+  //   - empty-options  : button.qo count >= 2 but >=2 of them have empty text (skeleton)
+  //   - modal-blocked  : a known auto-modal is intercepting (#help-overlay etc.)
+  //   - other          : none of the above
+  const hebCount = await page.locator('.heb').count().catch(() => 0);
+  let stemText = '';
+  let stemThrew = false;
+  if (hebCount > 0) {
+    try {
+      stemText = (await page.locator('.heb').first().innerText({ timeout: 600 })).trim();
+    } catch (_) { stemThrew = true; }
+  }
+  const qoCount = await page.locator('button.qo').count().catch(() => 0);
+  let qoTexts = [];
+  if (qoCount > 0) {
+    for (let i = 0; i < Math.min(qoCount, 6); i++) {
+      try { qoTexts.push((await page.locator('button.qo').nth(i).innerText({ timeout: 400 })).trim()); }
+      catch (_) { qoTexts.push(''); }
+    }
+  }
+  const nonEmptyQo = qoTexts.filter((t) => t && t.length > 0).length;
+  const modalIds = ['help-overlay', 'feModal', 'sdModal', 'miModal', 'mockPicker', 'examModal', 'mexModal', 'postLoginRstModal', 'rstModal'];
+  let modalPresent = null;
+  for (const id of modalIds) {
+    if ((await page.locator('#' + id).count().catch(() => 0)) > 0) { modalPresent = id; break; }
+  }
+
+  let mode = 'other';
+  if (modalPresent && qoCount < 2) mode = 'modal-blocked';
+  else if (hebCount === 0) mode = 'no-heb';
+  else if (stemThrew) mode = 'stem-throw';
+  else if (stemText.length < 20) mode = 'short-stem';
+  else if (qoCount < 2) mode = 'no-qo';
+  else if (nonEmptyQo < 2) mode = 'empty-options';
+
+  return {
+    mode,
+    hebCount,
+    stemTextSlice: stemText.slice(0, 80),
+    stemLen: stemText.length,
+    stemThrew,
+    qoCount,
+    qoNonEmpty: nonEmptyQo,
+    qoFirstText: (qoTexts[0] || '').slice(0, 40),
+    modalPresent,
+  };
+}
+
+async function advance(page) {
+  // Use the bot's actual advancement path without burning AI calls: click
+  // first option → check → next. This matches the bot's iteration cadence
+  // shape; if Next is already showing (e.g., post-check state from a prior
+  // attempt) skip directly to Next.
+  const next0 = page.locator('[aria-label="Next question"], [aria-label="Finish exam"]').first();
+  if ((await next0.count().catch(() => 0)) > 0) {
+    await next0.click({ timeout: 2500 }).catch(() => {});
+    return 'next-direct';
+  }
+  // Need to pick something to reveal a Next. The probe doesn't care about
+  // medical correctness — first option is fine.
+  const qo0 = page.locator('button.qo').first();
+  if ((await qo0.count().catch(() => 0)) === 0) return 'no-qo';
+  await qo0.click({ timeout: 2500 }).catch(() => {});
+  await sleep(150);
+  const check = page.locator('[aria-label="Check answer"]').first();
+  if ((await check.count().catch(() => 0)) > 0) {
+    await check.click({ timeout: 2500 }).catch(() => {});
+    await sleep(250);
+  }
+  const next1 = page.locator('[aria-label="Next question"], [aria-label="Finish exam"]').first();
+  if ((await next1.count().catch(() => 0)) > 0) {
+    await next1.click({ timeout: 2500 }).catch(() => {});
+    return 'next-after-check';
+  }
+  return 'stuck';
+}
+
+async function main() {
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const outDefault = path.resolve('chaos-reports/r1RedProbe', `${CONFIG.label}-${stamp}.json`);
+  const outPath = CONFIG.outPath ? path.resolve(CONFIG.outPath) : outDefault;
+  await fs.mkdir(path.dirname(outPath), { recursive: true });
+
+  const browser = await chromium.launch({ headless: CONFIG.headless });
+  const ctx = await browser.newContext({
+    viewport: { width: 1280, height: 900 },
+    locale: 'he-IL',
+    timezoneId: 'Asia/Jerusalem',
+  });
+  ctx.setDefaultTimeout(8000);
+  const page = await ctx.newPage();
+  const log = { actions: [], bugs: [] };
+
+  console.error(`[r1RedProbe] navigate ${CONFIG.url} (label=${CONFIG.label}, N=${CONFIG.attempts})`);
+  await page.goto(CONFIG.url, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {});
+  await sleep(2000); // post-load settle (matches bot's initial sleep at runWorker:932)
+
+  const stats = {
+    config: { ...CONFIG, outPath },
+    startedAt: nowIso(),
+    finishedAt: null,
+    total: 0,
+    extractedOk: 0,
+    extractionFailures: 0,
+    ensureOnQuizFailures: 0,
+    advanceOutcomes: { 'next-direct': 0, 'next-after-check': 0, 'no-qo': 0, 'stuck': 0 },
+    perMode: { 'no-heb': 0, 'stem-throw': 0, 'short-stem': 0, 'no-qo': 0, 'empty-options': 0, 'modal-blocked': 0, 'other': 0 },
+    samples: [],
+  };
+
+  for (let i = 0; i < CONFIG.attempts; i++) {
+    const onQuiz = await ensureOnPracticeQuiz(page, log);
+    if (!onQuiz) {
+      stats.ensureOnQuizFailures += 1;
+      try { await page.reload({ waitUntil: 'domcontentloaded', timeout: 15_000 }); } catch (_) { /* tolerate */ }
+      await sleep(1500);
+      continue;
+    }
+    const q = await extractQuestion(page);
+    stats.total += 1;
+    if (!q || q.options.length < 2) {
+      stats.extractionFailures += 1;
+      const klass = await classifyFailure(page);
+      stats.perMode[klass.mode] = (stats.perMode[klass.mode] || 0) + 1;
+      if (stats.samples.length < CONFIG.forensicSamples) {
+        stats.samples.push({ attempt: i, ...klass });
+      }
+    } else {
+      stats.extractedOk += 1;
+    }
+    const adv = await advance(page);
+    stats.advanceOutcomes[adv] = (stats.advanceOutcomes[adv] || 0) + 1;
+    await sleep(CONFIG.readPauseMs);
+  }
+
+  stats.finishedAt = nowIso();
+  stats.failureRate = stats.total > 0 ? stats.extractionFailures / stats.total : null;
+  stats.RED = stats.total > 0 && stats.failureRate >= CONFIG.redThreshold;
+
+  await fs.writeFile(outPath, JSON.stringify(stats, null, 2));
+  console.log(JSON.stringify({
+    label: CONFIG.label,
+    url: CONFIG.url,
+    total: stats.total,
+    extractedOk: stats.extractedOk,
+    extractionFailures: stats.extractionFailures,
+    failureRate: stats.failureRate,
+    RED: stats.RED,
+    threshold: CONFIG.redThreshold,
+    ensureOnQuizFailures: stats.ensureOnQuizFailures,
+    perMode: stats.perMode,
+    outPath,
+  }, null, 2));
+
+  await browser.close().catch(() => {});
+}
+
+main().catch((e) => { console.error('[r1RedProbe] FATAL', e); process.exitCode = 1; });

--- a/scripts/chaos-doctor-bot-v4.mjs
+++ b/scripts/chaos-doctor-bot-v4.mjs
@@ -228,7 +228,7 @@ const LETTER_TO_IDX = { A: 0, B: 1, C: 2, D: 3, a: 0, b: 1, c: 2, d: 3, 'א': 0,
 // Question / answer extraction (v4 targeted)
 // ============================================================
 
-async function extractQuestion(page) {
+export async function extractQuestion(page) {
   // Geri renders the stem inside the quiz card; first .heb element after
   // the question card header is the stem. Skeleton-state .qo blocks have
   // ⠀ (braille blank) so we filter on stem length to skip pre-load state.
@@ -814,7 +814,7 @@ async function maybeReportQuestion(page, log, finding) {
 // v4: practice-mode entry — no start-mock, no exam mode
 // ============================================================
 
-async function ensureOnPracticeQuiz(page, log) {
+export async function ensureOnPracticeQuiz(page, log) {
   // Step 1: hydrate. Geri uses onclick handlers (no [data-action]); wait
   // for body to be ready and the quiz card to render.
   try {


### PR DESCRIPTION
R1 of the [AUDIT-8 G5 REPAIR pre-registered gate](https://github.com/Eiasash/Geriatrics/blob/main/docs/AUDIT8_G5_REPAIR_GATE.md). Ships the pre-registered RED probe + an appended R1 RESULT section. **No fix in this PR.** The disk evidence contradicts R1's locked-procedure premise (steady-state 88% extraction failure), and the closest §6 bail condition (#1: "do not fabricate a fix") routes here.

## §0 STEP-0 results

- `origin/main` HEAD = `655953b`; branch cut clean; no collision (`claude/audit8-g5-r1-*` had no prior branch); per-repo CLAUDE.md "single lane from 2026-05-19" satisfied.
- Anchors verified on disk: `extractQuestion` `scripts/chaos-doctor-bot-v4.mjs:231`, `ensureOnPracticeQuiz` `:817`; `showHelp` `shlav-a-mega.html:8217`, `closeTopModal` `:8285`. Bisect window endpoints: audit-7 `dac09e2`, audit-8 `4a66ed8`.
- Vitest pre/post export change: chaos-bot trio 21/21 green (regex-grep tests preserved by `async function` prefix retention).

## §1.0 RED probe output (pre-fix: did NOT reproduce)

Probe: `scripts/audit8/r1RedProbe.mjs`. Uses real `extractQuestion` + `ensureOnPracticeQuiz` from the bot (import-from-source, no proxy). N=100 attempts × ~2.5s pacing × `[aria-label=\"Next question\"]` advance, zero Claude API calls. Forensic mode classifies `no-heb` / `stem-throw` / `short-stem` / `no-qo` / `empty-options` / `modal-blocked` / `other`.

Run against current `main` (live URL):

| field | value |
|---|---|
| total | 100 |
| extractedOk | 100 |
| extractionFailures | 0 |
| failureRate | 0.000 |
| RED criterion (≥ 0.85) | **NOT met** |
| ensureOnQuizFailures | 0 |

Per-mode counters all zero.

## §1.0b Refutation control output (structurally moot on disk)

The pre-registered control (live-DOM vs static pre-regression fixture) collapses to a no-op:

```
git log --oneline dac09e2..4a66ed8 -- shlav-a-mega.html       # EMPTY
git log --oneline dac09e2..main    -- shlav-a-mega.html       # EMPTY
git log --oneline dac09e2..4a66ed8 -- scripts/chaos-doctor-bot-v4.mjs scripts/lib/
#   cc85f91 (#235 PRE-STEP stemHash instrument — ADDS pre-pick-skip telemetry)
#   edfa433 (#236 frozen pick-representativeness analyzer — offline tool)
git log --all -S "extractQuestion" -- scripts/chaos-doctor-bot-v4.mjs
#   f0ac470 (chore(scripts): chaos-doctor-bot v4 — Geri-native port) — only one
```

Both sides of the static-fixture comparison are byte-identical. H1 (live-DOM drift) and the implicit alternative (bot-extractor regression in the window) are **both structurally unavailable as causes**.

## §1.1 Root-cause: bisect has no candidate in the pre-registered window

Empty-set output for the pre-registered scope. Skipping bisect is the procedure's empty-set output, not a procedure violation. See appended RESULT for `git show cc85f91 -- scripts/chaos-doctor-bot-v4.mjs` proof that the `pre-pick-skip` row is **added** in #235 (so audit-7 silently lacked the telemetry to measure any failures — its flat 4h success rate is consistent with either "no failures" or "failures-but-invisible").

## Bifurcation finding (the new fact this PR surfaces)

The kickoff's `~88%` rate is **time-pooled across a sharply bifurcated run**. Re-analyzing the audit-8 RESULT ledger (`chaos-reports/v4-long/audit8_20260518T191705Z/`):

| Phase | Window | Duration | pre-pick-skip | ok |
|---|---|---|---:|---:|
| Phase 1 | `19:17` → `22:30` | ≈ 3 h 14 min | **0** | 2–3 / min |
| Transition | `22:29:27` last ok → `22:31:07` first pps | ≈ 1 m 40 s | — | — |
| Phase 2 | `22:31` → `03:17` (end) | ≈ 4 h 46 min | **13–14 / min** | **0** |

- Mean delta between Phase-2 `pre-pick-skip` events: 4.52s (min 3.51 / max 5.53; 3799/3799 in 2-10s bucket). Consistent with worker-loop short-path `ensureOnPracticeQuiz` (~1.5s) + 4× `.innerText({timeout:500})` accumulation (~2-3s).
- dropCtx 100% `pre-pick-no-question` → `extractQuestion` returned `null` outright.
- **Zero `pageerror` / `console:error` / `requestfailed` / `http>=400` / `methodology` events at the transition or in the preceding 10 min.** No telemetry footprint for the trigger.
- 6 stuck-refresh events all fire **in Phase 1**; **none fire in Phase 2** — because the bot's `stuckCount` increments only on non-null `result.stemHash` matching `lastStemHash`, and failed extractions return `stemHash: null`. The bot is structurally unable to recover from Phase 2 with its current stuck-refresh contract.

Audit-7 cross-check (`chaos-reports/v4-long/audit7_2026-05-18/`, 4h, 569 ok): **flat 32-40 ok per 15-min window across the full 4h**, no tail-off. Never hit Phase 2. → Phase-2 onset is duration-gated to ≥ 3.2h, intermittently; audit-7's 4h budget escaped it, audit-8's 8h budget did not.

## §1.2 GREEN criterion math

R1.2's pre-registered GREEN criterion (`docs/AUDIT8_G5_REPAIR_GATE.md` §1.2) projects N_drop via *short-probe reached-pick rate × drop-fraction-among-reached*. A ≈ 15 min probe **systematically samples Phase 1 only** (Phase-2 onset ≥ 3.2 h). The projection is **non-validating for any fix that targets Phase-2** — it would over-state recovered yield.

Honest projection of Option B (scoped bot resilience) using audit-8's *Phase-1* rate × 8 h × audit-8's Phase-1 drop fraction:

| input | value |
|---|---|
| Phase-1 rate | 479 ok / 193 min = 2.48 Qs / min |
| Scaled to 8h | 2.48 × 480 = **≈ 1190 reach-pick** |
| Drop fraction (Phase 1 `ai-parse-error`/pick) | 30 / 509 = **5.9 %** |
| Projected N_drop | 1190 × 0.059 = **≈ 70** |

**< 80 → fails G2 N_drop ≥ 80 on its own.** Option B is a precondition for closure, not a closure on its own.

## Open routing question (§ "Open question for the gate author" in the appended RESULT)

- **Option A — close R1 findings-only.** R1's locked procedure (RED → bisect → fix) is empirically empty given the disk evidence. Author an R1.5 (its own gate) re-registering a procedure that targets the actual failure mode — long-duration probe (≥ 4 h) with screenshot-on-`pre-pick-skip`-streak + `pageerror`/`console` capture + DOM-state dump on the *first* `pre-pick-skip` after a successful Q. R2 and R3 stay blocked behind R1.5 closing.
- **Option B — accept a scoped bot resilience patch as R1's fix.** `null-stemHash` consecutive-skip counter + `page.reload()` in `runWorker`. Trinity untouched, GREEN validated by (a) unit test of counter+reload contract, (b) Phase-1-rate × 8h projection (≈ 70 drops; **under 80 — needs a separate drop-rate surface or R3 budget bump to close G2**). Re-naming the gate's R1 silently to "bot resilience" is forbidden; the doc must say so.

The session author cannot select between A and B inside R1's pre-registered scope — gate-author call (`feedback_design_gate_option_3_bias` carve-out, applied to a gate-level routing decision).

## Changes shipped

- `scripts/chaos-doctor-bot-v4.mjs`: minimal `export` on `extractQuestion` + `ensureOnPracticeQuiz` (2 lines). Bot CLI behavior unchanged (`isMain` guard preserved); regex-grep tests still match (`async function` prefix retained).
- `scripts/audit8/r1RedProbe.mjs`: the R1.0 RED probe, env-configurable.
- `docs/AUDIT8_G5_REPAIR_GATE.md`: appended R1 RESULT under the pre-registered HTML-comment marker. **R1 section above the marker is not retro-edited** (append-only per `feedback_spec_provenance_append_only`).

## Trinity + verify

`npm run verify`: **green** (79 files / 1469 passed, 7 skipped). Trinity untouched (bot/scripts/docs only — mirrors #235). No `verify-deploy.sh` post-merge — no monolith change, no Pages cache to verify.

## Review

- CI + Codex.
- Audit-evidence path → **NO self-merge**. Eias merges and selects Option A vs B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)