### PR TITLE
fix(weekly-audit): replace stale 'no GRS anywhere' check with scoped notes.ch hygiene

### DIFF
--- a/.github/workflows/weekly-audit.yml
+++ b/.github/workflows/weekly-audit.yml
@@ -140,19 +140,31 @@ jobs:
           print('OK: No eval() calls')
           "
 
-      - name: Check no GRS references
+      - name: Check notes.ch citation hygiene (Hazzard/Harrison/GRS8 only)
         run: |
           python3 -c "
-          import sys
-          html = open('shlav-a-mega.html').read()
-          data_files = ['data/questions.json','data/notes.json','data/flashcards.json']
-          for f in data_files:
-              content = open(f).read()
-              if 'GRS' in content:
-                  print(f'ERROR: GRS reference found in {f}'); sys.exit(1)
-          if 'GRS' in html:
-              print('ERROR: GRS reference found in HTML'); sys.exit(1)
-          print('OK: No GRS references in app or data')
+          import json, re, sys
+          notes = json.load(open('data/notes.json'))
+          # Exception per policy: legal-topic notes (ids 29..35) may cite Israeli law.
+          legal_ids = set(range(29, 36))
+          bad = []
+          for n in notes if isinstance(notes, list) else []:
+              if n.get('id') in legal_ids:
+                  continue
+              ch = str(n.get('ch','')).strip()
+              if not ch:
+                  continue
+              # Allow: 'Hazzard', 'Harrison', 'GRS8' (with digit). Reject legacy bare 'GRS'.
+              has_legacy = bool(re.search(r'\\bGRS(?!\\d)', ch))
+              ok_anchor = ('Hazzard' in ch) or ('Harrison' in ch) or ('GRS8' in ch)
+              if has_legacy or not ok_anchor:
+                  bad.append((n.get('id'), ch[:80]))
+          if bad:
+              print(f'ERROR: {len(bad)} notes with bad citation:')
+              for nid, ch in bad[:10]:
+                  print(f'  note id={nid}: {ch}')
+              sys.exit(1)
+          print(f'OK: {len(notes) if isinstance(notes, list) else 0} notes, citation hygiene clean')
           "
 
       - name: Audit innerHTML sanitization


### PR DESCRIPTION
## Problem

Second downstream stale-rule failure in the same Weekly Audit workflow. With #245's schema fix in place, the next step now reaches the runner and fails:

```
✗ failure  Check no GRS references
```

The check is a blanket "no GRS anywhere in data files or HTML" rule, built on a premise that's no longer policy.

## Actual GRS state on main

| File | GRS count | Status |
|------|-----------|--------|
| `data/notes.json` | 0 | clean |
| `data/flashcards.json` | 0 | clean |
| `data/questions.json` | 225 across 90 Qs | **all `GRS8`** — legitimate citations |
| `shlav-a-mega.html` | 43 | UI strings (`GRS8 Book 3 questions in this chapter`), feature code (`_grsData`, `_grsPanel`) |

Per the project knowledge hierarchy:
> SZMC DAG > Hazzard 8e > **GRS (AGS/Kendall-Hunt)** > Harrison 22e > Washington Manual

GRS is back as a primary source. The blanket ban is obsolete.

## Fix

Replace with the actual surviving rule from policy:

> Notes citation: `notes.ch` must cite Hazzard 8e or Harrison 22e (GRS8 ok; no legacy GRS). Exception: ids 29–35 (legal topics) may cite Israeli law.

The new check:
- iterates `notes[].ch`
- skips legal-topic ids (29..35)
- forbids bare `GRS` not followed by a digit (catches legacy citations like just `GRS`)
- requires a positive citation anchor: `Hazzard` / `Harrison` / `GRS8`

This is stricter than the old check in one respect — it now enforces that citations actually point somewhere — but on current data it passes cleanly (46 notes, all valid).

## Verification (pre-commit gate)

```
PASS: 46 notes, all citations Hazzard/Harrison/GRS8 (or legal exception)
```

## Scope

Workflow-only. No app code, no data, no trinity. Self-merge OK on CI/claude-review green per captain-mode carve-out (not audit-evidence, not PHI).
