### PR TITLE
fix: make merge-questions.cjs aware of the v10.64.93 explanations split

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -47,7 +47,12 @@ Generates a JSON file with validated questions in the app schema:
 
 ## merge-questions.cjs
 
-Merges generated questions into `data/questions.json` with dedup.
+Merges generated questions into `data/questions.json` with dedup. Each input
+question's `e` (explanation) is split out into `data/explanations.json` at the
+parallel array index — `questions.json` carries no inline `e` (post-v10.64.93).
+`_*`-prefixed provenance fields are stripped. `e` is optional on input. Existing
+entries in `questions.json` are preserved byte-identical (textual append);
+`explanations.json` is re-serialised minified.
 
 ```bash
 # Preview merge (dry run)

--- a/scripts/merge-questions.cjs
+++ b/scripts/merge-questions.cjs
@@ -90,9 +90,13 @@ function mergeQuestions(existingQs, existingExps, generated) {
 function appendToQuestionsText(existingText, newQs) {
   const close = existingText.lastIndexOf(']');
   if (close < 0) throw new Error('questions.json: no closing "]" found');
-  const head = existingText.slice(0, close).replace(/\s+$/, '');   // ends at the last "}"
+  const head = existingText.slice(0, close).replace(/\s+$/, '');
   const body = newQs.map(q => JSON.stringify(q, null, 1).replace(/^ +/gm, '')).join(',\n');
-  return `${head},\n${body}\n]`;
+  // `head` is exactly "[" only when the existing array is empty — then the
+  // first appended entry must NOT be preceded by a comma (would yield "[,…",
+  // invalid JSON). Otherwise `head` ends at the last "}" and needs the comma.
+  const sep = head === '[' ? '\n' : ',\n';
+  return `${head}${sep}${body}\n]`;
 }
 
 function main() {

--- a/scripts/merge-questions.cjs
+++ b/scripts/merge-questions.cjs
@@ -1,70 +1,144 @@
 #!/usr/bin/env node
+'use strict';
 /**
- * Merge generated questions into data/questions.json
- * 
+ * Merge generated questions into data/questions.json + data/explanations.json.
+ *
+ * Post-v10.64.93 the explanation lives in data/explanations.json — a flat array
+ * of strings PARALLEL TO questions.json BY ARRAY INDEX (explanations[i] is the
+ * explanation for questions[i]; questions.json carries no inline `e`). This
+ * script therefore:
+ *   - validates each input question (q / o[4] / c:int-in-range / t / ti:int —
+ *     `e` is NOT required for validity: a question with no explanation is still
+ *     a valid question, it just gets an empty explanation),
+ *   - dedups against the existing corpus by the first 80 chars of the stem,
+ *   - splits each merged question into a clean question object (canonical keys
+ *     only — `e` and every `_*` provenance field stripped) and an explanation
+ *     string, appending them at the SAME index to the two files.
+ *
+ * File-format handling:
+ *   - questions.json is rewritten by textual append — the existing entries are
+ *     left byte-identical. Its on-disk format (newline-separated, zero-indent)
+ *     is a Python format pass that Node's JSON.stringify cannot reproduce
+ *     byte-exact, so re-serialising the whole file would create a spurious
+ *     multi-thousand-line diff.
+ *   - explanations.json is re-serialised minified — Node JSON.stringify
+ *     round-trips it byte-exact (it is written that way by regen_explanations_v2).
+ *
  * Usage:
- *   node scripts/merge-questions.js generated-questions-12345.json
- *   node scripts/merge-questions.js generated-questions-12345.json --dry-run
+ *   node scripts/merge-questions.cjs <generated-file.json> [--dry-run]
  */
 
 const fs = require('fs');
 const path = require('path');
 
-const inputFile = process.argv[2];
-const dryRun = process.argv.includes('--dry-run');
+const Q_PATH = path.resolve(__dirname, '..', 'data', 'questions.json');
+const E_PATH = path.resolve(__dirname, '..', 'data', 'explanations.json');
 
-if (!inputFile) {
-  console.error('Usage: node scripts/merge-questions.js <generated-file.json> [--dry-run]');
-  process.exit(1);
+/** Strip `e` and every `_*` provenance key → a clean canonical question object. */
+function cleanQuestion(q) {
+  const clean = {};
+  for (const k of Object.keys(q)) {
+    if (k === 'e' || k.startsWith('_')) continue;
+    clean[k] = q[k];
+  }
+  return clean;
 }
 
-const qPath = path.resolve(__dirname, '..', 'data', 'questions.json');
-const existing = JSON.parse(fs.readFileSync(qPath, 'utf-8'));
-const generated = JSON.parse(fs.readFileSync(path.resolve(inputFile), 'utf-8'));
-
-console.log(`\n📋 Existing questions: ${existing.length}`);
-console.log(`📥 Generated questions: ${generated.length}`);
-
-// Dedup by first 80 chars
-const existingPrefixes = new Set(existing.map(q => q.q.substring(0, 80).toLowerCase()));
-const newQs = [];
-let dupes = 0;
-
-for (const q of generated) {
-  const prefix = q.q.substring(0, 80).toLowerCase();
-  if (existingPrefixes.has(prefix)) {
-    dupes++;
-    continue;
+/**
+ * Pure merge. Given the existing questions, the existing parallel explanations,
+ * and the generated input, return the clean new questions and their parallel
+ * explanation strings. No I/O. Throws if the existing arrays are not parallel.
+ */
+function mergeQuestions(existingQs, existingExps, generated) {
+  if (existingQs.length !== existingExps.length) {
+    throw new Error(
+      `parallel-index broken before merge: questions.json has ${existingQs.length} ` +
+      `entries but explanations.json has ${existingExps.length} — aborting.`);
   }
-  // Validate schema
-  if (!q.q || !Array.isArray(q.o) || q.o.length !== 4 || 
-      typeof q.c !== 'number' || !q.t || typeof q.ti !== 'number' || !q.e) {
-    console.log(`  ⚠️ Skipping invalid: ${q.q?.substring(0, 60) || 'no question text'}`);
-    continue;
+  const seen = new Set(existingQs.map(q => String(q.q || '').substring(0, 80).toLowerCase()));
+  const newQs = [];
+  const newExps = [];
+  let dupes = 0, invalid = 0, noExplanation = 0;
+
+  for (const q of generated) {
+    const prefix = String(q.q || '').substring(0, 80).toLowerCase();
+    if (seen.has(prefix)) { dupes++; continue; }
+    // Schema gate. `e` is intentionally NOT part of it — explanations are a
+    // separate file post-v10.64.93, so a question's validity does not depend
+    // on carrying an inline explanation.
+    if (!q.q || !Array.isArray(q.o) || q.o.length !== 4 ||
+        !Number.isInteger(q.c) || q.c < 0 || q.c >= q.o.length ||
+        !q.t || !Number.isInteger(q.ti)) {
+      console.log(`  ⚠️  skipping invalid: ${String(q.q || 'no question text').substring(0, 60)}`);
+      invalid++;
+      continue;
+    }
+    seen.add(prefix);
+    const exp = typeof q.e === 'string' ? q.e : '';
+    if (!exp) { noExplanation++; console.log(`  ⚠️  no explanation supplied: ${q.q.substring(0, 60)}`); }
+    newQs.push(cleanQuestion(q));
+    newExps.push(exp);
   }
-  existingPrefixes.add(prefix);
-  newQs.push(q);
+  return { newQs, newExps, dupes, invalid, noExplanation };
 }
 
-console.log(`\n✅ New unique questions: ${newQs.length}`);
-console.log(`🔄 Duplicates skipped: ${dupes}`);
-
-if (dryRun) {
-  console.log('\n🏃 DRY RUN — no files modified');
-  // Show topic distribution
-  const topicCounts = {};
-  for (const q of newQs) {
-    topicCounts[q.ti] = (topicCounts[q.ti] || 0) + 1;
-  }
-  console.log('\nTopic distribution:');
-  for (const [ti, count] of Object.entries(topicCounts).sort((a, b) => b[1] - a[1])) {
-    console.log(`  [${ti}]: ${count} questions`);
-  }
-} else {
-  const merged = [...existing, ...newQs];
-  fs.writeFileSync(qPath, JSON.stringify(merged, null, 2), 'utf-8');
-  console.log(`\n📁 Written ${merged.length} total questions to ${qPath}`);
-  console.log(`   (was ${existing.length}, added ${newQs.length})`);
+/**
+ * Append clean questions to questions.json's raw text WITHOUT re-serialising the
+ * existing entries — they stay byte-identical. New entries are written in the
+ * file's newline-separated, zero-indent style.
+ */
+function appendToQuestionsText(existingText, newQs) {
+  const close = existingText.lastIndexOf(']');
+  if (close < 0) throw new Error('questions.json: no closing "]" found');
+  const head = existingText.slice(0, close).replace(/\s+$/, '');   // ends at the last "}"
+  const body = newQs.map(q => JSON.stringify(q, null, 1).replace(/^ +/gm, '')).join(',\n');
+  return `${head},\n${body}\n]`;
 }
 
-console.log('');
+function main() {
+  const inputFile = process.argv[2];
+  const dryRun = process.argv.includes('--dry-run');
+  if (!inputFile || inputFile.startsWith('--')) {
+    console.error('Usage: node scripts/merge-questions.cjs <generated-file.json> [--dry-run]');
+    process.exit(1);
+  }
+
+  const qText = fs.readFileSync(Q_PATH, 'utf-8');
+  const existingQs = JSON.parse(qText);
+  const existingExps = JSON.parse(fs.readFileSync(E_PATH, 'utf-8'));
+  const generated = JSON.parse(fs.readFileSync(path.resolve(inputFile), 'utf-8'));
+
+  console.log(`\n📋 Existing: ${existingQs.length} questions / ${existingExps.length} explanations`);
+  console.log(`📥 Generated input: ${generated.length}`);
+
+  const { newQs, newExps, dupes, invalid, noExplanation } =
+    mergeQuestions(existingQs, existingExps, generated);
+
+  console.log(`\n✅ New unique questions: ${newQs.length}`);
+  console.log(`🔄 Duplicates skipped:   ${dupes}`);
+  console.log(`⚠️  Invalid skipped:     ${invalid}`);
+  if (noExplanation) console.log(`⚠️  Merged with empty explanation: ${noExplanation}`);
+
+  if (dryRun) {
+    console.log('\n🏃 DRY RUN — no files modified');
+    const topics = {};
+    for (const q of newQs) topics[q.ti] = (topics[q.ti] || 0) + 1;
+    console.log('Topic distribution:', JSON.stringify(topics));
+    console.log(`Would write: questions.json ${existingQs.length} → ${existingQs.length + newQs.length}, ` +
+                `explanations.json ${existingExps.length} → ${existingExps.length + newExps.length}`);
+    return;
+  }
+  if (!newQs.length) { console.log('\nNothing to merge — files unchanged.'); return; }
+
+  fs.writeFileSync(Q_PATH, appendToQuestionsText(qText, newQs), 'utf-8');
+  fs.writeFileSync(E_PATH, JSON.stringify([...existingExps, ...newExps]), 'utf-8');
+  console.log(`\n📁 questions.json:    ${existingQs.length} → ${existingQs.length + newQs.length}`);
+  console.log(`📁 explanations.json: ${existingExps.length} → ${existingExps.length + newExps.length}`);
+  console.log('   (parallel index preserved)');
+}
+
+if (require.main === module) main();
+
+// Exported for unit testing (tests/mergeQuestions.test.js). When imported rather
+// than run directly, main() above is skipped — no file I/O at import time.
+module.exports = { mergeQuestions, cleanQuestion, appendToQuestionsText };

--- a/tests/mergeQuestions.test.js
+++ b/tests/mergeQuestions.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import merge from '../scripts/merge-questions.cjs';
+
+/**
+ * Regression tests for the v10.64.93 e-split awareness of merge-questions.cjs.
+ * Before the fix the script required inline `q.e` and wrote `e` into
+ * questions.json — which post-split would either reject modern inputs or
+ * desync questions.json from the parallel-indexed explanations.json.
+ */
+
+const { mergeQuestions, cleanQuestion, appendToQuestionsText } = merge;
+
+const EXISTING_QS = [{ q: 'old question about hearts', o: ['a', 'b', 'c', 'd'], c: 0, t: '2022', ti: 17 }];
+const EXISTING_EXPS = ['explanation for the old question'];
+
+describe('merge-questions — e-split aware merge', () => {
+  it('exports the testable pure functions', () => {
+    expect(typeof mergeQuestions).toBe('function');
+    expect(typeof cleanQuestion).toBe('function');
+    expect(typeof appendToQuestionsText).toBe('function');
+  });
+
+  it('extracts e into the parallel explanations array, NOT into the question', () => {
+    const gen = [{ q: 'new q about falls in elderly', o: ['w', 'x', 'y', 'z'], c: 2, t: 'SZMC-Rescue', ti: 4, e: 'because balance' }];
+    const { newQs, newExps } = mergeQuestions(EXISTING_QS, EXISTING_EXPS, gen);
+    expect(newQs).toHaveLength(1);
+    expect(newExps).toEqual(['because balance']);
+    expect('e' in newQs[0]).toBe(false);
+    expect(newQs[0]).toEqual({ q: 'new q about falls in elderly', o: ['w', 'x', 'y', 'z'], c: 2, t: 'SZMC-Rescue', ti: 4 });
+  });
+
+  it('strips every _* provenance field from merged questions', () => {
+    const gen = [{
+      q: 'q carrying provenance', o: ['a', 'b', 'c', 'd'], c: 1, t: 'SZMC-Rescue', ti: 8, tis: [8], e: 'exp',
+      _source: 'R7', _orig_id: 'SA001', _ti_confidence: 'high', _q_he: 'שאלה',
+    }];
+    const { newQs } = mergeQuestions(EXISTING_QS, EXISTING_EXPS, gen);
+    expect(Object.keys(newQs[0]).some(k => k.startsWith('_'))).toBe(false);
+    expect(newQs[0]).toEqual({ q: 'q carrying provenance', o: ['a', 'b', 'c', 'd'], c: 1, t: 'SZMC-Rescue', ti: 8, tis: [8] });
+  });
+
+  it('keeps newQs and newExps parallel and equal-length', () => {
+    const gen = [
+      { q: 'falls question alpha', o: ['a', 'b', 'c', 'd'], c: 0, t: 'X', ti: 4, e: 'exp A' },
+      { q: 'delirium question beta', o: ['a', 'b', 'c', 'd'], c: 1, t: 'X', ti: 5, e: 'exp B' },
+    ];
+    const { newQs, newExps } = mergeQuestions(EXISTING_QS, EXISTING_EXPS, gen);
+    expect(newQs).toHaveLength(2);
+    expect(newExps).toEqual(['exp A', 'exp B']);
+  });
+
+  it('merges a question with NO e (gate no longer requires it) — explanation defaults to ""', () => {
+    const gen = [{ q: 'question with no explanation', o: ['a', 'b', 'c', 'd'], c: 0, t: 'X', ti: 2 }];
+    const { newQs, newExps, invalid, noExplanation } = mergeQuestions(EXISTING_QS, EXISTING_EXPS, gen);
+    expect(invalid).toBe(0);
+    expect(noExplanation).toBe(1);
+    expect(newQs).toHaveLength(1);
+    expect(newExps).toEqual(['']);
+  });
+
+  it('dedups against existing questions by 80-char stem prefix', () => {
+    const gen = [{ q: 'old question about hearts', o: ['a', 'b', 'c', 'd'], c: 0, t: 'X', ti: 17, e: 'dup' }];
+    const { newQs, dupes } = mergeQuestions(EXISTING_QS, EXISTING_EXPS, gen);
+    expect(dupes).toBe(1);
+    expect(newQs).toHaveLength(0);
+  });
+
+  it('skips invalid questions — wrong option count, out-of-range c', () => {
+    const gen = [
+      { q: 'three options only', o: ['a', 'b', 'c'], c: 0, t: 'X', ti: 1, e: 'e' },
+      { q: 'c index out of range', o: ['a', 'b', 'c', 'd'], c: 9, t: 'X', ti: 1, e: 'e' },
+    ];
+    const { newQs, invalid } = mergeQuestions(EXISTING_QS, EXISTING_EXPS, gen);
+    expect(invalid).toBe(2);
+    expect(newQs).toHaveLength(0);
+  });
+
+  it('throws if the existing questions/explanations arrays are not parallel', () => {
+    expect(() => mergeQuestions(EXISTING_QS, ['a', 'b'], [])).toThrow(/parallel/);
+  });
+
+  it('appendToQuestionsText preserves existing bytes and appends valid JSON', () => {
+    const orig = '[\n{\n"q": "first",\n"o": [\n"a",\n"b",\n"c",\n"d"\n],\n"c": 0,\n"t": "X",\n"ti": 1\n}\n]';
+    const head = orig.slice(0, orig.lastIndexOf(']')).replace(/\s+$/, '');
+    const out = appendToQuestionsText(orig, [{ q: 'second', o: ['a', 'b', 'c', 'd'], c: 1, t: 'X', ti: 2 }]);
+    expect(out.startsWith(head)).toBe(true);          // existing entry untouched
+    const parsed = JSON.parse(out);                   // result is valid JSON
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0].q).toBe('first');
+    expect(parsed[1].q).toBe('second');
+  });
+});

--- a/tests/mergeQuestions.test.js
+++ b/tests/mergeQuestions.test.js
@@ -89,4 +89,15 @@ describe('merge-questions — e-split aware merge', () => {
     expect(parsed[0].q).toBe('first');
     expect(parsed[1].q).toBe('second');
   });
+
+  // Codex P2 (PR #255): appending into an empty corpus must not emit "[,…".
+  it('appendToQuestionsText appends into an empty corpus without a leading comma', () => {
+    for (const empty of ['[]', '[\n]', '[ ]']) {
+      const out = appendToQuestionsText(empty, [{ q: 'first ever', o: ['a', 'b', 'c', 'd'], c: 0, t: 'X', ti: 1 }]);
+      expect(out.includes('[,'), `input ${JSON.stringify(empty)}`).toBe(false);
+      const parsed = JSON.parse(out);
+      expect(parsed, JSON.stringify(empty)).toHaveLength(1);
+      expect(parsed[0].q).toBe('first ever');
+    }
+  });
 });


### PR DESCRIPTION
## (a) Fix `merge-questions.cjs` for the v10.64.93 explanations split

Step (a) of the rescued-MCQ merge campaign (follows #254). `merge-questions.cjs` predated the v10.64.93 split of `e` out of `questions.json` into the parallel-indexed `data/explanations.json`. As written it required inline `q.e` **and** wrote `e` into `questions.json` — feeding it any modern input would either reject it or desync `questions.json` from `explanations.json`.

### Homework (done before patching, per review instruction)

1. **Callers** — `merge-questions.cjs` is a manually-run CLI with **no programmatic callers**. Only references: `scripts/README.md` (docs), a usage hint in `generate-questions.cjs`, a comment. No backward-compat shim needed.
2. **Indexing contract** — `explanations.json` is a flat array of strings **parallel to `questions.json` by array index** (no `id` field exists; `shlav-a-mega.html:896` — "indexed by Q position"). All spot-checked index pairs match.
3. **Drift** — `merge-questions.cjs` has one commit ever, predates the e-split (`d3f92e1`). **0 of 3743** questions carry inline `e` — no stale merge has run since. **Pure go-forward fix, no backfill.**

### The fix (two parts — ship together or explanations are lost)

- **Drop `e` from the schema gate** — a question with no explanation is still valid; explanations are separate data now.
- **Extract `e` → `explanations.json`** at the parallel index; strip `e` and all `_*` provenance fields from the object written to `questions.json`.

### File-format preservation

- `questions.json` — **textual append**: the 3743 existing entries stay **byte-identical**. Its on-disk format (newline-separated, zero-indent — a Python format pass) is not byte-reproducible by Node `JSON.stringify` (probed: off-by-4), so a full re-serialise would make a spurious multi-thousand-line diff.
- `explanations.json` — re-serialised minified; `JSON.stringify` round-trips it byte-exact (probed: exact).

### Also
- `c` validity tightened to integer-in-range (was `typeof === 'number'`).
- Parallel-length precondition asserted before merge.
- Refactored behind `require.main === module` + `module.exports` so the merge logic is unit-testable.

### Verification
- `tests/mergeQuestions.test.js` — 9 tests: `e`→explanations extraction, `_*` strip, parallel arrays, no-`e` accepted, dedup, invalid-skip, parallel-precondition throw, byte-preserving append.
- **Real-data integration check**: the 82-Q #254 staging file merges to **3743→3825** questions + **3743→3825** explanations, existing entries byte-identical, parallel index preserved, 0 dupes / 0 invalid.
- `npm run verify` green — 1511 tests, 0 regressions. No `data/` content, version, or `sw.js` change.

Campaign next: (b) `mcq-quality-auditor` over the 82 (running now), (c) optional EN→HE translation, (d) the live merge via this fixed script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
