### PR TITLE
fix(weekly-audit): acorn extractor handles multi-script HTML and string-literal false positives

### DIFF
--- a/.github/workflows/weekly-audit.yml
+++ b/.github/workflows/weekly-audit.yml
@@ -178,17 +178,30 @@ jobs:
         run: |
           npm ci
           node -e "
-          const html = require('fs').readFileSync('shlav-a-mega.html','utf8');
-          const start = html.lastIndexOf('<script>');
-          const end = html.lastIndexOf('</script>');
-          const js = html.substring(start+8, end);
-          try {
-            require('acorn').parse(js, { ecmaVersion: 2022, sourceType: 'script' });
-            console.log('OK: JS parses without errors');
-          } catch(e) {
-            console.error('JS SYNTAX ERROR at line', e.loc?.line, ':', e.message);
+          const fs = require('fs');
+          const acorn = require('acorn');
+          const html = fs.readFileSync('shlav-a-mega.html','utf8');
+          // Match <script>\\n...\\n</script> blocks. The newline anchors avoid matching
+          // '<script>' inside other scripts' string literals.
+          const re = /<script>\\n([\\s\\S]*?)\\n<\\/script>/g;
+          let m, blocks = 0;
+          while ((m = re.exec(html)) !== null) {
+            blocks++;
+            const offset = m.index + '<script>\\n'.length;
+            try {
+              acorn.parse(m[1], { ecmaVersion: 2024, sourceType: 'script' });
+            } catch(e) {
+              console.error('JS SYNTAX ERROR in inline block #' + blocks +
+                            ' (file offset ' + offset + ') at line ' + e.loc?.line +
+                            ':' + e.loc?.column + ' — ' + e.message);
+              process.exit(1);
+            }
+          }
+          if (blocks === 0) {
+            console.error('No inline <script> blocks found — extractor regex likely broken');
             process.exit(1);
           }
+          console.log('OK: ' + blocks + ' inline <script> blocks parse without errors');
           "
 
       # ── Tests ──


### PR DESCRIPTION
## Problem

Third downstream stale-rule failure in this workflow. After #245 (schema) and #247 (GRS), the next step finally reaches the runner and fails:

```
✗ failure  Check JS syntax with acorn
JS SYNTAX ERROR at line 1 : Unexpected token (1:91)
```

## Diagnosis

The extractor uses:

```js
const start = html.lastIndexOf('<script>');
const end   = html.lastIndexOf('</script>');
const js    = html.substring(start+8, end);
```

That worked when the file had exactly one inline `<script>` block at the bottom. On main today:

- `shlav-a-mega.html` has **6 unattributed `<script>` blocks** + **6 `<script src=...>` blocks**.
- `lastIndexOf('<script>')` resolves to byte **686259**, the tiny 67-byte `PWA_INSTALL_CONFIG` inline.
- `lastIndexOf('</script>')` resolves to byte **686412**, which is a *later* closing tag — from one of the external-src script tags after the PWA_INSTALL_CONFIG block.
- So the extracted slice includes raw HTML like `</script>\n<script src="shared/install-promo.js" defer>` starting at column 91. Acorn chokes on `<` at exactly column 91. Matches the error.

A second hazard: two `<script>` substrings at bytes **564294** and **620172** live inside *other* scripts' string literals — one is an XSS-warning UI string reading `'<script>/javascript:'`. A naïve scan would pick those up as real script tags.

## Fix

Iterate every `<script>\n...\n</script>` block via a regex anchored by newlines.

- The newline anchor (a) excludes string-literal occurrences (those don't have a newline immediately after `<script>`) and (b) excludes `<script src=...>` (those don't start with `<script>` either).
- Validates **every** legitimate inline block, not just one.
- Hard-fail if zero blocks are found — guards against future regex breakage.
- ecmaVersion bumped 2022 → 2024.

## Verification (pre-commit gate)

Local on `main`:

```
OK: 3 inline <script> blocks parse without errors
```

The 3 are: the DOMContentLoaded handler (byte 63485), the main app (byte 66118), and PWA_INSTALL_CONFIG (byte 686259). The 2 string-literal false positives at 564294 / 620172 are correctly excluded.

## Sweep context

This is the third PR closing stale-rule debt in this workflow. With this in, all upstream steps now reach the runner and pass on the latest manual dispatch; remaining downstream steps (vitest, CLAUDE.md drift) are either already-green or warning-only and will not block.

## Scope

Workflow-only. No app code, no data, no trinity. Self-merge OK on CI/claude-review green per captain-mode carve-out (not audit-evidence, not PHI).
