### PR TITLE
feat(proxy-client): structured error classification + retry helper

### DIFF
--- a/scripts/lib/proxy-client.cjs
+++ b/scripts/lib/proxy-client.cjs
@@ -21,12 +21,112 @@
  *
  * Returns just the response text (matches the previous per-script callClaude
  * shape so refactor is drop-in).
+ *
+ * Errors thrown by callClaude are ProxyError instances (instanceof Error) with
+ * structured classification: { transient, category, status, cause }. Callers
+ * that want automatic retry on transient failures should use callClaudeWithRetry
+ * instead of re-implementing the regex/status-code logic.
  */
 
 const PROXY_URL = 'https://toranot.netlify.app/api/claude';
 const PROXY_SECRET = 'shlav-a-mega-1f97f311d307-2026';
 const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
 const ANTHROPIC_VERSION = '2023-06-01';
+
+const TRANSIENT_NETWORK_CODES = new Set([
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'ECONNREFUSED',
+  'EPIPE',
+  'EHOSTUNREACH',
+]);
+
+class ProxyError extends Error {
+  constructor(message, { transient, category, status, cause } = {}) {
+    super(message);
+    this.name = 'ProxyError';
+    this.transient = Boolean(transient);
+    this.category = category || 'unknown';
+    this.status = status ?? null;
+    this.cause = cause ?? null;
+  }
+}
+
+/**
+ * Map raw failure inputs to a { transient, category, status } classification.
+ *
+ * Exported as `_classifyError` for direct unit testing. Underscore-prefixed to
+ * mark it as internal — callers should consume ProxyError on a real call, not
+ * call this directly.
+ *
+ * Precedence rule: body-type override applies ONLY for transient signals
+ * (overloaded_error, rate_limit/rate-limit). For non-transient categories
+ * (auth, bad_request, client_error), status wins. Rationale: only "retry me
+ * later" body types need to override status; terminal errors are well-
+ * characterized by status alone, and Anthropic's auth/bad_request body types
+ * mirror their status reliably.
+ */
+function _classifyError({ err, res, bodyText, parsedBody } = {}) {
+  if (err) {
+    if (err.name === 'AbortError') {
+      return { transient: true, category: 'timeout', status: null };
+    }
+    if (err.code && TRANSIENT_NETWORK_CODES.has(err.code)) {
+      return { transient: true, category: 'network', status: null };
+    }
+    return { transient: false, category: 'unknown', status: null };
+  }
+
+  const status = res && typeof res.status === 'number' ? res.status : null;
+
+  if (typeof bodyText === 'string' && bodyText.trimStart().startsWith('Upstream')) {
+    return { transient: true, category: 'netlify_upstream_timeout', status };
+  }
+
+  if (parsedBody && parsedBody.error && typeof parsedBody.error.type === 'string') {
+    const t = parsedBody.error.type.toLowerCase();
+    if (t === 'overloaded_error') {
+      return { transient: true, category: 'anthropic_overloaded', status };
+    }
+    if (t.includes('rate_limit') || t.includes('rate-limit')) {
+      return { transient: true, category: 'rate_limit', status };
+    }
+  }
+
+  const contentType =
+    res && res.headers && typeof res.headers.get === 'function'
+      ? String(res.headers.get('content-type') || '').toLowerCase()
+      : '';
+  const looksHtml =
+    contentType.startsWith('text/html') ||
+    (typeof bodyText === 'string' && bodyText.trimStart().startsWith('<'));
+  if (looksHtml && typeof status === 'number' && status >= 500) {
+    return { transient: true, category: 'netlify_5xx', status };
+  }
+
+  if (status === 502 || status === 503 || status === 504) {
+    return { transient: true, category: 'netlify_5xx', status };
+  }
+  if (status === 429) {
+    return { transient: true, category: 'rate_limit', status };
+  }
+  if (typeof status === 'number' && status >= 500 && status < 600) {
+    return { transient: true, category: 'server', status };
+  }
+  if (status === 401 || status === 403) {
+    return { transient: false, category: 'auth', status };
+  }
+  if (status === 400) {
+    return { transient: false, category: 'bad_request', status };
+  }
+  if (typeof status === 'number' && status >= 400 && status < 500) {
+    return { transient: false, category: 'client_error', status };
+  }
+
+  return { transient: false, category: 'malformed_response', status };
+}
 
 /**
  * Call Claude. Returns a Promise<string> resolving to the response text.
@@ -42,6 +142,8 @@ const ANTHROPIC_VERSION = '2023-06-01';
  * @param {function} [options.fetchImpl=fetch] - injectable for tests
  *
  * @returns {Promise<string>} concatenated text from response.content
+ * @throws {ProxyError} on any failure (instanceof Error). Inspect .transient,
+ *   .category, .status to decide retry vs. bail.
  */
 async function callClaude(prompt, options = {}) {
   const {
@@ -55,6 +157,9 @@ async function callClaude(prompt, options = {}) {
   } = options;
 
   if (direct && !apiKey) {
+    // programmer error — not wrapped in ProxyError intentionally. A config bug
+    // surfaces immediately at the call site instead of looking like a network
+    // failure that retry logic would chew through.
     throw new Error('proxy-client: direct=true requires apiKey (ANTHROPIC_API_KEY)');
   }
 
@@ -73,6 +178,7 @@ async function callClaude(prompt, options = {}) {
   const ac = new AbortController();
   const t = setTimeout(() => ac.abort(), timeout_ms);
   let res;
+  let networkErr;
   try {
     res = await fetchImpl(url, {
       method: 'POST',
@@ -80,25 +186,111 @@ async function callClaude(prompt, options = {}) {
       body: JSON.stringify(body),
       signal: ac.signal,
     });
+  } catch (e) {
+    networkErr = e;
   } finally {
     clearTimeout(t);
   }
 
-  if (!res.ok) {
-    const errText = await res.text().catch(() => '<unreadable>');
-    throw new Error(`proxy-client: HTTP ${res.status} from ${direct ? 'Anthropic' : 'proxy'}: ${errText.slice(0, 300)}`);
+  if (networkErr) {
+    const cls = _classifyError({ err: networkErr });
+    throw new ProxyError(
+      `proxy-client: ${networkErr.name || 'Error'}: ${networkErr.message || String(networkErr)}`,
+      { ...cls, cause: networkErr }
+    );
   }
 
-  const data = await res.json();
-  if (!Array.isArray(data.content)) {
-    throw new Error(`proxy-client: malformed response — content array missing. Got: ${JSON.stringify(data).slice(0, 300)}`);
+  const bodyText = await res.text().catch(() => '<unreadable>');
+  let parsedBody = null;
+  if (bodyText && bodyText !== '<unreadable>') {
+    try { parsedBody = JSON.parse(bodyText); } catch (_) { /* not JSON */ }
   }
-  const text = data.content.map(b => (b && typeof b.text === 'string') ? b.text : '').join('');
+
+  if (typeof bodyText === 'string' && bodyText.trimStart().startsWith('Upstream')) {
+    const cls = _classifyError({ res, bodyText, parsedBody });
+    throw new ProxyError(
+      `proxy-client: Netlify upstream timeout: ${bodyText.slice(0, 300)}`,
+      cls
+    );
+  }
+
+  if (!res.ok) {
+    const cls = _classifyError({ res, bodyText, parsedBody });
+    throw new ProxyError(
+      `proxy-client: HTTP ${res.status} from ${direct ? 'Anthropic' : 'proxy'}: ${(bodyText || '').slice(0, 300)}`,
+      cls
+    );
+  }
+
+  if (!parsedBody || !Array.isArray(parsedBody.content)) {
+    throw new ProxyError(
+      `proxy-client: malformed response — content array missing. Got: ${(bodyText || '').slice(0, 300)}`,
+      { transient: false, category: 'malformed_response', status: res.status }
+    );
+  }
+
+  const text = parsedBody.content
+    .map(b => (b && typeof b.text === 'string') ? b.text : '')
+    .join('');
   return text;
+}
+
+/**
+ * Call Claude with exponential-backoff retry on transient ProxyErrors.
+ *
+ * @param {string} prompt
+ * @param {object} options - all callClaude options PLUS:
+ * @param {number} [options.maxAttempts=3]
+ * @param {number} [options.baseDelayMs=1000]
+ * @param {number} [options.jitterMs=300]  - additive jitter ([0, jitterMs))
+ * @param {function} [options.onRetry=null] - (err, attempt) => void
+ *
+ * Retry policy: ProxyError with transient=true triggers a retry up to
+ * maxAttempts. Non-ProxyError, non-transient ProxyError, and final-attempt
+ * failures rethrow.
+ *
+ * Jitter is additive (never accelerates): finalDelay =
+ * baseDelayMs * 2^(attempt-1) + Math.floor(Math.random() * jitterMs).
+ * This preserves the invariant that we never retry sooner than the nominal
+ * exponential delay; only later. Matches generate_distractors.cjs's pre-
+ * existing 600ms+jitter behavior shape, modulo the additive-only choice
+ * (the pre-existing inline impl used symmetric ±300ms).
+ */
+async function callClaudeWithRetry(prompt, options = {}) {
+  const {
+    maxAttempts = 3,
+    baseDelayMs = 1000,
+    jitterMs = 300,
+    onRetry = null,
+    ...callOpts
+  } = options;
+  let lastErr;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await callClaude(prompt, callOpts);
+    } catch (err) {
+      lastErr = err;
+      const shouldRetry =
+        err instanceof ProxyError &&
+        err.transient &&
+        attempt < maxAttempts;
+      if (!shouldRetry) throw err;
+      const exponentialDelay = baseDelayMs * Math.pow(2, attempt - 1);
+      const jitter = jitterMs > 0 ? Math.floor(Math.random() * jitterMs) : 0;
+      if (typeof onRetry === 'function') {
+        try { onRetry(err, attempt); } catch (_) { /* onRetry must never break retry loop */ }
+      }
+      await new Promise(r => setTimeout(r, exponentialDelay + jitter));
+    }
+  }
+  throw lastErr;
 }
 
 module.exports = {
   callClaude,
+  callClaudeWithRetry,
+  ProxyError,
+  _classifyError,
   PROXY_URL,
   PROXY_SECRET,
   ANTHROPIC_URL,

--- a/tests/proxyClient.test.js
+++ b/tests/proxyClient.test.js
@@ -1,9 +1,11 @@
 /**
  * Unit tests for scripts/lib/proxy-client.cjs.
  *
- * Verifies the proxy contract is wired correctly so the 3 batch scripts
- * (translate_questions_to_hebrew, generate_explanations, generate-questions)
- * don't silently regress on auth headers or URL when refactored to use it.
+ * Verifies the proxy contract is wired correctly so the 5 batch scripts
+ * (translate_questions_to_hebrew, generate_explanations, generate-questions,
+ * gen_ai_hard_geri, source-scanner) don't silently regress on auth headers
+ * or URL when refactored to use it, and that ProxyError classification +
+ * callClaudeWithRetry behave per the documented contract.
  *
  * Mocked fetch — does NOT hit the real proxy.
  */
@@ -14,15 +16,42 @@ import { resolve } from 'node:path';
 
 const require = createRequire(import.meta.url);
 const ROOT = resolve(import.meta.dirname, '..');
-const { callClaude, PROXY_URL, PROXY_SECRET, ANTHROPIC_URL, ANTHROPIC_VERSION } =
-  require(resolve(ROOT, 'scripts', 'lib', 'proxy-client.cjs'));
+const {
+  callClaude,
+  callClaudeWithRetry,
+  ProxyError,
+  _classifyError,
+  PROXY_URL,
+  PROXY_SECRET,
+  ANTHROPIC_URL,
+  ANTHROPIC_VERSION,
+} = require(resolve(ROOT, 'scripts', 'lib', 'proxy-client.cjs'));
+
+// --- mock helpers --------------------------------------------------------
+
+function makeResponse({ ok = true, status = 200, body = null, contentType = 'application/json' } = {}) {
+  const bodyText = body == null
+    ? JSON.stringify({ content: [{ type: 'text', text: 'mock response' }] })
+    : (typeof body === 'string' ? body : JSON.stringify(body));
+  return {
+    ok,
+    status,
+    headers: { get: (name) => (String(name).toLowerCase() === 'content-type' ? contentType : null) },
+    text: () => Promise.resolve(bodyText),
+    json: () => {
+      try { return Promise.resolve(JSON.parse(bodyText)); }
+      catch (e) { return Promise.reject(e); }
+    },
+  };
+}
 
 function mockOk(text = 'mock response') {
-  return vi.fn().mockResolvedValue({
-    ok: true,
-    json: () => Promise.resolve({ content: [{ type: 'text', text }] }),
-  });
+  return vi.fn().mockResolvedValue(makeResponse({
+    body: { content: [{ type: 'text', text }] },
+  }));
 }
+
+// --- existing-contract tests (unchanged in spirit) ------------------------
 
 describe('proxy-client — default proxy mode', () => {
   it('POSTs to PROXY_URL with x-api-secret header (no x-api-key)', async () => {
@@ -45,7 +74,7 @@ describe('proxy-client — default proxy mode', () => {
     expect(body.model).toBe('opus');
     expect(body.max_tokens).toBe(512);
     expect(body.messages).toEqual([{ role: 'user', content: 'hello' }]);
-    expect(body.secret).toBeUndefined();         // not in body
+    expect(body.secret).toBeUndefined();
     expect(body['x-api-secret']).toBeUndefined();
   });
 
@@ -67,32 +96,28 @@ describe('proxy-client — default proxy mode', () => {
   });
 
   it('returns concatenated text from content array', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ content: [
+    const fetchImpl = vi.fn().mockResolvedValue(makeResponse({
+      body: { content: [
         { type: 'text', text: 'part one ' },
         { type: 'text', text: 'part two' },
-      ]}),
-    });
+      ] },
+    }));
     const result = await callClaude('q', { fetchImpl });
     expect(result).toBe('part one part two');
   });
 
-  it('throws with status + body on non-2xx', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue({
-      ok: false, status: 400,
-      text: () => Promise.resolve('Unsupported model'),
-      json: () => Promise.resolve(null),
-    });
+  it('throws ProxyError with status + body on non-2xx (preserves legacy message format)', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(makeResponse({
+      ok: false, status: 400, body: 'Unsupported model',
+    }));
     await expect(callClaude('q', { model: 'claude-opus-4-20250514', fetchImpl }))
       .rejects.toThrow(/HTTP 400 from proxy.*Unsupported model/);
   });
 
-  it('throws when response content array is missing/malformed', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ error: { type: 'invalid_request_error' } }),
-    });
+  it('throws ProxyError when response content array is missing/malformed', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(makeResponse({
+      body: { error: { type: 'invalid_request_error' } },
+    }));
     await expect(callClaude('q', { fetchImpl })).rejects.toThrow(/malformed response/);
   });
 });
@@ -108,8 +133,16 @@ describe('proxy-client — direct fallback mode', () => {
     expect(init.headers['x-api-secret']).toBeUndefined();
   });
 
-  it('refuses direct mode without apiKey', async () => {
+  it('refuses direct mode without apiKey (programmer-error path — NOT ProxyError)', async () => {
     await expect(callClaude('q', { direct: true })).rejects.toThrow(/requires apiKey/);
+    // Verify it is a plain Error, not a ProxyError — config bugs must surface
+    // as such instead of looking like retryable network failures.
+    try {
+      await callClaude('q', { direct: true });
+    } catch (e) {
+      expect(e).toBeInstanceOf(Error);
+      expect(e).not.toBeInstanceOf(ProxyError);
+    }
   });
 });
 
@@ -117,5 +150,382 @@ describe('proxy-client — exports', () => {
   it('exports PROXY_URL and PROXY_SECRET as fixed constants', () => {
     expect(PROXY_URL).toBe('https://toranot.netlify.app/api/claude');
     expect(PROXY_SECRET).toBe('shlav-a-mega-1f97f311d307-2026');
+  });
+
+  it('exports ProxyError, callClaudeWithRetry, and _classifyError', () => {
+    expect(typeof ProxyError).toBe('function');
+    expect(typeof callClaudeWithRetry).toBe('function');
+    expect(typeof _classifyError).toBe('function');
+  });
+});
+
+// --- _classifyError: one assertion per documented row ---------------------
+
+describe('_classifyError — network errors (err.code)', () => {
+  it.each([
+    'ECONNRESET',
+    'ETIMEDOUT',
+    'ENOTFOUND',
+    'EAI_AGAIN',
+    'ECONNREFUSED',
+    'EPIPE',
+    'EHOSTUNREACH',
+  ])('classifies %s as transient network', (code) => {
+    const err = Object.assign(new Error('boom'), { code });
+    expect(_classifyError({ err })).toEqual({ transient: true, category: 'network', status: null });
+  });
+
+  it('non-transient err.code falls through to unknown', () => {
+    const err = Object.assign(new Error('boom'), { code: 'ENOENT' });
+    expect(_classifyError({ err })).toEqual({ transient: false, category: 'unknown', status: null });
+  });
+
+  it('error without code or AbortError name → non-transient unknown', () => {
+    expect(_classifyError({ err: new Error('mystery') }))
+      .toEqual({ transient: false, category: 'unknown', status: null });
+  });
+});
+
+describe('_classifyError — AbortError (client-side timeout)', () => {
+  it('err.name === "AbortError" → transient timeout', () => {
+    const err = Object.assign(new Error('aborted'), { name: 'AbortError' });
+    expect(_classifyError({ err })).toEqual({ transient: true, category: 'timeout', status: null });
+  });
+
+  it('DOMException-style AbortError (name set, no code) → transient timeout', () => {
+    // Real fetch in node produces a DOMException with .name === 'AbortError' and no .code.
+    const domEx = Object.assign(new Error('The operation was aborted'), { name: 'AbortError' });
+    expect(_classifyError({ err: domEx })).toEqual({ transient: true, category: 'timeout', status: null });
+  });
+});
+
+describe('_classifyError — Netlify plain-text upstream timeout', () => {
+  it('body starting with "Upstream" → transient netlify_upstream_timeout regardless of status', () => {
+    const res = { status: 200, headers: { get: () => 'text/plain' } };
+    expect(_classifyError({ res, bodyText: 'Upstream timeout' }))
+      .toEqual({ transient: true, category: 'netlify_upstream_timeout', status: 200 });
+  });
+
+  it('body with leading whitespace + "Upstream" still matches (trimStart)', () => {
+    const res = { status: 504, headers: { get: () => 'text/plain' } };
+    expect(_classifyError({ res, bodyText: '   Upstream timeout' }))
+      .toEqual({ transient: true, category: 'netlify_upstream_timeout', status: 504 });
+  });
+});
+
+describe('_classifyError — Anthropic error body (transient-only override)', () => {
+  it('overloaded_error → transient anthropic_overloaded (overrides 500-class status)', () => {
+    const res = { status: 500, headers: { get: () => 'application/json' } };
+    const parsedBody = { error: { type: 'overloaded_error' } };
+    expect(_classifyError({ res, bodyText: JSON.stringify(parsedBody), parsedBody }))
+      .toEqual({ transient: true, category: 'anthropic_overloaded', status: 500 });
+  });
+
+  it('rate_limit_error (underscore) → transient rate_limit', () => {
+    const res = { status: 429, headers: { get: () => 'application/json' } };
+    const parsedBody = { error: { type: 'rate_limit_error' } };
+    expect(_classifyError({ res, bodyText: JSON.stringify(parsedBody), parsedBody }))
+      .toEqual({ transient: true, category: 'rate_limit', status: 429 });
+  });
+
+  it('hyphenated rate-limit variant → transient rate_limit (paranoid catch preserved)', () => {
+    const res = { status: 429, headers: { get: () => 'application/json' } };
+    const parsedBody = { error: { type: 'some-rate-limit-thing' } };
+    expect(_classifyError({ res, bodyText: JSON.stringify(parsedBody), parsedBody }))
+      .toEqual({ transient: true, category: 'rate_limit', status: 429 });
+  });
+
+  it('precedence: invalid_request_error body does NOT override status (status wins for non-transient)', () => {
+    const res = { status: 400, headers: { get: () => 'application/json' } };
+    const parsedBody = { error: { type: 'invalid_request_error' } };
+    expect(_classifyError({ res, bodyText: JSON.stringify(parsedBody), parsedBody }))
+      .toEqual({ transient: false, category: 'bad_request', status: 400 });
+  });
+});
+
+describe('_classifyError — HTML page detection (Netlify 5xx)', () => {
+  it('body starts with "<" + status 502 → transient netlify_5xx', () => {
+    const res = { status: 502, headers: { get: () => 'text/plain' } };
+    expect(_classifyError({ res, bodyText: '<!DOCTYPE html><html>...' }))
+      .toEqual({ transient: true, category: 'netlify_5xx', status: 502 });
+  });
+
+  it('content-type text/html + status 503 → transient netlify_5xx', () => {
+    const res = { status: 503, headers: { get: () => 'text/html; charset=utf-8' } };
+    expect(_classifyError({ res, bodyText: 'whatever' }))
+      .toEqual({ transient: true, category: 'netlify_5xx', status: 503 });
+  });
+
+  it('HTML body with status 200 does NOT match netlify_5xx (status floor not met)', () => {
+    const res = { status: 200, headers: { get: () => 'text/html' } };
+    // Falls through: status 200 + no Anthropic error type → malformed_response
+    expect(_classifyError({ res, bodyText: '<html>...' }))
+      .toEqual({ transient: false, category: 'malformed_response', status: 200 });
+  });
+});
+
+describe('_classifyError — status-based classification', () => {
+  it.each([
+    [502, true,  'netlify_5xx'],
+    [503, true,  'netlify_5xx'],
+    [504, true,  'netlify_5xx'],
+    [429, true,  'rate_limit'],
+    [500, true,  'server'],
+    [599, true,  'server'],
+    [401, false, 'auth'],
+    [403, false, 'auth'],
+    [400, false, 'bad_request'],
+    [404, false, 'client_error'],
+    [422, false, 'client_error'],
+  ])('status %i → transient=%s category=%s', (status, transient, category) => {
+    const res = { status, headers: { get: () => 'application/json' } };
+    expect(_classifyError({ res, bodyText: '{}', parsedBody: {} }))
+      .toEqual({ transient, category, status });
+  });
+
+  it('status 200 with no Anthropic error → malformed_response', () => {
+    const res = { status: 200, headers: { get: () => 'application/json' } };
+    expect(_classifyError({ res, bodyText: '{}', parsedBody: {} }))
+      .toEqual({ transient: false, category: 'malformed_response', status: 200 });
+  });
+});
+
+// --- callClaude: integration — ProxyError is thrown and classified --------
+
+describe('callClaude — throws ProxyError with classification', () => {
+  it('502 from proxy → ProxyError transient=true category=netlify_5xx', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(makeResponse({
+      ok: false, status: 502, body: '<html>Bad gateway</html>', contentType: 'text/html',
+    }));
+    try {
+      await callClaude('q', { fetchImpl });
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ProxyError);
+      expect(e.transient).toBe(true);
+      expect(e.category).toBe('netlify_5xx');
+      expect(e.status).toBe(502);
+      expect(e.message).toMatch(/HTTP 502 from proxy/);
+    }
+  });
+
+  it('429 with Anthropic rate_limit_error → ProxyError transient=true category=rate_limit', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(makeResponse({
+      ok: false, status: 429, body: { error: { type: 'rate_limit_error', message: 'slow down' } },
+    }));
+    try {
+      await callClaude('q', { fetchImpl });
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ProxyError);
+      expect(e.transient).toBe(true);
+      expect(e.category).toBe('rate_limit');
+      expect(e.status).toBe(429);
+    }
+  });
+
+  it('401 → ProxyError transient=false category=auth', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(makeResponse({
+      ok: false, status: 401, body: 'Unauthorized',
+    }));
+    try {
+      await callClaude('q', { fetchImpl });
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ProxyError);
+      expect(e.transient).toBe(false);
+      expect(e.category).toBe('auth');
+      expect(e.status).toBe(401);
+    }
+  });
+
+  it('AbortError from fetch (timeout) → ProxyError transient=true category=timeout', async () => {
+    const abortErr = Object.assign(new Error('aborted'), { name: 'AbortError' });
+    const fetchImpl = vi.fn().mockRejectedValue(abortErr);
+    try {
+      await callClaude('q', { fetchImpl, timeout_ms: 50 });
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ProxyError);
+      expect(e.transient).toBe(true);
+      expect(e.category).toBe('timeout');
+      expect(e.cause).toBe(abortErr);
+    }
+  });
+
+  it('ENOTFOUND from fetch → ProxyError transient=true category=network with cause', async () => {
+    const netErr = Object.assign(new Error('getaddrinfo ENOTFOUND'), { code: 'ENOTFOUND' });
+    const fetchImpl = vi.fn().mockRejectedValue(netErr);
+    try {
+      await callClaude('q', { fetchImpl });
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ProxyError);
+      expect(e.transient).toBe(true);
+      expect(e.category).toBe('network');
+      expect(e.cause).toBe(netErr);
+    }
+  });
+
+  it('"Upstream timeout" plain-text body (status 200) → ProxyError transient=true netlify_upstream_timeout', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(makeResponse({
+      ok: true, status: 200, body: 'Upstream timeout', contentType: 'text/plain',
+    }));
+    try {
+      await callClaude('q', { fetchImpl });
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ProxyError);
+      expect(e.transient).toBe(true);
+      expect(e.category).toBe('netlify_upstream_timeout');
+      expect(e.message).toMatch(/Netlify upstream timeout.*Upstream timeout/);
+    }
+  });
+});
+
+// --- callClaudeWithRetry --------------------------------------------------
+
+describe('callClaudeWithRetry', () => {
+  it('retries on transient ProxyError twice, then succeeds on attempt 3', async () => {
+    const transientResp = makeResponse({ ok: false, status: 502, body: 'gateway error' });
+    const okResp = makeResponse({ body: { content: [{ type: 'text', text: 'finally ok' }] } });
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(transientResp)
+      .mockResolvedValueOnce(transientResp)
+      .mockResolvedValueOnce(okResp);
+
+    const result = await callClaudeWithRetry('q', {
+      fetchImpl,
+      maxAttempts: 3,
+      baseDelayMs: 1,
+      jitterMs: 0,
+    });
+
+    expect(result).toBe('finally ok');
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('does NOT retry on non-transient ProxyError — rethrows after attempt 1', async () => {
+    const authResp = makeResponse({ ok: false, status: 401, body: 'Unauthorized' });
+    const fetchImpl = vi.fn().mockResolvedValue(authResp);
+
+    try {
+      await callClaudeWithRetry('q', { fetchImpl, maxAttempts: 5, baseDelayMs: 1, jitterMs: 0 });
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ProxyError);
+      expect(e.transient).toBe(false);
+      expect(e.category).toBe('auth');
+    }
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('rethrows last error after maxAttempts on persistent transient failures', async () => {
+    const transientResp = makeResponse({ ok: false, status: 503, body: 'gateway' });
+    const fetchImpl = vi.fn().mockResolvedValue(transientResp);
+
+    try {
+      await callClaudeWithRetry('q', { fetchImpl, maxAttempts: 3, baseDelayMs: 1, jitterMs: 0 });
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ProxyError);
+      expect(e.transient).toBe(true);
+      expect(e.category).toBe('netlify_5xx');
+    }
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('onRetry callback fires N-1 times for N attempts on persistent transient', async () => {
+    const transientResp = makeResponse({ ok: false, status: 502, body: 'gateway' });
+    const fetchImpl = vi.fn().mockResolvedValue(transientResp);
+    const onRetry = vi.fn();
+
+    await expect(callClaudeWithRetry('q', {
+      fetchImpl,
+      maxAttempts: 4,
+      baseDelayMs: 1,
+      jitterMs: 0,
+      onRetry,
+    })).rejects.toBeInstanceOf(ProxyError);
+
+    // 4 attempts → onRetry called between attempts 1→2, 2→3, 3→4 = 3 times.
+    expect(onRetry).toHaveBeenCalledTimes(3);
+    expect(onRetry.mock.calls[0][1]).toBe(1);
+    expect(onRetry.mock.calls[1][1]).toBe(2);
+    expect(onRetry.mock.calls[2][1]).toBe(3);
+  });
+
+  it('non-ProxyError (plain Error) is NOT retried', async () => {
+    const fetchImpl = vi.fn().mockImplementation(() => {
+      throw new Error('plain synchronous failure');
+    });
+
+    await expect(callClaudeWithRetry('q', {
+      fetchImpl,
+      maxAttempts: 5,
+      baseDelayMs: 1,
+      jitterMs: 0,
+    })).rejects.toThrow(/plain synchronous failure/);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes through callClaude options (model, system, etc.)', async () => {
+    const fetchImpl = mockOk();
+    await callClaudeWithRetry('q', {
+      fetchImpl,
+      model: 'opus',
+      system: 'system prompt',
+      max_tokens: 256,
+      maxAttempts: 1,
+      baseDelayMs: 1,
+      jitterMs: 0,
+    });
+    const body = JSON.parse(fetchImpl.mock.calls[0][1].body);
+    expect(body.model).toBe('opus');
+    expect(body.system).toBe('system prompt');
+    expect(body.max_tokens).toBe(256);
+  });
+
+  it('onRetry exception does not break the retry loop', async () => {
+    const transientResp = makeResponse({ ok: false, status: 502, body: 'gateway' });
+    const okResp = makeResponse({ body: { content: [{ type: 'text', text: 'ok' }] } });
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(transientResp)
+      .mockResolvedValueOnce(okResp);
+    const onRetry = vi.fn(() => { throw new Error('onRetry blew up'); });
+
+    const result = await callClaudeWithRetry('q', {
+      fetchImpl, maxAttempts: 2, baseDelayMs: 1, jitterMs: 0, onRetry,
+    });
+    expect(result).toBe('ok');
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ProxyError class', () => {
+  it('is an Error subclass', () => {
+    const e = new ProxyError('m', { transient: true, category: 'network', status: null });
+    expect(e).toBeInstanceOf(Error);
+    expect(e).toBeInstanceOf(ProxyError);
+    expect(e.name).toBe('ProxyError');
+    expect(e.message).toBe('m');
+    expect(e.transient).toBe(true);
+    expect(e.category).toBe('network');
+    expect(e.status).toBeNull();
+    expect(e.cause).toBeNull();
+  });
+
+  it('defaults: transient=false, category=unknown, status=null, cause=null', () => {
+    const e = new ProxyError('m');
+    expect(e.transient).toBe(false);
+    expect(e.category).toBe('unknown');
+    expect(e.status).toBeNull();
+    expect(e.cause).toBeNull();
+  });
+
+  it('preserves cause for downstream debugging', () => {
+    const root = new Error('root cause');
+    const e = new ProxyError('wrap', { transient: true, category: 'network', cause: root });
+    expect(e.cause).toBe(root);
   });
 });


### PR DESCRIPTION
## Goal

Centralize transient-vs-non-transient classification in `scripts/lib/proxy-client.cjs` so the five batch callers can retry intelligently without each script reimplementing the regex/status-code logic.

## Changes

- **`ProxyError`** (exported) — Error subclass with `{ transient, category, status, cause }`.
- **`_classifyError(...)`** — exported as `_` to mark it internal; testable in isolation.
- **`callClaude`** — every throw site now wraps the failure in `ProxyError` with the classification. `AbortError` from the internal `AbortController` is now caught and surfaced as transient `'timeout'` instead of propagating uncaught.
- **`callClaudeWithRetry(prompt, opts)`** — exponential backoff with additive jitter. Defaults: `maxAttempts=3, baseDelayMs=1000, jitterMs=300`. Jitter is additive (`finalDelay = base * 2^(attempt-1) + random[0, jitter)`), never accelerates. Optional `onRetry(err, attempt)` callback for logging.
- **Programmer-error throw** (`direct=true` without `apiKey`) stays as plain `Error` — config bugs must surface as such, not as retryable network failures. Documented inline.

## Classification table

| Input | `transient` | `category` |
|---|---|---|
| **Network err.code**: `ECONNRESET` \| `ETIMEDOUT` \| `ENOTFOUND` \| `EAI_AGAIN` \| `ECONNREFUSED` \| `EPIPE` \| `EHOSTUNREACH` | ✅ | `network` |
| **AbortError** (`err.name === 'AbortError'`) — internal timeout | ✅ | `timeout` |
| **Body** starts with `"Upstream"` (Netlify upstream timeout plain-text) — any status | ✅ | `netlify_upstream_timeout` |
| **Anthropic** `error.type === 'overloaded_error'` (overrides status) | ✅ | `anthropic_overloaded` |
| **Anthropic** `error.type` includes `'rate_limit'` OR `'rate-limit'` (overrides status) | ✅ | `rate_limit` |
| **HTML body** (`<` or `content-type: text/html`) + status ≥ 500 | ✅ | `netlify_5xx` |
| **Status 502 / 503 / 504** | ✅ | `netlify_5xx` |
| **Status 429** | ✅ | `rate_limit` |
| **Status 500 / other 5xx** | ✅ | `server` |
| **Status 401 / 403** | ❌ | `auth` |
| **Status 400** | ❌ | `bad_request` |
| **Other 4xx** | ❌ | `client_error` |
| **2xx with no content array** | ❌ | `malformed_response` |
| Unknown error (no `code`, name ≠ `AbortError`) | ❌ | `unknown` |

### Precedence
**Body-type override applies ONLY for transient signals** (`overloaded_error`, `rate_limit`). For non-transient body types (`invalid_request_error`, etc.), **status wins** — Anthropic's terminal-error body types reliably mirror their status, and only retry-me-later signals need to override status.

### Jitter shape
The pre-existing inline implementation in `generate_distractors.cjs` used symmetric ±300ms jitter. This module uses additive `[0, jitterMs)` so the invariant **"never retry sooner than `base × 2^(attempt-1)`"** holds. A deliberate small behavior change.

## Tests

`tests/proxyClient.test.js`: **12 → 59 (+47 new)**. One assertion per classification row, plus integration tests through `callClaude` for `AbortError` and network-error paths, plus the full retry matrix:
- 2× transient then success → 3 fetch calls, returns value
- Non-transient → 1 call, rethrows immediately
- Persistent transient → maxAttempts hit, rethrows last error
- `onRetry` callback fires N-1 times for N attempts
- Non-ProxyError (plain `Error`) is not retried
- `callClaude` options (model, system, max_tokens) pass through
- `onRetry` exception does not break the retry loop

Full suite: **1596 passed + 7 skipped across 85 files** locally (`npm run verify`).

## What this PR does NOT do

- Does **not** migrate `generate_distractors.cjs` to use the new module — that is the planned follow-up PR, intentionally separated so this one is reviewable as pure infrastructure.
- Does **not** change behavior for the existing 5 cjs/mjs callers (`translate_questions_to_hebrew`, `generate_explanations`, `generate-questions`, `gen_ai_hard_geri`, `source-scanner`). They all just call `callClaude(prompt, opts)` and ignore error structure beyond `.message`. `ProxyError extends Error`, so `instanceof Error` and `.message` continue to work; the new structured fields are additive.

## D.1 precheck

- Branch created off `origin/main` HEAD `eda74b9` in an isolated worktree at `../Geriatrics-proxy-errors`.
- Pre-push intersection (origin/main commits since branch creation × this PR's files): **empty**. Zero intervening commits, zero file overlap. Safe to push.

## D.6 ownership

Scanned open PRs and remote branches for proxy/error/classif/retry keywords pre-work — only #252 open (audit8 r15 winfix, unrelated). No parallel work signal on this surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)