### PR TITLE
fix(weekly-audit): acorn — single-line scripts, non-empty guard, module sourceType

### DIFF
--- a/.github/workflows/weekly-audit.yml
+++ b/.github/workflows/weekly-audit.yml
@@ -177,32 +177,40 @@ jobs:
       - name: Check JS syntax with acorn
         run: |
           npm ci
-          node -e "
+          node << 'NODEEOF'
           const fs = require('fs');
           const acorn = require('acorn');
           const html = fs.readFileSync('shlav-a-mega.html','utf8');
-          // Match <script>\\n...\\n</script> blocks. The newline anchors avoid matching
-          // '<script>' inside other scripts' string literals.
-          const re = /<script>\\n([\\s\\S]*?)\\n<\\/script>/g;
-          let m, blocks = 0;
+          // Match each <script ...>...</script> block (multi-line OR single-line,
+          // with or without attributes). Empty/external-src blocks are skipped.
+          // Inline blocks with type='module' are parsed as ES modules so
+          // import/export don't get reported as syntax errors.
+          const re = /<script\b([^>]*)>([\s\S]*?)<\/script>/g;
+          let m, blocks = 0, parsed = 0;
           while ((m = re.exec(html)) !== null) {
             blocks++;
-            const offset = m.index + '<script>\\n'.length;
+            const attrs = m[1];
+            const body = m[2];
+            if (!body.trim()) continue;  // empty / external-src blocks
+            const innerStart = m.index + m[0].indexOf('>') + 1;
+            const isModule = /\btype\s*=\s*["']module["']/.test(attrs);
+            parsed++;
             try {
-              acorn.parse(m[1], { ecmaVersion: 2024, sourceType: 'script' });
+              acorn.parse(body, { ecmaVersion: 2024, sourceType: isModule ? 'module' : 'script' });
             } catch(e) {
               console.error('JS SYNTAX ERROR in inline block #' + blocks +
-                            ' (file offset ' + offset + ') at line ' + e.loc?.line +
-                            ':' + e.loc?.column + ' — ' + e.message);
+                            ' (file offset ' + innerStart + ', sourceType=' +
+                            (isModule ? 'module' : 'script') + ') at line ' +
+                            e.loc?.line + ':' + e.loc?.column + ' — ' + e.message);
               process.exit(1);
             }
           }
-          if (blocks === 0) {
-            console.error('No inline <script> blocks found — extractor regex likely broken');
+          if (parsed === 0) {
+            console.error('No inline-with-body <script> blocks found — extractor regex likely broken');
             process.exit(1);
           }
-          console.log('OK: ' + blocks + ' inline <script> blocks parse without errors');
-          "
+          console.log('OK: ' + blocks + ' total blocks, ' + parsed + ' non-empty parsed without errors');
+          NODEEOF
 
       # ── Tests ──
       - name: Run Vitest tests


### PR DESCRIPTION
## Problem

Three real issues with the current `Check JS syntax with acorn` step (added in #249, addressed in closed-without-merge #250). All three are P2s from Codex review on #250 that didn't get applied because #250 had a base conflict after #249 landed.

| # | Issue | Impact |
|---|-------|--------|
| 1 | Regex requires `\n` after `<script>` and before `</script>` | Misses single-line `<script>...</script>` blocks. `shlav-a-mega.html` has one at line 8352 (`window.PWA_INSTALL_CONFIG`) that's invisible to this check today. |
| 2 | Zero-block guard checks `blocks === 0` (counts external `src=` tags) | A file with only external scripts would pass while parsing zero actual JS — false-green. |
| 3 | All blocks parsed with `sourceType: 'script'` | An inline `<script type='module'>` with `import`/`export` would be reported as a syntax error despite being browser-valid. |

## Fix

```js
// 1. Match attribute-bearing AND single-line tags:
const re = /<script\b([^>]*)>([\s\S]*?)<\/script>/g;
//                  ^^^^^^^         attrs captured for module check

while ((m = re.exec(html)) !== null) {
  blocks++;
  const body = m[2];
  if (!body.trim()) continue;        // skip empty/external-src
  parsed++;
  const isModule = /\btype\s*=\s*[\"']module[\"']/.test(m[1]);
  // 3. Parse modules as modules:
  acorn.parse(body, { ecmaVersion: 2024, sourceType: isModule ? 'module' : 'script' });
}

// 2. Real non-empty count:
if (parsed === 0) { /* error */ }
```

## Verification

Local against `main` HEAD `shlav-a-mega.html`:
```
OK: 10 total blocks, 4 non-empty parsed without errors
```

(4 non-empty = 2 header scripts + 620 KB main app + 91-char PWA config. 6 are external `src=` and now correctly skipped without counting toward the guard.)

Synthetic: `<script type='module'>import x from './y.js'; export const z=1;</script>` parses cleanly under the new logic (would have errored under `sourceType:'script'`).

## Scope

Workflow-only. Same self-merge carve-out as #245/#246/#248/#249. After merge I'll re-dispatch Weekly Audit to confirm the full job goes green end-to-end.
