### PR TITLE
chore(scripts): migrate source-scanner.mjs + gen_ai_hard_geri.mjs to Toranot proxy

### DIFF
--- a/scripts/gen_ai_hard_geri.mjs
+++ b/scripts/gen_ai_hard_geri.mjs
@@ -6,16 +6,25 @@
 // + GRS8 source library. Per Phase 2c of 2026-05-08 plan: NEVER auto-merge,
 // outputs to data/ai_hard_seed.geri.generated.json for morning review.
 //
-// Usage:
-//   ANTHROPIC_API_KEY=sk-... node scripts/gen_ai_hard_geri.mjs --hazzard 30 --harrison 15 --grs8 5
+// Usage (proxy mode — default, no local key needed):
+//   node scripts/gen_ai_hard_geri.mjs --hazzard 30 --harrison 15 --grs8 5
 //
-// Cost: ~$0.0080 per question on Sonnet 4.6. Default cap: $25 = ~3000 Qs ceiling.
-// Plan-target: 50 new Qs total — that's ~$0.40. Cheap.
+// Usage (direct mode fallback, when Toranot is down):
+//   AI_DIRECT=1 ANTHROPIC_API_KEY=sk-... node scripts/gen_ai_hard_geri.mjs --hazzard 30 --harrison 15 --grs8 5
+//
+// Cost: ~$0.0080 per question on Sonnet 4.6. Cap enforcement moved server-side to Toranot
+// proxy in v10.64.131 (per audit-fix-deploy D.3 + #261 precedent). Direct mode bypasses
+// the cap entirely — use with care.
 
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 import { extractJson } from './lib/extractJson.mjs';
+
+// proxy-client.cjs is CJS — use createRequire for ESM interop
+const require = createRequire(import.meta.url);
+const { callClaude: callClaudeProxy } = require('./lib/proxy-client.cjs');
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
@@ -37,11 +46,14 @@ if (!N_HAZZARD && !N_HARRISON && !N_GRS8) {
   process.exit(1);
 }
 
-const API_KEY = process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_API_KEY;
-if (!API_KEY) { console.error('ANTHROPIC_API_KEY (or CLAUDE_API_KEY) env var not set.'); process.exit(2); }
-if (API_KEY.length !== 108) { console.error(`API key length=${API_KEY.length}, expected 108`); process.exit(2); }
+// v10.64.131: migrated to Toranot proxy (per audit-fix-deploy D.3 + memory #29).
+// Default = proxy mode (no key needed locally). Set AI_DIRECT=1 + ANTHROPIC_API_KEY
+// for fallback when Toranot is down (per deploy-primitives §4 direct-api carve-out).
+const DIRECT_MODE = process.env.AI_DIRECT === '1';
+const DIRECT_KEY = DIRECT_MODE ? (process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_API_KEY) : null;
+if (DIRECT_MODE && !DIRECT_KEY) { console.error('AI_DIRECT=1 but ANTHROPIC_API_KEY (or CLAUDE_API_KEY) env var not set.'); process.exit(2); }
 
-const MODEL = process.env.AI_MODEL || 'claude-opus-4-7';
+const MODEL = process.env.AI_MODEL || 'opus';
 const COST_CAP_USD = Number(process.env.CHAOS_COST_CAP_USD || 25);
 const COST = { calls: 0, inTok: 0, outTok: 0 };
 const priceUsd = () => (COST.inTok / 1e6) * 3 + (COST.outTok / 1e6) * 15;
@@ -70,18 +82,19 @@ Topic indices (ti, 0-45):
 `;
 
 async function callAnthropic(userPrompt, maxTokens = 1800) {
-  if (priceUsd() >= COST_CAP_USD) throw new Error(`cost-cap reached: $${priceUsd().toFixed(2)} >= $${COST_CAP_USD}`);
-  const res = await fetch('https://api.anthropic.com/v1/messages', {
-    method: 'POST',
-    headers: { 'x-api-key': API_KEY, 'anthropic-version': '2023-06-01', 'content-type': 'application/json' },
-    body: JSON.stringify({ model: MODEL, max_tokens: maxTokens, system: SYSTEM, messages: [{ role: 'user', content: userPrompt }] }),
+  // v10.64.131: cost cap now enforced by Toranot proxy server-side (per #261 precedent).
+  // Client-side cap is a no-op in proxy mode because proxy-client doesn't expose usage tokens.
+  // Set CHAOS_COST_CAP_USD on the proxy side via toranot_config if tighter caps are needed.
+  const text = await callClaudeProxy(userPrompt, {
+    model: MODEL,
+    system: SYSTEM,
+    max_tokens: maxTokens,
+    timeout_ms: 60_000,
+    direct: DIRECT_MODE,
+    apiKey: DIRECT_KEY,
   });
-  if (!res.ok) throw new Error(`Anthropic API ${res.status}: ${(await res.text()).slice(0, 200)}`);
-  const json = await res.json();
   COST.calls += 1;
-  COST.inTok += json.usage?.input_tokens || 0;
-  COST.outTok += json.usage?.output_tokens || 0;
-  return json.content[0].text;
+  return text;
 }
 
 function parseQs(text, expectedTag) {

--- a/scripts/gen_ai_hard_geri.mjs
+++ b/scripts/gen_ai_hard_geri.mjs
@@ -53,7 +53,11 @@ const DIRECT_MODE = process.env.AI_DIRECT === '1';
 const DIRECT_KEY = DIRECT_MODE ? (process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_API_KEY) : null;
 if (DIRECT_MODE && !DIRECT_KEY) { console.error('AI_DIRECT=1 but ANTHROPIC_API_KEY (or CLAUDE_API_KEY) env var not set.'); process.exit(2); }
 
-const MODEL = process.env.AI_MODEL || 'opus';
+// Default model branches on mode: proxy accepts 'opus' alias (resolves to current
+// opus server-side); direct mode forwards the string straight to Anthropic, which
+// needs a canonical model ID. AI_MODEL env var overrides both paths.
+// (Codex P1 #264 caught the original 'opus'-everywhere default breaking direct fallback.)
+const MODEL = process.env.AI_MODEL || (DIRECT_MODE ? 'claude-opus-4-7' : 'opus');
 const COST_CAP_USD = Number(process.env.CHAOS_COST_CAP_USD || 25);
 const COST = { calls: 0, inTok: 0, outTok: 0 };
 const priceUsd = () => (COST.inTok / 1e6) * 3 + (COST.outTok / 1e6) * 15;

--- a/scripts/source-scanner.mjs
+++ b/scripts/source-scanner.mjs
@@ -42,8 +42,12 @@ const { callClaude: callClaudeProxy } = require('./lib/proxy-client.cjs');
 // v10.64.131: migrated to Toranot proxy (per audit-fix-deploy D.3 + memory #29).
 // Default = proxy mode (no key needed locally). Set SCAN_DIRECT=1 + CLAUDE_API_KEY
 // for fallback when Toranot is down (per deploy-primitives §4 direct-api carve-out).
-const MODEL = process.env.SCAN_MODEL || 'opus';
 const DIRECT_MODE = process.env.SCAN_DIRECT === '1';
+// Default model branches on mode: proxy accepts 'opus' alias (resolves to current
+// opus server-side); direct mode forwards the string straight to Anthropic, which
+// needs a canonical model ID. SCAN_MODEL env var overrides both paths.
+// (Codex P1 #264 caught the original 'opus'-everywhere default breaking direct fallback.)
+const MODEL = process.env.SCAN_MODEL || (DIRECT_MODE ? 'claude-opus-4-7' : 'opus');
 const DIRECT_KEY = DIRECT_MODE ? (process.env.CLAUDE_API_KEY || process.env.ANTHROPIC_API_KEY) : null;
 if (DIRECT_MODE && !DIRECT_KEY) { console.error('SCAN_DIRECT=1 but CLAUDE_API_KEY/ANTHROPIC_API_KEY not set'); process.exit(2); }
 

--- a/scripts/source-scanner.mjs
+++ b/scripts/source-scanner.mjs
@@ -32,13 +32,20 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
+import { createRequire } from 'node:module';
 import { extractJson } from './lib/extractJson.mjs';
 
-const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
-const MODEL = process.env.SCAN_MODEL || 'claude-opus-4-7';
-const KEY = process.env.CLAUDE_API_KEY;
-if (!KEY) { console.error('CLAUDE_API_KEY not set'); process.exit(2); }
-if (KEY.length !== 108) { console.error(`CLAUDE_API_KEY length=${KEY.length}, expected 108`); process.exit(2); }
+// proxy-client.cjs is CJS — use createRequire for ESM interop
+const require = createRequire(import.meta.url);
+const { callClaude: callClaudeProxy } = require('./lib/proxy-client.cjs');
+
+// v10.64.131: migrated to Toranot proxy (per audit-fix-deploy D.3 + memory #29).
+// Default = proxy mode (no key needed locally). Set SCAN_DIRECT=1 + CLAUDE_API_KEY
+// for fallback when Toranot is down (per deploy-primitives §4 direct-api carve-out).
+const MODEL = process.env.SCAN_MODEL || 'opus';
+const DIRECT_MODE = process.env.SCAN_DIRECT === '1';
+const DIRECT_KEY = DIRECT_MODE ? (process.env.CLAUDE_API_KEY || process.env.ANTHROPIC_API_KEY) : null;
+if (DIRECT_MODE && !DIRECT_KEY) { console.error('SCAN_DIRECT=1 but CLAUDE_API_KEY/ANTHROPIC_API_KEY not set'); process.exit(2); }
 
 const CONFIG = {
   questionsPath: process.env.SCAN_QUESTIONS || 'data/questions.json',
@@ -50,28 +57,35 @@ const CONFIG = {
 
 const COST = { totalCalls: 0, inTok: 0, outTok: 0, failures: 0 };
 const priceUsd = (i, o) => (i / 1e6) * 3 + (o / 1e6) * 15;
-const costExceeded = () => priceUsd(COST.inTok, COST.outTok) >= CONFIG.costCapUsd;
+// v10.64.131: cost cap now enforced by Toranot proxy server-side (per #261 precedent).
+// Client-side cap is a no-op in proxy mode because proxy-client doesn't expose usage tokens.
+// In direct mode (SCAN_DIRECT=1) the cap is also disabled — for that case, set tighter
+// CHAOS_COST_CAP_USD environment guards or use the proxy.
+const costExceeded = () => false;
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 async function callClaude(system, user, { maxTokens = 250, retries = 3 } = {}) {
-  const body = { model: MODEL, max_tokens: maxTokens, system, messages: [{ role: 'user', content: user }] };
+  // Retry wrapper around proxy-client. proxy-client throws on any !res.ok,
+  // so we catch and retry uniformly (vs the pre-migration code which distinguished
+  // 429/5xx as retryable and 4xx as fatal). Net effect: more retries on bad requests,
+  // which costs an extra ~3 attempts at script start if the prompt is malformed.
   let lastErr = null;
   for (let attempt = 0; attempt < retries; attempt++) {
     try {
-      const res = await fetch(ANTHROPIC_URL, {
-        method: 'POST',
-        headers: { 'anthropic-version': '2023-06-01', 'x-api-key': KEY, 'content-type': 'application/json' },
-        body: JSON.stringify(body),
+      const text = await callClaudeProxy(user, {
+        model: MODEL,
+        system,
+        max_tokens: maxTokens,
+        timeout_ms: 60_000,
+        direct: DIRECT_MODE,
+        apiKey: DIRECT_KEY,
       });
-      if (res.status === 429 || res.status >= 500) { await sleep((attempt + 1) * 1500); continue; }
-      if (!res.ok) { lastErr = new Error(`API ${res.status}: ${(await res.text()).slice(0, 200)}`); break; }
-      const data = await res.json();
-      const text = (data.content || []).filter((c) => c.type === 'text').map((c) => c.text).join('');
       COST.totalCalls += 1;
-      COST.inTok += data.usage?.input_tokens || 0;
-      COST.outTok += data.usage?.output_tokens || 0;
       return { text };
-    } catch (e) { lastErr = e; await sleep((attempt + 1) * 800); }
+    } catch (e) {
+      lastErr = e;
+      await sleep((attempt + 1) * 1500);
+    }
   }
   COST.failures += 1;
   throw lastErr || new Error('Claude API call failed after retries');


### PR DESCRIPTION
## What

Closes the proxy migration scope: 2 remaining `.mjs` batch scripts that were still hitting `api.anthropic.com` directly after PR #261 migrated the 3 main `.cjs` scripts.

Today's bash_history credential leak (CLAUDE_API_KEY in plaintext, rotated this session) is exactly the failure mode this migration prevents — proxy mode needs no local key.

## Scope (audited via full enumeration of 42 scripts in scripts/)

**In scope:**
- `scripts/source-scanner.mjs` — bypassed proxy, read `CLAUDE_API_KEY`
- `scripts/gen_ai_hard_geri.mjs` — bypassed proxy, read `ANTHROPIC_API_KEY`

**Deferred (with reason):**
- `chaos-doctor-bot-v4.mjs` — already has `CHAOS_USE_PROXY=1` opt-in; default-flip is a behavior change worth its own PR
- `generate_distractors.cjs` — already proxy-routed (inline impl); refactor to shared helper is consistency cleanup, not bug fix
- 5 Python scripts — need a Python proxy client first, separate work

## Migration pattern (mirrors PR #261 precedent)

| Concern | Before | After |
|---|---|---|
| Auth | `process.env.CLAUDE_API_KEY` required at startup | Proxy default; `SCAN_DIRECT=1` / `AI_DIRECT=1` for fallback |
| URL | `https://api.anthropic.com/v1/messages` direct | `callClaudeProxy(...)` (proxy or direct via opt-in) |
| Default model | `claude-opus-4-7` (not in proxy allowlist) | `'opus'` alias (proxy-resolvable) |
| Cost cap | Client-side mid-call throw | Delegated to Toranot proxy server-side |
| Retry (source-scanner) | 429/5xx-distinguishing retry loop | Same loop, treats all errors as retry-eligible (slight over-retry on 4xx) |

## Verified

- Both files pass `node --check`
- ESM→CJS interop smoke test: `createRequire` resolves `callClaude` from `scripts/lib/proxy-client.cjs` ✓
- Migration code path mirrors the 3 already-merged `.cjs` migrations from #261

## Not verified from web side (CC: please confirm post-merge)

- End-to-end run against the proxy (cost + network)
- Direct-mode fallback path (`SCAN_DIRECT=1` / `AI_DIRECT=1`)
- That `opus` alias resolves on the proxy side (the helper's documented allowlist is dated 2026-05-22)

## Behavior changes for script users

- No longer need `CLAUDE_API_KEY` / `ANTHROPIC_API_KEY` in env for default proxy mode
- Default model is `opus` alias; override via `SCAN_MODEL` / `AI_MODEL`
- Cost cap no longer client-side — rely on Toranot proxy or use smaller batch sizes
- Direct mode is opt-in fallback: `SCAN_DIRECT=1` or `AI_DIRECT=1` + key env var

D.1 applied (re-fetched main HEAD just before push). D.5 will apply at merge time per wa2/Geriatrics pattern.