### PR TITLE
fix(weekly-audit): respect allow_dup, broken, c_accept in conflict check

### DIFF
--- a/.github/workflows/weekly-audit.yml
+++ b/.github/workflows/weekly-audit.yml
@@ -60,17 +60,35 @@ jobs:
 
       - name: Check for conflicting duplicates
         run: |
-          python3 -c "
+          python3 << 'PYEOF'
+          # Respect canonical authority flags:
+          #   - allow_dup=True  → intentional curator-flagged duplicate (936 Qs on main)
+          #   - broken=True     → explicitly suppressed (~24 Qs), skip integrity checks
+          #   - c_accept        → multi-accept; if one Q's c is in the other's c_accept,
+          #                       the chosen answers are compatible, not conflicting
           import json, sys
           qs = json.load(open('data/questions.json'))
           seen = {}
           conflicts = []
+          intentional_skipped = 0
           for i, q in enumerate(qs):
+              if q.get('broken'):
+                  continue
               key = q['q'].strip()[:80]
               if key in seen:
                   j = seen[key]
-                  if qs[i]['c'] != qs[j]['c']:
-                      conflicts.append((j, i, key[:60]))
+                  qi, qj = qs[i], qs[j]
+                  if qi['c'] == qj['c']:
+                      continue
+                  # Intentional duplicates marked by curator
+                  if qi.get('allow_dup') and qj.get('allow_dup'):
+                      intentional_skipped += 1
+                      continue
+                  # c_accept compatibility: chosen answers cross-accepted
+                  if qi['c'] in qj.get('c_accept', []) or qj['c'] in qi.get('c_accept', []):
+                      intentional_skipped += 1
+                      continue
+                  conflicts.append((j, i, key[:60]))
               else:
                   seen[key] = i
           if conflicts:
@@ -78,8 +96,11 @@ jobs:
               for j, i, k in conflicts:
                   print(f'  Q{j} vs Q{i}: {k}...')
               sys.exit(1)
-          print('OK: No conflicting duplicates')
-          "
+          msg = 'OK: No conflicting duplicates'
+          if intentional_skipped:
+              msg += f' ({intentional_skipped} curator-flagged / c_accept-compatible pairs skipped)'
+          print(msg)
+          PYEOF
 
       - name: Check topic coverage (min 5 per topic)
         run: |

--- a/.github/workflows/weekly-audit.yml
+++ b/.github/workflows/weekly-audit.yml
@@ -66,17 +66,20 @@ jobs:
           #   - broken=True     → explicitly suppressed (~24 Qs), skip integrity checks
           #   - c_accept        → multi-accept; if one Q's c is in the other's c_accept,
           #                       the chosen answers are compatible, not conflicting
+          # Compare each new occurrence against ALL prior occurrences of the same
+          # stem (not just the first) so a skipped pair doesn't shadow a real
+          # conflict later in a triplet.
           import json, sys
           qs = json.load(open('data/questions.json'))
-          seen = {}
+          seen = {}  # key -> list of prior indices
           conflicts = []
           intentional_skipped = 0
           for i, q in enumerate(qs):
               if q.get('broken'):
                   continue
               key = q['q'].strip()[:80]
-              if key in seen:
-                  j = seen[key]
+              priors = seen.get(key, [])
+              for j in priors:
                   qi, qj = qs[i], qs[j]
                   if qi['c'] == qj['c']:
                       continue
@@ -89,8 +92,7 @@ jobs:
                       intentional_skipped += 1
                       continue
                   conflicts.append((j, i, key[:60]))
-              else:
-                  seen[key] = i
+              seen.setdefault(key, []).append(i)
           if conflicts:
               print(f'CRITICAL: {len(conflicts)} conflicting duplicates:')
               for j, i, k in conflicts:


### PR DESCRIPTION
## Problem

After #245 (schema-check fix) merged, I dispatched the Weekly Audit to verify on a live run. The schema check now passes ✓, but the NEXT step — `Check for conflicting duplicates` — failed with 4 'CRITICAL' conflicts. This failure was previously masked because the schema check was failing earlier in the job.

All 4 reported conflicts are **legitimate** per the canonical schema and authority flags:

| Pair | Reason it shouldn't be flagged |
|------|--------------------------------|
| Q2415 vs Q2726 | Q2415 has `broken=True` — explicitly suppressed |
| Q2492 vs Q3169 | both have `allow_dup=True`, c_accept-compatible |
| Q2525 vs Q3205 | both have `allow_dup=True`, c_accept-compatible |
| Q3526 vs Q3527 | both have `allow_dup=True` |

## Root cause

The duplicate check ignored three canonical authority signals documented in the project memory:

- `broken=True` (~24 Qs) → explicitly suppressed; should not participate in integrity checks
- `allow_dup=True` (936 Qs) → curator-flagged intentional duplicates where differing `c` is by design
- `c_accept` (48 Qs) → multi-accept output of the v10.64.102–108 reframe pipeline; if one Q's `c` is in the other's `c_accept`, the chosen answers are compatible, not conflicting

## Fix

- Skip `broken` Qs at the top of the loop (don't even add them to the seen map).
- For stem-prefix duplicates with differing `c`, only flag if NEITHER `allow_dup` pair NOR `c_accept`-compatible.
- Real conflicts still fail (synthetic-injected negative test passes).
- Print count of intentionally-skipped pairs for visibility.

## Verification (pre-commit gate)

Against `main` HEAD:
```
PASS: 0 conflicts (3 curator-flagged / c_accept-compatible pairs correctly skipped)
PASS: synthetic conflict still flagged
```

Pair 1 (Q2415 with `broken=True`) is filtered out before participating in stem-matching, hence 3 (not 4) appear in `intentional_skipped`.

## Scope

Workflow-only change. No app code, no data, no trinity bump. Same self-merge carve-out as #245.

After merge: I'll re-dispatch the Weekly Audit to confirm the full job passes.
