### PR TITLE
chore(git-hooks): add regen_derived.cjs --check to pre-push gate

### DIFF
--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Pre-push hook: run both innerHTML safety checkers before allowing push.
+# Pre-push hook: run innerHTML safety checkers + derived-data drift check before push.
 #
 # Install (one-time):
 #   cp scripts/git-hooks/pre-push .git/hooks/pre-push && chmod +x .git/hooks/pre-push
@@ -9,9 +9,12 @@
 # Runs:
 #   1. check-innerhtml.py          — catches unsafe `.innerHTML = ` template literals
 #   2. check-innerhtml-pieces.py   — catches partial-sanitize (e.g. `${sanitize(a)} ${b}`)
+#   3. regen_derived.cjs --check   — catches derived-data drift (syllabus_data /
+#                                    regulatory / question_chapters stale vs canonical
+#                                    data/questions.json — denominator-invalidates-ratios)
 #
-# These are the same checks `npm run verify` runs, but gated at the push
-# boundary so a rushed `git push` can't ship a regression.
+# Checks 1–2 mirror `npm run verify`; check 3 mirrors `npm run regen:check`.
+# All are gated at the push boundary so a rushed `git push` can't ship a regression.
 
 set -e
 
@@ -29,6 +32,12 @@ fi
 if ! python3 scripts/check-innerhtml-pieces.py; then
   echo ""
   echo "❌ pre-push: check-innerhtml-pieces.py found partial-sanitize gap."
+  FAIL=1
+fi
+
+if ! node scripts/regen_derived.cjs --check; then
+  echo ""
+  echo "❌ pre-push: regen_derived.cjs --check found derived-data drift."
   FAIL=1
 fi
 


### PR DESCRIPTION
## What

Appends `node scripts/regen_derived.cjs --check` to `scripts/git-hooks/pre-push`, after the two innerHTML safety checks, using the same `if ! … then FAIL=1; fi` collecting idiom.

## Why

Closes the **denominator-invalidates-all-ratios** bug class at the push boundary. `regen_derived.cjs` (added #259) verifies that `syllabus_data.json` / `regulatory.json` / `question_chapters.json` are not stale vs canonical `data/questions.json`. `npm run regen:check` (alias #262) runs it; this wires it into the pre-push gate so a rushed `git push` can't ship 19/46-stale-frequency_pct-style drift (the PR #258 incident).

## Verification

- `bash -n scripts/git-hooks/pre-push` → syntax OK
- `node scripts/regen_derived.cjs --check` on clean `origin/main` → `no drift`, exit 0
- Single-file change, 12 insertions / 3 deletions. Header comment + Runs list updated for accuracy (check 3 mirrors `npm run regen:check`, not `npm run verify`).

## Notes

Established by audit-fix-deploy SKILL.md § DISCIPLINE D.3 (derived-data regen gate). No logic, no test-defining changes — git-hook config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)