### PR TITLE
chore(scripts): npm run regen:derived + regen:check aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "smoke:api-key": "node scripts/smoke-api-key-restore.mjs",
     "hooks:install": "git config core.hooksPath scripts/git-hooks && echo '\u00e2\u0153\u201c pre-commit + pre-push hooks active'",
     "verify": "node --check src/sw-update.js && python3 scripts/check-version-sync.py && python3 scripts/check-brace-balance.py && python3 scripts/check-inline-js.py && python3 scripts/check-innerhtml.py && python3 scripts/check-innerhtml-pieces.py && cross-env HARRISON_HEBREW_BASELINE=0 node scripts/harrison-hebrew-baseline.cjs --strict && vitest run",
+    "regen:derived": "node scripts/regen_derived.cjs",
+    "regen:check": "node scripts/regen_derived.cjs --check",
     "image:check": "node scripts/add-image-question.cjs --help"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

Two npm script aliases for the regen_derived gate landed in 80b16e376d:

```
npm run regen:derived   # node scripts/regen_derived.cjs
npm run regen:check     # node scripts/regen_derived.cjs --check
```

## Why

CC's regen gate is enforced via `regenDerived.test.js` in `npm run verify`. These aliases are purely ergonomic — easier to remember than the script path. Standard `<verb>:<noun>` npm convention matching `test:coverage`, `smoke:api-key`, `hooks:install` already in this package.json.

## Diff

| File | Change |
|---|---|
| `package.json` | +2 lines (additive only, 801B prefix + 292B suffix unchanged) |

Will self-merge once Codex + CI clean.

🤖 Claude (claude.ai web)