### PR TITLE
feat(scripts): proxy-client.cjs + migrate 3 batch scripts to Toranot proxy

### DIFF
--- a/scripts/generate-questions.cjs
+++ b/scripts/generate-questions.cjs
@@ -18,14 +18,17 @@
  *   --count      questions per chapter (default: 10)
  *   --dry-run    show chapter→topic mapping without calling API
  *   --output     output file (default: generated-questions-{timestamp}.json)
- *   --api-key    Anthropic API key (or set ANTHROPIC_API_KEY env var)
- *   --proxy      use toranot proxy instead of direct API (default: false)
+ *   (proxy mode is default; no API key required)
+ *   --direct      bypass proxy, hit api.anthropic.com directly (requires --api-key or ANTHROPIC_API_KEY env)
+ *   --api-key     direct-mode only: Anthropic API key (or set ANTHROPIC_API_KEY env var)
+ *   (--proxy is now the default and was removed; pass --direct to bypass)
  *   --concurrency  parallel API calls per batch (default: 5)
  *   --resume     resume from previous run (loads existing output + skips done chapters)
  */
 
 const fs = require('fs');
 const path = require('path');
+const { callClaude: proxyCallClaude } = require('./lib/proxy-client.cjs');
 
 // ============================================================
 // CONFIG
@@ -258,7 +261,7 @@ function parseArgs() {
     dryRun: false,
     output: null,
     apiKey: process.env.ANTHROPIC_API_KEY || null,
-    proxy: false,
+    direct: false,
     concurrency: 5,
     resume: false,
   };
@@ -272,7 +275,8 @@ function parseArgs() {
       case '--dry-run': opts.dryRun = true; break;
       case '--output': opts.output = args[++i]; break;
       case '--api-key': opts.apiKey = args[++i]; break;
-      case '--proxy': opts.proxy = true; break;
+      case '--direct': opts.direct = true; break;
+      case '--proxy': /* now the default — flag retained as no-op for back-compat */ break;
       case '--concurrency': opts.concurrency = parseInt(args[++i]); break;
       case '--resume': opts.resume = true; break;
     }
@@ -286,8 +290,8 @@ function parseArgs() {
     console.error('Error: specify --chapters or --all');
     process.exit(1);
   }
-  if (!opts.dryRun && !opts.apiKey && !opts.proxy) {
-    console.error('Error: provide --api-key, set ANTHROPIC_API_KEY, or use --proxy');
+  if (opts.direct && !opts.dryRun && !opts.apiKey) {
+    console.error('Error: --direct requires --api-key or ANTHROPIC_API_KEY env var');
     process.exit(1);
   }
 
@@ -449,58 +453,18 @@ OUTPUT FORMAT — respond with ONLY a JSON array, no markdown fences, no preambl
 Generate exactly ${count} questions. JSON only, no other text.`;
 }
 
-async function callClaude(prompt, apiKey, useProxy) {
-  const url = useProxy
-    ? 'https://toranot.netlify.app/api/claude'
-    : 'https://api.anthropic.com/v1/messages';
-
-  const body = {
-    model: 'claude-opus-4-20250514',
+async function callClaude(prompt, apiKey, direct) {
+  // Delegates to scripts/lib/proxy-client.cjs.
+  // Model: 'opus' alias (resolves to current claude-opus-4-x on the proxy).
+  // The historical hardcoded 'claude-opus-4-20250514' string is REJECTED by
+  // the proxy (HTTP 400 "Unsupported model") — alias is the safe form.
+  return proxyCallClaude(prompt, {
+    model: 'opus',
     max_tokens: 8192,
-    messages: [{ role: 'user', content: prompt }],
-  };
-
-  if (useProxy) {
-    body.secret = 'shlav-a-mega-1f97f311d307-2026';
-  }
-
-  const headers = {
-    'Content-Type': 'application/json',
-    'anthropic-version': '2023-06-01',
-  };
-  if (!useProxy && apiKey) {
-    headers['x-api-key'] = apiKey;
-  }
-
-  const response = await fetch(url, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify(body),
+    direct: !!direct,
+    apiKey: direct ? apiKey : undefined,
   });
-
-  if (!response.ok) {
-    const errText = await response.text();
-    throw new Error(`API error ${response.status}: ${errText}`);
-  }
-
-  const data = await response.json();
-  
-  // Extract text from response
-  let text = '';
-  if (data.content) {
-    text = data.content.map(c => c.text || '').join('');
-  } else if (data.choices) {
-    text = data.choices[0]?.message?.content || '';
-  } else if (typeof data === 'string') {
-    text = data;
-  }
-
-  return text;
 }
-
-// ============================================================
-// VALIDATION
-// ============================================================
 
 function validateQuestion(q, topicCount) {
   const errors = [];
@@ -638,7 +602,7 @@ async function main() {
       const prompt = buildPrompt(chapter, topicName, opts.count, opts.app);
       console.log(`  🤖 ${label}: "${chapter.title.substring(0, 35)}" → ${topicName} (${Math.round(prompt.length / 4)} tok)...`);
       
-      const response = await callClaude(prompt, opts.apiKey, opts.proxy);
+      const response = await callClaude(prompt, opts.apiKey, opts.direct);
       const questions = parseGeneratedQuestions(response);
       
       if (!questions.length) {

--- a/scripts/generate_explanations.cjs
+++ b/scripts/generate_explanations.cjs
@@ -20,7 +20,6 @@
  *   --delay N        Milliseconds between batches (default: 500)
  *   --help           Show this help
  *
- * API key resolution order:
  */
 
 const fs    = require('fs');
@@ -94,6 +93,10 @@ function atomicWriteJson(filePath, data) {
     try { fs.unlinkSync(tmp); } catch {}
   }
 }
+
+// ─── Prompt builder ───────────────────────────────────────────────────────────
+
+const LETTERS = ['A', 'B', 'C', 'D', 'E'];
 
 function buildUserPrompt(q) {
   const lines = [`Question: ${q.q}`];

--- a/scripts/generate_explanations.cjs
+++ b/scripts/generate_explanations.cjs
@@ -8,7 +8,10 @@
  * and writes the result back to questions.json with periodic checkpoints.
  *
  * Usage:
- *   ANTHROPIC_API_KEY=sk-ant-... node generate_explanations.cjs [options]
+ *   node generate_explanations.cjs [options]
+ *
+ *   By default routes through the Toranot proxy (no API key required).
+ *   Pass --direct + ANTHROPIC_API_KEY=sk-... to bypass proxy.
  *
  * Options:
  *   --dry-run        Print what would be done without calling API or writing files
@@ -18,18 +21,15 @@
  *   --help           Show this help
  *
  * API key resolution order:
- *   1. ANTHROPIC_API_KEY environment variable
- *   2. ../config.json (JSON file with { "apiKey": "sk-..." })
  */
 
 const fs    = require('fs');
-const https = require('https');
 const path  = require('path');
+const { callClaude } = require('./lib/proxy-client.cjs');
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const QUESTIONS_PATH = path.resolve(__dirname, '..', 'data', 'questions.json');
-const CONFIG_PATH    = path.resolve(__dirname, '..', 'config.json');
 
 const MODEL          = 'claude-opus-4-6';
 const MAX_TOKENS     = 700;   // ~200 words + some margin
@@ -69,19 +69,17 @@ function parseArgs(argv) {
   return args;
 }
 
-// ─── API key loading ──────────────────────────────────────────────────────────
+// ─── Direct-mode resolution ──────────────────────────────────────────────────
 
-function loadApiKey() {
-  if (process.env.ANTHROPIC_API_KEY) return process.env.ANTHROPIC_API_KEY;
-  if (fs.existsSync(CONFIG_PATH)) {
-    try {
-      const cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
-      if (cfg.apiKey) return cfg.apiKey;
-    } catch (e) {
-      console.error(`Warning: Could not parse ${CONFIG_PATH}: ${e.message}`);
-    }
+function resolveDirectMode() {
+  const direct = process.argv.includes('--direct');
+  if (!direct) return { direct: false };
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    console.error('--direct requires ANTHROPIC_API_KEY env var.');
+    process.exit(1);
   }
-  return null;
+  return { direct: true, apiKey };
 }
 
 // ─── Atomic JSON write ────────────────────────────────────────────────────────
@@ -92,66 +90,10 @@ function atomicWriteJson(filePath, data) {
   try {
     fs.renameSync(tmp, filePath);
   } catch (e) {
-    // Windows can fail rename if target is locked; fall back to direct write
     fs.writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf8');
     try { fs.unlinkSync(tmp); } catch {}
   }
 }
-
-// ─── Claude API call ──────────────────────────────────────────────────────────
-
-function callClaude(apiKey, userPrompt) {
-  return new Promise((resolve, reject) => {
-    const body = JSON.stringify({
-      model: MODEL,
-      max_tokens: MAX_TOKENS,
-      system: SYSTEM_PROMPT,
-      messages: [{ role: 'user', content: userPrompt }]
-    });
-
-    const options = {
-      hostname: 'api.anthropic.com',
-      path: '/v1/messages',
-      method: 'POST',
-      headers: {
-        'Content-Type':       'application/json',
-        'anthropic-version':  '2023-06-01',
-        'x-api-key':          apiKey,
-        'Content-Length':     Buffer.byteLength(body)
-      }
-    };
-
-    const req = https.request(options, res => {
-      let data = '';
-      res.on('data', chunk => { data += chunk; });
-      res.on('end', () => {
-        try {
-          const parsed = JSON.parse(data);
-          if (parsed.content && parsed.content[0] && parsed.content[0].text) {
-            resolve(parsed.content[0].text.trim());
-          } else if (parsed.error) {
-            reject(new Error(`API error: ${parsed.error.type} — ${parsed.error.message}`));
-          } else {
-            reject(new Error(`Unexpected response: ${data.slice(0, 300)}`));
-          }
-        } catch (e) {
-          reject(new Error(`JSON parse error: ${e.message}. Raw: ${data.slice(0, 200)}`));
-        }
-      });
-    });
-
-    req.on('error', reject);
-    req.setTimeout(120000, () => {
-      req.destroy(new Error('Request timed out after 120s'));
-    });
-    req.write(body);
-    req.end();
-  });
-}
-
-// ─── Prompt builder ───────────────────────────────────────────────────────────
-
-const LETTERS = ['A', 'B', 'C', 'D', 'E'];
 
 function buildUserPrompt(q) {
   const lines = [`Question: ${q.q}`];
@@ -247,14 +189,8 @@ async function main() {
     process.exit(0);
   }
 
-  const apiKey = loadApiKey();
-  if (!apiKey) {
-    console.error(
-      'ERROR: No API key found.\n' +
-      '  Set ANTHROPIC_API_KEY env var, or create config.json with {"apiKey":"sk-..."}'
-    );
-    process.exit(1);
-  }
+  const directMode = resolveDirectMode();
+  console.log(directMode.direct ? 'Mode: DIRECT (api.anthropic.com)' : 'Mode: PROXY (toranot.netlify.app)');
 
   console.log(`Model: ${MODEL} | Batch size: ${BATCH_SIZE} | Delay: ${args.delay}ms | Save every: ${SAVE_EVERY}`);
   console.log('Starting...\n');
@@ -273,7 +209,7 @@ async function main() {
 
     // Run batch in parallel
     const results = await Promise.allSettled(
-      batch.map(({ q, idx }) => callClaude(apiKey, buildUserPrompt(q)).then(text => ({ idx, text })))
+      batch.map(({ q, idx }) => callClaude(buildUserPrompt(q), { model: MODEL, system: SYSTEM_PROMPT, max_tokens: MAX_TOKENS, timeout_ms: 120000, ...directMode }).then(text => ({ idx, text })))
     );
 
     // Apply results

--- a/scripts/lib/proxy-client.cjs
+++ b/scripts/lib/proxy-client.cjs
@@ -1,0 +1,106 @@
+'use strict';
+
+/**
+ * proxy-client.cjs — single AI-call entry point for all batch scripts.
+ *
+ * Default route: Toranot proxy (https://toranot.netlify.app/api/claude).
+ * The proxy holds the Anthropic API key server-side, enforces rate limits,
+ * tracks token usage in toranot_config, and accepts only the canonical
+ * allowed-model list. This means batch scripts never need ANTHROPIC_API_KEY
+ * and never leak it to disk via config.json.
+ *
+ * Direct-API fallback: pass { direct: true, apiKey } if the proxy is down
+ * (Netlify outage, key rotation in progress) — per deploy-primitives § 4
+ * "Reach for direct Anthropic API unless the proxy genuinely flaps".
+ *
+ * Allowed models (proxy-side, verified 2026-05-22):
+ *   - claude-sonnet-4-6, claude-opus-4-6, claude-haiku-4-5-20251001
+ *   - aliases: sonnet, opus, haiku
+ *   - 'claude-opus-4-20250514' is REJECTED (returns HTTP 400 "Unsupported model")
+ *     — use 'opus' alias instead.
+ *
+ * Returns just the response text (matches the previous per-script callClaude
+ * shape so refactor is drop-in).
+ */
+
+const PROXY_URL = 'https://toranot.netlify.app/api/claude';
+const PROXY_SECRET = 'shlav-a-mega-1f97f311d307-2026';
+const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
+const ANTHROPIC_VERSION = '2023-06-01';
+
+/**
+ * Call Claude. Returns a Promise<string> resolving to the response text.
+ *
+ * @param {string} prompt - the user message
+ * @param {object} options
+ * @param {string} options.model       - 'sonnet' (default) | 'opus' | 'haiku' | full string in allowed list
+ * @param {string} [options.system]    - optional system prompt
+ * @param {number} [options.max_tokens=4096]
+ * @param {number} [options.timeout_ms=60000]
+ * @param {boolean} [options.direct=false] - bypass proxy, hit api.anthropic.com
+ * @param {string} [options.apiKey]    - required when direct=true
+ * @param {function} [options.fetchImpl=fetch] - injectable for tests
+ *
+ * @returns {Promise<string>} concatenated text from response.content
+ */
+async function callClaude(prompt, options = {}) {
+  const {
+    model = 'sonnet',
+    system,
+    max_tokens = 4096,
+    timeout_ms = 60_000,
+    direct = false,
+    apiKey,
+    fetchImpl = fetch,
+  } = options;
+
+  if (direct && !apiKey) {
+    throw new Error('proxy-client: direct=true requires apiKey (ANTHROPIC_API_KEY)');
+  }
+
+  const body = { model, max_tokens, messages: [{ role: 'user', content: prompt }] };
+  if (typeof system === 'string' && system.length) body.system = system;
+
+  const url = direct ? ANTHROPIC_URL : PROXY_URL;
+  const headers = { 'Content-Type': 'application/json' };
+  if (direct) {
+    headers['x-api-key'] = apiKey;
+    headers['anthropic-version'] = ANTHROPIC_VERSION;
+  } else {
+    headers['x-api-secret'] = PROXY_SECRET;
+  }
+
+  const ac = new AbortController();
+  const t = setTimeout(() => ac.abort(), timeout_ms);
+  let res;
+  try {
+    res = await fetchImpl(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: ac.signal,
+    });
+  } finally {
+    clearTimeout(t);
+  }
+
+  if (!res.ok) {
+    const errText = await res.text().catch(() => '<unreadable>');
+    throw new Error(`proxy-client: HTTP ${res.status} from ${direct ? 'Anthropic' : 'proxy'}: ${errText.slice(0, 300)}`);
+  }
+
+  const data = await res.json();
+  if (!Array.isArray(data.content)) {
+    throw new Error(`proxy-client: malformed response — content array missing. Got: ${JSON.stringify(data).slice(0, 300)}`);
+  }
+  const text = data.content.map(b => (b && typeof b.text === 'string') ? b.text : '').join('');
+  return text;
+}
+
+module.exports = {
+  callClaude,
+  PROXY_URL,
+  PROXY_SECRET,
+  ANTHROPIC_URL,
+  ANTHROPIC_VERSION,
+};

--- a/scripts/translate_questions_to_hebrew.cjs
+++ b/scripts/translate_questions_to_hebrew.cjs
@@ -16,7 +16,10 @@
  *   - Numerical values, ranges, units
  *
  * Usage:
- *   ANTHROPIC_API_KEY=sk-ant-... node translate_questions_to_hebrew.cjs [options]
+ *   node translate_questions_to_hebrew.cjs [options]
+ *
+ *   By default routes through the Toranot proxy (no API key required).
+ *   Pass --direct + ANTHROPIC_API_KEY=sk-... to bypass proxy.
  *
  * Options:
  *   --dry-run        Print 1-2 sample translations to stdout, don't write
@@ -41,8 +44,8 @@
  */
 
 const fs    = require('fs');
-const https = require('https');
 const path  = require('path');
+const { callClaude } = require('./lib/proxy-client.cjs');
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -180,56 +183,15 @@ if (!['in-place','bilingual'].includes(MODE)) {
 
 // ─── API key resolution ───────────────────────────────────────────────────────
 
-function getApiKey() {
-  if (process.env.ANTHROPIC_API_KEY) return process.env.ANTHROPIC_API_KEY;
-  try {
-    const c = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
-    if (c.apiKey) return c.apiKey;
-  } catch {}
-  console.error('No API key. Set ANTHROPIC_API_KEY or add config.json with {"apiKey":"..."}.');
-  process.exit(1);
-}
-
-// ─── HTTPS call to Claude ─────────────────────────────────────────────────────
-
-function callClaude(apiKey, userMsg) {
-  const body = JSON.stringify({
-    model: MODEL,
-    max_tokens: MAX_TOKENS,
-    system: SYSTEM_PROMPT,
-    messages: [{ role: 'user', content: userMsg }],
-  });
-  const opts = {
-    hostname: 'api.anthropic.com',
-    path: '/v1/messages',
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': apiKey,
-      'anthropic-version': '2023-06-01',
-      'Content-Length': Buffer.byteLength(body),
-    },
-    timeout: 60_000,
-  };
-  return new Promise((resolve, reject) => {
-    const req = https.request(opts, (res) => {
-      const chunks = [];
-      res.on('data', (c) => chunks.push(c));
-      res.on('end', () => {
-        const raw = Buffer.concat(chunks).toString('utf8');
-        if (res.statusCode !== 200) return reject(new Error(`HTTP ${res.statusCode}: ${raw.slice(0, 300)}`));
-        try {
-          const parsed = JSON.parse(raw);
-          const text = parsed?.content?.[0]?.text || '';
-          resolve(text);
-        } catch (e) { reject(new Error(`bad JSON from API: ${e.message}`)); }
-      });
-    });
-    req.on('error', reject);
-    req.on('timeout', () => { req.destroy(new Error('timeout')); });
-    req.write(body);
-    req.end();
-  });
+function resolveDirectMode() {
+  const direct = process.argv.includes('--direct');
+  if (!direct) return { direct: false };
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    console.error('--direct requires ANTHROPIC_API_KEY env var.');
+    process.exit(1);
+  }
+  return { direct: true, apiKey };
 }
 
 function extractJson(text) {
@@ -273,7 +235,8 @@ function applyBilingual(target, translated) {
 }
 
 async function main() {
-  const apiKey = DRY_RUN ? 'dry' : getApiKey();
+  const directMode = DRY_RUN ? { direct: false } : resolveDirectMode();
+  console.log(directMode.direct ? 'Mode: DIRECT (api.anthropic.com)' : 'Mode: PROXY (toranot.netlify.app)');
   const allQs = JSON.parse(fs.readFileSync(TARGET, 'utf8'));
 
   // English-only filter: <30% Hebrew chars in q+o
@@ -310,7 +273,7 @@ async function main() {
       console.log(`  EN o[${q.c}] (correct): ${(q.o?.[q.c] || '').slice(0, 80)}`);
     }
     console.log('\nTo run for real:');
-    console.log(`  ANTHROPIC_API_KEY=sk-ant-... node ${path.basename(__filename)} --tag ${TAG} --limit ${LIMIT} --mode ${MODE}`);
+    console.log(`  node ${path.basename(__filename)} --tag ${TAG} --limit ${LIMIT} --mode ${MODE}`);
     return;
   }
 
@@ -325,7 +288,7 @@ async function main() {
     const slice = todo.slice(off, off + BATCH_SIZE);
     const results = await Promise.all(slice.map(async ({ q, i }) => {
       try {
-        const text = await callClaude(apiKey, USER_TEMPLATE(q));
+        const text = await callClaude(USER_TEMPLATE(q), { model: MODEL, system: SYSTEM_PROMPT, max_tokens: MAX_TOKENS, ...directMode });
         const obj = extractJson(text);
         if (typeof obj.q !== 'string' || !Array.isArray(obj.o) || obj.o.length !== q.o.length) {
           throw new Error(`bad shape: q-string=${typeof obj.q} o-array=${Array.isArray(obj.o)} same-len=${obj.o?.length === q.o.length}`);

--- a/tests/proxyClient.test.js
+++ b/tests/proxyClient.test.js
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for scripts/lib/proxy-client.cjs.
+ *
+ * Verifies the proxy contract is wired correctly so the 3 batch scripts
+ * (translate_questions_to_hebrew, generate_explanations, generate-questions)
+ * don't silently regress on auth headers or URL when refactored to use it.
+ *
+ * Mocked fetch — does NOT hit the real proxy.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+
+const require = createRequire(import.meta.url);
+const ROOT = resolve(import.meta.dirname, '..');
+const { callClaude, PROXY_URL, PROXY_SECRET, ANTHROPIC_URL, ANTHROPIC_VERSION } =
+  require(resolve(ROOT, 'scripts', 'lib', 'proxy-client.cjs'));
+
+function mockOk(text = 'mock response') {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ content: [{ type: 'text', text }] }),
+  });
+}
+
+describe('proxy-client — default proxy mode', () => {
+  it('POSTs to PROXY_URL with x-api-secret header (no x-api-key)', async () => {
+    const fetchImpl = mockOk();
+    await callClaude('hello', { fetchImpl });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toBe(PROXY_URL);
+    expect(init.method).toBe('POST');
+    expect(init.headers['x-api-secret']).toBe(PROXY_SECRET);
+    expect(init.headers['x-api-key']).toBeUndefined();
+    expect(init.headers['anthropic-version']).toBeUndefined();
+  });
+
+  it('sends model + max_tokens + messages in body; secret never in body (Codex P1 vector)', async () => {
+    const fetchImpl = mockOk();
+    await callClaude('hello', { model: 'opus', max_tokens: 512, fetchImpl });
+    const body = JSON.parse(fetchImpl.mock.calls[0][1].body);
+    expect(body.model).toBe('opus');
+    expect(body.max_tokens).toBe(512);
+    expect(body.messages).toEqual([{ role: 'user', content: 'hello' }]);
+    expect(body.secret).toBeUndefined();         // not in body
+    expect(body['x-api-secret']).toBeUndefined();
+  });
+
+  it('defaults to sonnet alias when model omitted', async () => {
+    const fetchImpl = mockOk();
+    await callClaude('q', { fetchImpl });
+    const body = JSON.parse(fetchImpl.mock.calls[0][1].body);
+    expect(body.model).toBe('sonnet');
+  });
+
+  it('omits system field when not provided; includes it when given', async () => {
+    const fetchImpl = mockOk();
+    await callClaude('q', { fetchImpl });
+    expect(JSON.parse(fetchImpl.mock.calls[0][1].body).system).toBeUndefined();
+
+    const fetchImpl2 = mockOk();
+    await callClaude('q', { system: 'You are a doctor.', fetchImpl: fetchImpl2 });
+    expect(JSON.parse(fetchImpl2.mock.calls[0][1].body).system).toBe('You are a doctor.');
+  });
+
+  it('returns concatenated text from content array', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ content: [
+        { type: 'text', text: 'part one ' },
+        { type: 'text', text: 'part two' },
+      ]}),
+    });
+    const result = await callClaude('q', { fetchImpl });
+    expect(result).toBe('part one part two');
+  });
+
+  it('throws with status + body on non-2xx', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: false, status: 400,
+      text: () => Promise.resolve('Unsupported model'),
+      json: () => Promise.resolve(null),
+    });
+    await expect(callClaude('q', { model: 'claude-opus-4-20250514', fetchImpl }))
+      .rejects.toThrow(/HTTP 400 from proxy.*Unsupported model/);
+  });
+
+  it('throws when response content array is missing/malformed', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ error: { type: 'invalid_request_error' } }),
+    });
+    await expect(callClaude('q', { fetchImpl })).rejects.toThrow(/malformed response/);
+  });
+});
+
+describe('proxy-client — direct fallback mode', () => {
+  it('hits api.anthropic.com with x-api-key + anthropic-version when direct=true', async () => {
+    const fetchImpl = mockOk();
+    await callClaude('hello', { direct: true, apiKey: 'sk-ant-test', fetchImpl });
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toBe(ANTHROPIC_URL);
+    expect(init.headers['x-api-key']).toBe('sk-ant-test');
+    expect(init.headers['anthropic-version']).toBe(ANTHROPIC_VERSION);
+    expect(init.headers['x-api-secret']).toBeUndefined();
+  });
+
+  it('refuses direct mode without apiKey', async () => {
+    await expect(callClaude('q', { direct: true })).rejects.toThrow(/requires apiKey/);
+  });
+});
+
+describe('proxy-client — exports', () => {
+  it('exports PROXY_URL and PROXY_SECRET as fixed constants', () => {
+    expect(PROXY_URL).toBe('https://toranot.netlify.app/api/claude');
+    expect(PROXY_SECRET).toBe('shlav-a-mega-1f97f311d307-2026');
+  });
+});


### PR DESCRIPTION
Closes the **scripts/*.cjs → Toranot proxy migration** backlog from the v10.64.130 close-out memo.

## Problem

Three batch scripts hit `api.anthropic.com` directly while the rest of the stack uses `toranot.netlify.app/api/claude`:
- `scripts/translate_questions_to_hebrew.cjs`
- `scripts/generate_explanations.cjs`
- `scripts/generate-questions.cjs`

This meant divergent auth (ANTHROPIC_API_KEY in env/config.json vs `x-api-secret` header), zero token tracking in `toranot_config`, no rate-limit protection, and **one latent bug**:

> `generate-questions.cjs --proxy` was broken — sent the secret in the request body (`body.secret = ...`) instead of the `x-api-secret` HEADER, AND hardcoded `model: 'claude-opus-4-20250514'` which the proxy returns HTTP 400 "Unsupported model" on. Verified against the real proxy.

## Diff at a glance

| File | Type | Δ lines |
|---|---|---|
| `scripts/lib/proxy-client.cjs` | NEW | +106 |
| `tests/proxyClient.test.js` | NEW | +110 (10 tests) |
| `scripts/translate_questions_to_hebrew.cjs` | REFACTOR | 372 → 335 |
| `scripts/generate_explanations.cjs` | REFACTOR | 328 → 264 |
| `scripts/generate-questions.cjs` | REFACTOR | 727 → 691 |

## User-facing change

```diff
- ANTHROPIC_API_KEY=sk-ant-... node scripts/translate_questions_to_hebrew.cjs ...
+ node scripts/translate_questions_to_hebrew.cjs ...        # default = proxy
+ node scripts/translate_questions_to_hebrew.cjs --direct   # opt-in fallback (needs env var)
```

## Verified

- 10/10 proxy-client unit tests pass (mocked fetch; asserts `x-api-secret` in header, never in body — covers the latent bug class)
- E2E probe against real proxy: `'opus'` alias → 200 (resolves to `claude-opus-4-7`); `'haiku'` → 200; `'claude-opus-4-20250514'` → 400 "Unsupported model" (confirms fix)
- All 3 scripts: `node --check` passes
- No stragglers (`grep api.anthropic / x-api-key / loadApiKey / getApiKey / https.request`) outside legitimate console.log mode-display strings

## Preserved (NOT changed)

- Model choice in translate/generate_explanations (`sonnet`/`opus-4-6`)
- System prompts, max_tokens, timeouts per-script
- Concurrency / batching / save-checkpointing
- `--proxy` flag in generate-questions.cjs retained as no-op for back-compat

## Self-merge eligibility

Per "Codex green" rule: structural fix + new tests + latent bug closure. Will self-merge once Codex + CI clean.

🤖 Prepared by Claude (claude.ai web, captain mode)