### PR TITLE
feat(scripts): regen_derived.cjs — close denominator-invalidates-all-ratios bug class

### DIFF
--- a/scripts/regen_derived.cjs
+++ b/scripts/regen_derived.cjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+/**
+ * regen_derived.cjs — single-command regeneration of all derived data files.
+ *
+ * Closes the "denominator-invalidates-all-ratios" bug class that bit PR #258:
+ * when data/questions.json row count changes, every file caching a ratio or
+ * tagger output against it drifts silently. Pre-PR #258 there was no audit
+ * step; the syllabus_data.json shipped with 19/46 stale frequency_pct values
+ * (caught by CC during merge, not before).
+ *
+ * Scope — DETERMINISTIC derived files only:
+ *   - data/regulatory.json      via scripts/tag_regulatory.cjs (idempotent)
+ *   - data/question_chapters.json via scripts/tag_chapters.cjs (idempotent)
+ *   - data/syllabus_data.json   inline: Geri section's n_questions +
+ *                                frequency_pct + total_questions_analyzed.
+ *                                Preserves: weight (opaque), keywords, en/he,
+ *                                topic order, Pnimit/Mishpacha sections (those
+ *                                are cross-repo data, not derivable here).
+ *
+ * Out of scope — NON-DETERMINISTIC AI outputs:
+ *   - data/distractors.json    (AI-generated, cached)
+ *   - data/explanations.json   (AI-generated, canonical post-v10.64.93 split)
+ *
+ * Modes:
+ *   node scripts/regen_derived.cjs           regenerate in place
+ *   node scripts/regen_derived.cjs --check   write to .tmp/, diff vs current,
+ *                                            exit 1 on drift (CI gate use)
+ *   node scripts/regen_derived.cjs --verbose include diff detail on drift
+ *
+ * Exit codes:
+ *   0  no drift (--check) or regen successful (default mode)
+ *   1  drift detected (--check) or regen failed (default mode)
+ *   2  unexpected error (corpus unreadable, tagger script missing, etc.)
+ */
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '..');
+const Q_PATH = path.join(ROOT, 'data', 'questions.json');
+const SYL_PATH = path.join(ROOT, 'data', 'syllabus_data.json');
+const REG_PATH = path.join(ROOT, 'data', 'regulatory.json');
+const QC_PATH = path.join(ROOT, 'data', 'question_chapters.json');
+const TAG_REG_SCRIPT = path.join(__dirname, 'tag_regulatory.cjs');
+const TAG_CH_SCRIPT = path.join(__dirname, 'tag_chapters.cjs');
+
+const CHECK = process.argv.includes('--check');
+const VERBOSE = process.argv.includes('--verbose');
+
+/**
+ * Regenerate the Geri section of syllabus_data.json against questions.json.
+ * Pure function — takes parsed inputs, returns the new full syllabus object.
+ * Preserves weight, keywords, en/he, topic order, and Pnimit/Mishpacha
+ * sections untouched. Only updates n_questions, frequency_pct, and the
+ * top-level total_questions_analyzed for the Geri section.
+ */
+function regenSyllabusGeri(syllabus, questions) {
+  const out = JSON.parse(JSON.stringify(syllabus));  // deep clone, don't mutate input
+  if (!out.Geri || !Array.isArray(out.Geri.topics)) {
+    throw new Error('syllabus_data.json: Geri.topics missing or not an array');
+  }
+  const total = questions.length;
+  out.Geri.total_questions_analyzed = total;
+  for (const topic of out.Geri.topics) {
+    if (!Number.isInteger(topic.id)) {
+      throw new Error(`syllabus topic missing integer id: ${JSON.stringify(topic).slice(0, 100)}`);
+    }
+    const n = questions.filter(q => q.ti === topic.id).length;
+    topic.n_questions = n;
+    // round to 2 decimals — matches the convention CC used in PR #258 fix commit
+    topic.frequency_pct = Math.round((n / total) * 100 * 100) / 100;
+  }
+  return out;
+}
+
+function runTagger(scriptPath, label) {
+  if (!fs.existsSync(scriptPath)) {
+    throw new Error(`${label}: script not found at ${scriptPath}`);
+  }
+  const r = spawnSync('node', [scriptPath], { cwd: ROOT, encoding: 'utf-8' });
+  if (r.status !== 0) {
+    throw new Error(`${label} exited ${r.status}\nstdout: ${r.stdout}\nstderr: ${r.stderr}`);
+  }
+  return r.stdout;
+}
+
+function readJson(p) {
+  return JSON.parse(fs.readFileSync(p, 'utf-8'));
+}
+
+function regenAll() {
+  // Run taggers (they write directly to data/)
+  runTagger(TAG_REG_SCRIPT, 'tag_regulatory');
+  runTagger(TAG_CH_SCRIPT, 'tag_chapters');
+  // Regenerate syllabus Geri section
+  const syllabus = readJson(SYL_PATH);
+  const questions = readJson(Q_PATH);
+  const newSyllabus = regenSyllabusGeri(syllabus, questions);
+  // Preserve the existing 2-space pretty-print + trailing newline convention
+  const serialized = JSON.stringify(newSyllabus, null, 2);
+  const existing = fs.readFileSync(SYL_PATH, 'utf-8');
+  const trailingNewline = existing.endsWith('\n') ? '\n' : '';
+  fs.writeFileSync(SYL_PATH, serialized + trailingNewline);
+}
+
+/**
+ * Deep-equal for JSON content (arrays, objects, primitives). Used by --check
+ * to compare derived files semantically, ignoring whitespace/formatting drift
+ * that doesn't affect runtime behavior. Matches the existing test convention
+ * in tests/regulatoryTags.test.js (which parses before comparing).
+ */
+function jsonContentEqual(a, b) {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b) || a.length !== b.length) return false;
+    // For regulatory.json (array of integers) order-independence is the
+    // existing convention; we sort-compare. For other arrays, fall back to
+    // positional compare.
+    const allNum = a.every(x => typeof x === 'number');
+    if (allNum) {
+      const as = [...a].sort((x, y) => x - y);
+      const bs = [...b].sort((x, y) => x - y);
+      return as.every((x, i) => x === bs[i]);
+    }
+    return a.every((x, i) => jsonContentEqual(x, b[i]));
+  }
+  if (a && typeof a === 'object') {
+    if (!b || typeof b !== 'object') return false;
+    const ak = Object.keys(a), bk = Object.keys(b);
+    if (ak.length !== bk.length) return false;
+    return ak.every(k => Object.prototype.hasOwnProperty.call(b, k) && jsonContentEqual(a[k], b[k]));
+  }
+  return false;
+}
+
+function check() {
+  // Snapshot the three derived files, run regen, diff parsed content, restore.
+  // Content-equal (not byte-equal) — matches existing repo convention and
+  // focuses the gate on the bug class (wrong values), not format drift.
+  const targets = [REG_PATH, QC_PATH, SYL_PATH];
+  const snapshots = new Map();
+  for (const t of targets) {
+    if (fs.existsSync(t)) snapshots.set(t, fs.readFileSync(t));
+  }
+  try {
+    regenAll();
+    const drift = [];
+    for (const t of targets) {
+      const before = snapshots.get(t);
+      const after = fs.readFileSync(t);
+      if (!before) {
+        drift.push({ file: path.relative(ROOT, t), reason: 'file did not exist before regen' });
+        continue;
+      }
+      let beforeParsed, afterParsed;
+      try { beforeParsed = JSON.parse(before.toString('utf-8')); }
+      catch (e) { drift.push({ file: path.relative(ROOT, t), reason: 'pre-regen parse failed: ' + e.message }); continue; }
+      try { afterParsed = JSON.parse(after.toString('utf-8')); }
+      catch (e) { drift.push({ file: path.relative(ROOT, t), reason: 'post-regen parse failed: ' + e.message }); continue; }
+      if (!jsonContentEqual(beforeParsed, afterParsed)) {
+        drift.push({ file: path.relative(ROOT, t), reason: 'content drift (parsed JSON differs)' });
+      }
+    }
+    return drift;
+  } finally {
+    // Always restore originals — --check must be non-mutating
+    for (const [t, content] of snapshots) {
+      fs.writeFileSync(t, content);
+    }
+  }
+}
+
+function describeSyllabusDrift() {
+  // Helper for verbose mode: show which topics drifted in syllabus_data.json
+  const current = readJson(SYL_PATH);
+  const questions = readJson(Q_PATH);
+  const regenerated = regenSyllabusGeri(current, questions);
+  const lines = [];
+  if (current.Geri.total_questions_analyzed !== regenerated.Geri.total_questions_analyzed) {
+    lines.push(`  total_questions_analyzed: ${current.Geri.total_questions_analyzed} -> ${regenerated.Geri.total_questions_analyzed}`);
+  }
+  const byId = new Map(regenerated.Geri.topics.map(t => [t.id, t]));
+  for (const t of current.Geri.topics) {
+    const r = byId.get(t.id);
+    if (!r) continue;
+    if (t.n_questions !== r.n_questions || t.frequency_pct !== r.frequency_pct) {
+      lines.push(`  topic id=${t.id} (${t.en}): n_questions ${t.n_questions} -> ${r.n_questions}, frequency_pct ${t.frequency_pct} -> ${r.frequency_pct}`);
+    }
+  }
+  return lines;
+}
+
+function main() {
+  try {
+    if (CHECK) {
+      const drift = check();
+      if (drift.length === 0) {
+        console.log('regen_derived: no drift. All 3 derived files match canonical state.');
+        process.exit(0);
+      }
+      console.error('regen_derived: DRIFT DETECTED in', drift.length, 'file(s):');
+      for (const d of drift) {
+        console.error(`  ${d.file}: ${d.reason}`);
+      }
+      if (VERBOSE && drift.some(d => d.file.endsWith('syllabus_data.json'))) {
+        console.error('\nSyllabus drift detail:');
+        for (const line of describeSyllabusDrift()) console.error(line);
+      }
+      console.error('\nFix: run `node scripts/regen_derived.cjs` (no flags) to regenerate.');
+      process.exit(1);
+    } else {
+      regenAll();
+      console.log('regen_derived: regenerated regulatory.json + question_chapters.json + syllabus_data.json (Geri section).');
+      process.exit(0);
+    }
+  } catch (e) {
+    console.error('regen_derived: ERROR -', e.message);
+    if (VERBOSE) console.error(e.stack);
+    process.exit(2);
+  }
+}
+
+if (require.main === module) main();
+
+module.exports = { regenSyllabusGeri, jsonContentEqual };

--- a/scripts/regen_derived.cjs
+++ b/scripts/regen_derived.cjs
@@ -139,21 +139,25 @@ function check() {
   // Snapshot the three derived files, run regen, diff parsed content, restore.
   // Content-equal (not byte-equal) — matches existing repo convention and
   // focuses the gate on the bug class (wrong values), not format drift.
+  //
+  // Existence is snapshotted alongside content so the finally block can restore
+  // exactly the pre-regen state — including deleting files that the taggers
+  // newly created (Codex P2 on PR #259: "--check must not dirty the worktree").
   const targets = [REG_PATH, QC_PATH, SYL_PATH];
   const snapshots = new Map();
   for (const t of targets) {
-    if (fs.existsSync(t)) snapshots.set(t, fs.readFileSync(t));
+    snapshots.set(t, fs.existsSync(t) ? fs.readFileSync(t) : null);
   }
   try {
     regenAll();
     const drift = [];
     for (const t of targets) {
       const before = snapshots.get(t);
-      const after = fs.readFileSync(t);
-      if (!before) {
+      if (before === null) {
         drift.push({ file: path.relative(ROOT, t), reason: 'file did not exist before regen' });
         continue;
       }
+      const after = fs.readFileSync(t);
       let beforeParsed, afterParsed;
       try { beforeParsed = JSON.parse(before.toString('utf-8')); }
       catch (e) { drift.push({ file: path.relative(ROOT, t), reason: 'pre-regen parse failed: ' + e.message }); continue; }
@@ -165,9 +169,14 @@ function check() {
     }
     return drift;
   } finally {
-    // Always restore originals — --check must be non-mutating
+    // Restore EXACTLY the pre-regen state: write back if present, delete if absent.
     for (const [t, content] of snapshots) {
-      fs.writeFileSync(t, content);
+      if (content === null) {
+        // File didn't exist before regen — if the tagger created one, remove it.
+        if (fs.existsSync(t)) fs.unlinkSync(t);
+      } else {
+        fs.writeFileSync(t, content);
+      }
     }
   }
 }

--- a/tests/regenDerived.test.js
+++ b/tests/regenDerived.test.js
@@ -151,4 +151,35 @@ describe('regen_derived.cjs --check (integration gate)', () => {
       });
     }).not.toThrow();
   }, 35000);
+
+  it('is non-mutating: deletes files the regen created when target was absent before (Codex P2 PR #259)', async () => {
+    // Codex P2 catch: if a derived file is missing before --check runs, the
+    // taggers will create one, and the finally block must delete it again so
+    // the worktree is left in its pre-check state.
+    const fs = await import('node:fs');
+    const REG_PATH = resolve(ROOT, 'data', 'regulatory.json');
+    if (!fs.existsSync(REG_PATH)) {
+      // Skip if the file genuinely doesn't exist — can't test the restore path
+      return;
+    }
+    const snapshot = fs.readFileSync(REG_PATH);
+    try {
+      fs.unlinkSync(REG_PATH);
+      expect(fs.existsSync(REG_PATH)).toBe(false);
+      // --check should exit non-zero (drift: file was absent), AND should NOT
+      // leave a regenerated file behind.
+      let exitCode = 0;
+      try {
+        execSync('node scripts/regen_derived.cjs --check', {
+          cwd: ROOT, stdio: 'pipe', timeout: 30000,
+        });
+      } catch (e) {
+        exitCode = e.status;
+      }
+      expect(exitCode).toBe(1);
+      expect(fs.existsSync(REG_PATH)).toBe(false);  // <- the P2 assertion
+    } finally {
+      fs.writeFileSync(REG_PATH, snapshot);
+    }
+  }, 35000);
 });

--- a/tests/regenDerived.test.js
+++ b/tests/regenDerived.test.js
@@ -1,0 +1,154 @@
+/**
+ * Tests for scripts/regen_derived.cjs — the structural fix for the
+ * "denominator-invalidates-all-ratios" bug class that bit PR #258.
+ *
+ * Two levels of coverage:
+ *   1. Unit tests for the pure function regenSyllabusGeri (deterministic
+ *      recompute of n_questions + frequency_pct + total_questions_analyzed,
+ *      preserving weight/keywords/en/he/topic-order and Pnimit/Mishpacha).
+ *   2. Integration gate: run the script in --check mode against the live
+ *      repo state — must exit 0 (no drift). This is the CI gate that would
+ *      have caught PR #258's stale syllabus_data.json before merge.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+
+const require = createRequire(import.meta.url);
+const ROOT = resolve(import.meta.dirname, '..');
+const { regenSyllabusGeri, jsonContentEqual } = require(
+  resolve(ROOT, 'scripts', 'regen_derived.cjs')
+);
+
+describe('regenSyllabusGeri — pure function', () => {
+  // Minimal synthetic syllabus mimicking the live schema
+  const baseSyllabus = () => ({
+    Geri: {
+      repo: 'Eiasash/Geriatrics',
+      total_questions_analyzed: 100,
+      total_topics: 3,
+      topics: [
+        { id: 8, en: 'Polypharm', he: 'פוליפרמסיה', keywords: ['Beers','STOPP'], n_questions: 40, frequency_pct: 40.0, weight: 3.82 },
+        { id: 6, en: 'Dementia',  he: 'דמנציה',   keywords: ['MMSE'],          n_questions: 30, frequency_pct: 30.0, weight: 2.20 },
+        { id: 5, en: 'Delirium',  he: 'דליריום',  keywords: ['CAM'],           n_questions: 30, frequency_pct: 30.0, weight: 2.11 },
+      ],
+    },
+    Pnimit: { repo: 'Eiasash/InternalMedicine', total_questions_analyzed: 9999, topics: [{ id: 0, n_questions: 42 }] },
+    Mishpacha: { repo: 'Eiasash/FamilyMedicine', total_questions_analyzed: 8888, topics: [{ id: 7, n_questions: 17 }] },
+  });
+
+  it('recomputes n_questions correctly by counting q.ti matches', () => {
+    const qs = [
+      ...Array(326).fill().map(() => ({ ti: 8 })),
+      ...Array(188).fill().map(() => ({ ti: 6 })),
+      ...Array(182).fill().map(() => ({ ti: 5 })),
+    ];
+    const out = regenSyllabusGeri(baseSyllabus(), qs);
+    expect(out.Geri.topics.find(t => t.id === 8).n_questions).toBe(326);
+    expect(out.Geri.topics.find(t => t.id === 6).n_questions).toBe(188);
+    expect(out.Geri.topics.find(t => t.id === 5).n_questions).toBe(182);
+  });
+
+  it('updates total_questions_analyzed to questions.length', () => {
+    const qs = Array(3823).fill().map((_, i) => ({ ti: i % 3 ? 8 : 6 }));
+    const out = regenSyllabusGeri(baseSyllabus(), qs);
+    expect(out.Geri.total_questions_analyzed).toBe(3823);
+  });
+
+  it('computes frequency_pct rounded to 2 decimals (n/total * 100)', () => {
+    // 326 of 3823 = 8.526... rounds to 8.53; matches live syllabus value
+    const qs = [
+      ...Array(326).fill().map(() => ({ ti: 8 })),
+      ...Array(3823 - 326).fill().map(() => ({ ti: 99 })),
+    ];
+    const out = regenSyllabusGeri(baseSyllabus(), qs);
+    expect(out.Geri.topics.find(t => t.id === 8).frequency_pct).toBe(8.53);
+  });
+
+  it('preserves weight, keywords, en, he, and topic order (no reshuffling)', () => {
+    const qs = Array(50).fill().map(() => ({ ti: 8 }));
+    const out = regenSyllabusGeri(baseSyllabus(), qs);
+    const topic8 = out.Geri.topics.find(t => t.id === 8);
+    expect(topic8.weight).toBe(3.82);
+    expect(topic8.keywords).toEqual(['Beers','STOPP']);
+    expect(topic8.en).toBe('Polypharm');
+    expect(topic8.he).toBe('פוליפרמסיה');
+    // Topic order: id 8 first, then 6, then 5 (matches input order)
+    expect(out.Geri.topics.map(t => t.id)).toEqual([8, 6, 5]);
+  });
+
+  it('does NOT touch Pnimit or Mishpacha sections (cross-repo data preserved)', () => {
+    const qs = Array(5000).fill().map(() => ({ ti: 8 }));
+    const out = regenSyllabusGeri(baseSyllabus(), qs);
+    expect(out.Pnimit.total_questions_analyzed).toBe(9999);
+    expect(out.Pnimit.topics[0].n_questions).toBe(42);
+    expect(out.Mishpacha.total_questions_analyzed).toBe(8888);
+    expect(out.Mishpacha.topics[0].n_questions).toBe(17);
+  });
+
+  it('does not mutate the input syllabus (pure function discipline)', () => {
+    const syl = baseSyllabus();
+    const snapshot = JSON.stringify(syl);
+    regenSyllabusGeri(syl, Array(100).fill({ ti: 8 }));
+    expect(JSON.stringify(syl)).toBe(snapshot);
+  });
+
+  it('handles topic with zero matching questions (n=0, frequency_pct=0)', () => {
+    const qs = [{ ti: 8 }, { ti: 8 }];  // only ti=8, none for 6 or 5
+    const out = regenSyllabusGeri(baseSyllabus(), qs);
+    expect(out.Geri.topics.find(t => t.id === 6).n_questions).toBe(0);
+    expect(out.Geri.topics.find(t => t.id === 6).frequency_pct).toBe(0);
+  });
+
+  it('throws if Geri.topics is missing or not an array', () => {
+    const bad = { Geri: { total_questions_analyzed: 0 } };
+    expect(() => regenSyllabusGeri(bad, [])).toThrow(/Geri\.topics/);
+  });
+
+  it('throws if any topic lacks an integer id', () => {
+    const bad = { Geri: { total_questions_analyzed: 0, topics: [{ en: 'Anon' }] } };
+    expect(() => regenSyllabusGeri(bad, [])).toThrow(/id/);
+  });
+});
+
+describe('jsonContentEqual — content-equal helper', () => {
+  it('treats integer arrays as sets (order-independent)', () => {
+    expect(jsonContentEqual([1, 2, 3], [3, 2, 1])).toBe(true);
+    expect(jsonContentEqual([1, 2, 3], [1, 2, 4])).toBe(false);
+  });
+
+  it('deep-equals objects', () => {
+    expect(jsonContentEqual({ a: 1, b: { c: 2 } }, { a: 1, b: { c: 2 } })).toBe(true);
+    expect(jsonContentEqual({ a: 1, b: { c: 2 } }, { a: 1, b: { c: 3 } })).toBe(false);
+  });
+
+  it('compares primitives correctly', () => {
+    expect(jsonContentEqual(5, 5)).toBe(true);
+    expect(jsonContentEqual('x', 'x')).toBe(true);
+    expect(jsonContentEqual(null, null)).toBe(true);
+    expect(jsonContentEqual(5, '5')).toBe(false);
+  });
+
+  it('compares non-integer arrays positionally (not as sets)', () => {
+    expect(jsonContentEqual([{ a: 1 }, { a: 2 }], [{ a: 1 }, { a: 2 }])).toBe(true);
+    expect(jsonContentEqual([{ a: 1 }, { a: 2 }], [{ a: 2 }, { a: 1 }])).toBe(false);
+  });
+});
+
+describe('regen_derived.cjs --check (integration gate)', () => {
+  it('passes against current canonical state — no drift between canonical and derived', () => {
+    // This is the CI gate. If a future PR mutates data/questions.json without
+    // regenerating syllabus_data.json + regulatory.json + question_chapters.json,
+    // this test fails — exactly the safety net that would have caught PR #258's
+    // shipped 19/46 stale denominators.
+    //
+    // execSync throws non-zero exit codes as exceptions; that's the assertion.
+    expect(() => {
+      execSync('node scripts/regen_derived.cjs --check', {
+        cwd: ROOT, stdio: 'pipe', timeout: 30000,
+      });
+    }).not.toThrow();
+  }, 35000);
+});


### PR DESCRIPTION
## Why

Closes the **denominator-invalidates-all-ratios** bug class that bit PR #258. When `data/questions.json` row count changes, every derived file caching a ratio against the count drifts silently. PR #258 shipped initial commit with 19/46 stale `frequency_pct` values in `syllabus_data.json` — caught by CC during merge (commit `0d6a2a9`), not before. Pre-PR audit relied on memory discipline, which fails under load.

This PR replaces memory discipline with a programmatic gate.

## What

**`scripts/regen_derived.cjs`** — one-command regeneration of all three deterministic derived files:

| Derived file | Mechanism |
|---|---|
| `data/regulatory.json` | shells out to `scripts/tag_regulatory.cjs` (idempotent tagger) |
| `data/question_chapters.json` | shells out to `scripts/tag_chapters.cjs` (idempotent tagger) |
| `data/syllabus_data.json` (Geri section only) | inline regen of `n_questions` + `frequency_pct` + `total_questions_analyzed`; preserves `weight` (opaque), `keywords`, `en`/`he`, topic order, and Pnimit/Mishpacha sections |

**Two modes:**
- `node scripts/regen_derived.cjs` — regenerate in place
- `node scripts/regen_derived.cjs --check` — exit 1 on drift, non-mutating (snapshot → regen → diff → restore)
- `node scripts/regen_derived.cjs --check --verbose` — also dump which topics drifted in syllabus

**Scope deliberately excludes non-deterministic AI outputs:**
- `data/distractors.json` (cached AI generations)
- `data/explanations.json` (canonical post-v10.64.93 e-split)

## Tests (`tests/regenDerived.test.js`, 14 cases)

- **`regenSyllabusGeri` unit tests** — correct counting, correct rounding (matches CC's PR #258 fix convention: round(n/total*100, 2)), preserves weight/keywords/order, never mutates input, throws on bad schema, never touches Pnimit/Mishpacha sections
- **`jsonContentEqual` unit tests** — integer arrays as sets (matches existing test convention), deep-equal objects, primitives
- **Integration gate** — `--check` exits 0 against current canonical state. This is the CI safety net that would have caught PR #258 before merge.

## Local verification

Verified against pristine `main` (post-PR #258 / v10.64.130, 3823 Qs):
- ✅ Default mode produces 3 files content-equal to canonical
- ✅ `--check` exits 0 against canonical state
- ✅ Simulated denominator bug (`+80 fake Qs to corpus`) → `--check` correctly detects 3-file drift; verbose output shows `total_questions_analyzed: 3823 → 3903` + every affected topic's old vs new `frequency_pct` (the exact diagnostic that would have prevented PR #258's stale syllabus from shipping)

## Self-merge eligibility

Per "Codex green" rule: prophylactic addition (new script + new test), no existing code/data modified. Will self-merge once CI + Codex pass.

🤖 Prepared by Claude (claude.ai web, captain mode)