### PR TITLE
refactor(distractors): use callClaudeWithRetry from proxy-client

### DIFF
--- a/scripts/generate_distractors.cjs
+++ b/scripts/generate_distractors.cjs
@@ -30,15 +30,11 @@
  */
 
 const fs    = require('fs');
-const https = require('https');
 const path  = require('path');
+const { callClaudeWithRetry } = require('./lib/proxy-client.cjs');
 
 const QUESTIONS_PATH   = path.resolve(__dirname, '..', 'data', 'questions.json');
 const DISTRACTORS_PATH = path.resolve(__dirname, '..', 'data', 'distractors.json');
-
-const PROXY_HOST   = 'toranot.netlify.app';
-const PROXY_PATH   = '/api/claude';
-const PROXY_SECRET = 'shlav-a-mega-1f97f311d307-2026';
 
 const MODEL_MAP = {
   sonnet: 'claude-sonnet-4-6',
@@ -72,87 +68,15 @@ function buildUserPrompt(q) {
   return lines.join('\n');
 }
 
-function callProxyOnce(model, userPrompt) {
-  return new Promise((resolve, reject) => {
-    const body = JSON.stringify({
-      model,
-      max_tokens: MAX_TOKENS,
-      system: SYSTEM_PROMPT,
-      messages: [{ role: 'user', content: userPrompt }]
-    });
-    const options = {
-      hostname: PROXY_HOST,
-      path: PROXY_PATH,
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-api-secret': PROXY_SECRET,
-        'Content-Length': Buffer.byteLength(body)
-      }
-    };
-    const req = https.request(options, res => {
-      let data = '';
-      res.on('data', c => data += c);
-      res.on('end', () => {
-        const trimmed = (data || '').trim();
-        // Upstream timeouts come back as plain-text "Upstream timeout" from Netlify
-        if (trimmed.startsWith('Upstream')) {
-          const e = new Error('proxy_timeout'); e.transient = true; return reject(e);
-        }
-        // Netlify / Cloudflare 5xx pages come back as HTML, not JSON.
-        // Detect by leading '<' (covers both '<!DOCTYPE' and bare '<html>').
-        if (trimmed.startsWith('<') || (res.statusCode >= 500 && res.statusCode < 600)) {
-          const e = new Error(`upstream_${res.statusCode||'html'}`); e.transient = true; return reject(e);
-        }
-        try {
-          const p = JSON.parse(data);
-          if (p.content && p.content[0] && p.content[0].text) {
-            resolve(p.content[0].text.trim());
-          } else if (p.error) {
-            const t = (p.error.type || '').toLowerCase();
-            const e = new Error(`API error: ${p.error.type||'?'} — ${p.error.message||data.slice(0,200)}`);
-            // Anthropic transient classes — retry-able
-            if (t.includes('overloaded') || t.includes('rate_limit') || t.includes('rate-limit')) e.transient = true;
-            reject(e);
-          } else {
-            reject(new Error(`Unexpected: ${data.slice(0,300)}`));
-          }
-        } catch (e) {
-          reject(new Error(`JSON parse: ${e.message}. Raw: ${data.slice(0,200)}`));
-        }
-      });
-    });
-    req.on('error', e => {
-      // Network-layer errors: DNS cache overflow (ENOTFOUND/EAI_AGAIN), conn drops, timeouts
-      if (e && typeof e.code === 'string' &&
-          ['ENOTFOUND','ECONNRESET','ETIMEDOUT','EAI_AGAIN','ECONNREFUSED','EPIPE','EHOSTUNREACH'].includes(e.code)) {
-        e.transient = true;
-      }
-      reject(e);
-    });
-    req.setTimeout(120000, () => {
-      const e = new Error('Timeout 120s'); e.transient = true; req.destroy(e);
-    });
-    req.write(body);
-    req.end();
-  });
-}
-
-async function callProxy(model, userPrompt, attempts = 5) {
-  let lastErr;
-  for (let i = 0; i < attempts; i++) {
-    try { return await callProxyOnce(model, userPrompt); }
-    catch (e) {
-      lastErr = e;
-      const retriable = e && (e.transient || e.message === 'proxy_timeout');
-      if (!retriable) throw e;
-      // Exponential backoff with jitter: 600ms, 1.2s, 2.4s, 4.8s, 9.6s ± up to 300ms
-      const base = 600 * Math.pow(2, i);
-      const jitter = Math.floor(Math.random() * 300);
-      await new Promise(r => setTimeout(r, base + jitter));
-    }
-  }
-  throw lastErr || new Error('proxy_timeout');
+// onRetry hook for callClaudeWithRetry — logs to stderr so the stdout progress
+// bar stays clean. Uses err.category from ProxyError (proxy-client.cjs) instead
+// of the prior inline regex/status logic.
+function logRetry(err, attempt, maxAttempts) {
+  const cat = (err && err.category) || 'unknown';
+  const flag = err && err.transient ? 'transient' : 'terminal';
+  process.stderr.write(
+    `[distractors] attempt ${attempt}/${maxAttempts} failed: ${cat} (${flag}) — ${err.message}\n`
+  );
 }
 
 function parseResponse(rawText, q) {
@@ -292,8 +216,18 @@ async function main() {
 
     const results = await Promise.allSettled(
       batch.map(({q, idx}) =>
-        callProxy(model, buildUserPrompt(q))
-          .then(txt => ({ idx, q, txt }))
+        callClaudeWithRetry(buildUserPrompt(q), {
+          model,
+          system: SYSTEM_PROMPT,
+          max_tokens: MAX_TOKENS,
+          // Preserve the prior socket-level 120s budget (callClaude default is 60s).
+          timeout_ms: 120_000,
+          maxAttempts: 5,
+          baseDelayMs: 600,
+          jitterMs: 300,
+          onRetry: (err, attempt) => logRetry(err, attempt, 5),
+        })
+          .then(txt => ({ idx, q, txt: (txt || '').trim() }))
       )
     );
 


### PR DESCRIPTION
Follow-up to #267. Replaces the inline transient-error classification + retry loop in `scripts/generate_distractors.cjs` with the shared `callClaudeWithRetry` from `scripts/lib/proxy-client.cjs`.

## Net diff
**-66 lines** (22+/88-). Single file: `scripts/generate_distractors.cjs`.

## Deleted
- `callProxyOnce()` — 65-line wrapper around `https.request` doing body sniffing, Anthropic `error.type` substring matching, network `err.code` allowlist, and socket-level timeout.
- `callProxy()` — 16-line retry loop with manual exponential backoff + symmetric ±300 ms jitter.
- `PROXY_HOST` / `PROXY_PATH` / `PROXY_SECRET` constants (now owned by proxy-client.cjs).
- `const https = require('https')` (replaced by `fetch` via proxy-client).

## Added
~10 lines: a `logRetry()` helper wired through `callClaudeWithRetry`'s `onRetry` callback, logging `ProxyError.category` to stderr so the stdout progress bar stays clean.

## Preserved invariants
- 5 retry attempts (`maxAttempts: 5`)
- 600 ms exponential base (`baseDelayMs: 600`)
- **120 s per-call timeout** (passed explicitly as `timeout_ms: 120_000` — `callClaude` defaults to 60 s, so without this the per-call budget would silently halve)
- Same payload shape (`model`, `system=SYSTEM_PROMPT`, `max_tokens=1200`, `messages`)

## Behavior changes
1. **Jitter shape**: ±300 ms symmetric → additive [0, 300 ms). Mean retry delay shifts ~150 ms later; variance halves. Invariant *"never retry sooner than `base × 2^(attempt-1)`"* preserved. No expected operational impact.
2. **Retry visibility**: previously silent on transient retries; now emits `[distractors] attempt N/5 failed: <category> (transient) — <msg>` on **stderr**. Stdout (progress bar) unchanged — downstream pipes that capture stdout only see identical output.
3. **Error category strings change**: old strings (`proxy_timeout`, `upstream_<status>`, `API error: <type>`, raw `e.code`) replaced with canonical `ProxyError.category` values (`netlify_upstream_timeout`, `netlify_5xx`, `server`, `rate_limit`, `anthropic_overloaded`, `network`, `timeout`, …). **Grep confirmed no downstream consumer matches on the old strings** — the `failures` array surfaces `err.message` only for end-of-run diagnostic printing.

## Step-1 halt-and-report audit (per task spec)
Audited every inline classification case against `_classifyError` shipped in #267:

| Inline case | Covered by `_classifyError`? |
|---|---|
| ECONNRESET / ETIMEDOUT / ENOTFOUND / EAI_AGAIN / ECONNREFUSED / EPIPE / EHOSTUNREACH | ✅ all seven in `TRANSIENT_NETWORK_CODES` |
| body starts with `"Upstream"` | ✅ `netlify_upstream_timeout` |
| body starts with `"<"` or status 5xx | ✅ `netlify_5xx` / `server` |
| Anthropic `error.type` `'overloaded'` / `'rate_limit'` / `'rate-limit'` substring | ✅ same matching semantics preserved |
| Socket-level 120 s timeout | ✅ AbortController + explicit `timeout_ms: 120_000` |

No cases dropped. No downstream `err.message` string-matching exists (verified with `grep`).

## Tests
Suite identical to #267 baseline: **1596 passed + 7 skipped across 85 files**.

`tests/distractorsDrift.test.js` validates `data/distractors.json` contents, not the script's error path — no mocks to update.

Dry-run smoke (`node scripts/generate_distractors.cjs --dry-run --limit 3`) loads 3823 questions, selects 3 candidates, exits cleanly without API calls.

## D.1 precheck
Branch created off `origin/main` HEAD `16d1540` (the #267 merge commit). Pre-push intersection (origin/main commits since branch creation × this PR's files): **empty**. Zero intervening commits, zero file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)