### PR TITLE
docs(claude): define "Codex green" + disable auto-merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,10 @@ Claude lane, and no `claude/web-` vs `claude/term-` branch split.
 
 Workflow: branch `claude/<slug>` -> PR -> CI green + Codex review -> Claude Code
 self-merges -> post-merge `verify-deploy`. Codex is the independent automated
-reviewer. Codex green + CI green is sufficient self-merge authority. Eias sign-off is required only for: (a) PRs touching patient-data paths (ward-helper PHI crypto, IDB roster schema, rounds-data persistence — enumerated in ward-helper codeowners, queued as follow-up PR), and (b) per-PR gate docs that explicitly carry a "NO self-merge" clause (audit-8 R1.5 / R1.6 and subsequent R1.x gates). Claude Code never self-certifies its own audit — independence comes from cross-model review (Codex), not from human-vs-AI gates. All release,
+reviewer. Codex green + CI green is sufficient self-merge authority.
+**"Codex green" is defined as:** review state ∈ {`APPROVED`, `COMMENTED`} AND no unresolved P0 or P1 inline comments at the moment of merge. P2 inline comments may self-merge with an in-thread reply explaining the decision. Auto-merge (`gh pr merge --auto`) is **disabled** — every self-merge requires explicitly reading the latest Codex review surface and CI status before merging. If Codex has not reviewed and the PR is substantive, wait or ping; do not deadline-out a missing reviewer on non-trivial changes.
+
+ Eias sign-off is required only for: (a) PRs touching patient-data paths (ward-helper PHI crypto, IDB roster schema, rounds-data persistence — enumerated in ward-helper codeowners, queued as follow-up PR), and (b) per-PR gate docs that explicitly carry a "NO self-merge" clause (audit-8 R1.5 / R1.6 and subsequent R1.x gates). Claude Code never self-certifies its own audit — independence comes from cross-model review (Codex), not from human-vs-AI gates. All release,
 version-trinity, and verification rules in the repo's skill still apply
 unchanged.
 


### PR DESCRIPTION
## What

Defines "Codex green" precisely in the self-merge rule. One-paragraph addition right after the existing self-merge clause in CLAUDE.md.

## Why

PR #212 on `watch-advisor2` broke `vitest` on main by ignoring a Codex **P1** inline comment that named the exact file, line, and failure mechanism (`tests/phase5_6.test.js`, `readFileSync`, `ENOENT`). Codex's review *state* was `COMMENTED` (Codex never uses `CHANGES_REQUESTED` for this kind of finding), so under the rule's literal reading "Codex green + CI green is sufficient" the PR self-merged 72 seconds after Codex's comment landed — auto-merge fired the moment CI flipped.

The rule was technically followed and substantively violated. This addendum closes that gap by:

1. **Defining `Codex green`** to mean `state ∈ {APPROVED, COMMENTED}` **AND** no unresolved P0/P1 inline comments.
2. **Disabling `gh pr merge --auto`** — every self-merge requires reading the most recent Codex review at the moment of merge.

## Source of truth

The phrase "no unresolved P1" is **not new** — it's already in `ward-helper/CLAUDE.md` (the PHI repo). This PR ports the existing language into the 5 sibling repos that were missing it.

## Why this PR is open for human review, not self-merged

Per the recent operating lesson (2026-05-21): *Captain mode does not override the value of a second reviewer.* Governance docs that define when self-merge is allowed are exactly the meta-case where the rule itself should not be modified by automation. Eias sign-off required.

## Scope

| Repo | Status |
|---|---|
| watch-advisor2 | this PR |
| Toranot | parallel PR |
| Geriatrics | parallel PR |
| InternalMedicine | parallel PR |
| FamilyMedicine | parallel PR |
| ward-helper | **no change** — already has the `no unresolved P1` clause |

🤖 Prepared by Claude (claude.ai web, captain mode)
