### PR TITLE
docs(chore): refresh CLAUDE.md stale metrics + log 2026-05-23 RLS sanity pass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,8 +34,8 @@ These four rules are the floor. They override any conflicting guidance later in 
 **Shlav A Mega** is a Progressive Web App (PWA) for Israeli geriatrics board exam preparation (שלב א גריאטריה, P005-2026). It is a single-file, no-build-step application deployed via GitHub Pages.
 
 - **Live URL**: https://eiasash.github.io/Geriatrics/
-- **Main file**: `shlav-a-mega.html` (~636 KB, ~7,634 lines, 224 named functions)
-- **App version**: v10.64.108 (as of 11/05/26) — 3,743 Qs across 46 topics. All 3,743 Qs carry `ref` (Hazzard / Harrison chapter + title) and pre-generated `e` explanation. Recent: v10.64.102-108 multi-accept reframe campaign — 143 questions with `c_accept` array (multi-correct semantic) reframed via Sonnet REFRAME/KEEP → Opus cold-validate revert 39 → Opus rescue 23/39 → lane-sync +1; v10.64.101 verify chain hardened (node --check on inline scripts, cp1252-safe); v10.64.93 split `e` field into `data/explanations.json` (-43% questions.json — mobile load 79s→24s); v10.64.87-92 a11y + mobile UI polish (skip-link mobile fix, header dark-on-dark, topic groups collapsed by default); v10.64.86 a11y issue #125 final close (4 amber-600 → amber-800 button fixes, white-on-amber 3.19:1 → 7.39:1 AAA) + 6 new integrity ratchet tests (`tests/integrityRatchet.test.js`); v10.64.82–85 a11y dir=rtl + skip-link + theme-aware dm-btn + slate hierarchy + 4 residual contrast clears; v10.64.81 cancer cluster wrong_textbook drain CLOSED (record-not-queue going forward); v10.64.61 search matches across Hebrew + English variants; v10.64.60 bilingual schema + Hebrew↔English toggle for AI-translated Qs (paired Heb/Eng `o[]` arrays — `c` index valid for both); v10.64.59 1,255 AI Qs translated to Hebrew (Sonnet 4.6 batch 2); v10.64.58 pre-emptive defensive guards (FM v1.21.13 chaos-pattern parity); v10.64.57 faceted pill counts (cross-axis filter narrowing); v10.64.56 year + topic INTERSECT (was mutually exclusive); v10.64.55 topic groups (12 clinical categories) + year presets; v10.64.54 622 AI Qs translated to Hebrew (Sonnet 4.6); v10.64.51 multi-select topic filter + dynamic year picker (was hiding 1,284 Qs); v10.64.48–50 cloud-sync API key with user account (cloudBackup _apikey + auth_login_user.api_key restore); v10.64.47 loading-skeleton stale count fix + STALE_COUNTS guard; v10.64.46 Track-I distractor regen — 75 drifted Qs regenerated; v10.64.45 Track-R 1547 Hazzard refs realigned; v10.64.42–44 Track-Q backup_set SECURITY DEFINER RPC + PDF externalization to GitHub Releases (-85% repo size); v10.64.30s–40 Tracks D/H/I/J/K/L/M/N/O/P — distractor regen + detector v3 + 110 curator overrides triangulated.
+- **Main file**: `shlav-a-mega.html` (~704 KB, ~8,354 lines, 227 named functions)
+- **App version**: v10.64.130 (as of 23/05/26) — 3,823 Qs across 46 topics. All 3,823 Qs carry `ref` (Hazzard / Harrison chapter + title) and pre-generated `e` explanation. Recent: v10.64.109–130 — rescued-MCQ pipeline campaign (PRs #254/#255/#256/#258: 82 normalized rescue MCQs via `merge-questions.cjs` + v10.64.93 explanations split; bilingual translation for 80 of them via `claude/fix-translate-bilingual-schema`); regen_derived gate landed (PRs #259/#262/#263: `scripts/regen_derived.cjs --check` closes the denominator-invalidates-all-ratios bug class for `regulatory.json` / `question_chapters.json` / `syllabus_data.json`); audit-6/7/8 instrument campaign (judge-letter frame correction, pick-channel precision, stemHash identity prestep). Pre-v10.64.108 narrative: v10.64.102-108 multi-accept reframe campaign — 143 questions with `c_accept` array (multi-correct semantic) reframed via Sonnet REFRAME/KEEP → Opus cold-validate revert 39 → Opus rescue 23/39 → lane-sync +1; v10.64.101 verify chain hardened (node --check on inline scripts, cp1252-safe); v10.64.93 split `e` field into `data/explanations.json` (-43% questions.json — mobile load 79s→24s); v10.64.87-92 a11y + mobile UI polish (skip-link mobile fix, header dark-on-dark, topic groups collapsed by default); v10.64.86 a11y issue #125 final close (4 amber-600 → amber-800 button fixes, white-on-amber 3.19:1 → 7.39:1 AAA) + 6 new integrity ratchet tests (`tests/integrityRatchet.test.js`); v10.64.82–85 a11y dir=rtl + skip-link + theme-aware dm-btn + slate hierarchy + 4 residual contrast clears; v10.64.81 cancer cluster wrong_textbook drain CLOSED (record-not-queue going forward); v10.64.61 search matches across Hebrew + English variants; v10.64.60 bilingual schema + Hebrew↔English toggle for AI-translated Qs (paired Heb/Eng `o[]` arrays — `c` index valid for both); v10.64.59 1,255 AI Qs translated to Hebrew (Sonnet 4.6 batch 2); v10.64.58 pre-emptive defensive guards (FM v1.21.13 chaos-pattern parity); v10.64.57 faceted pill counts (cross-axis filter narrowing); v10.64.56 year + topic INTERSECT (was mutually exclusive); v10.64.55 topic groups (12 clinical categories) + year presets; v10.64.54 622 AI Qs translated to Hebrew (Sonnet 4.6); v10.64.51 multi-select topic filter + dynamic year picker (was hiding 1,284 Qs); v10.64.48–50 cloud-sync API key with user account (cloudBackup _apikey + auth_login_user.api_key restore); v10.64.47 loading-skeleton stale count fix + STALE_COUNTS guard; v10.64.46 Track-I distractor regen — 75 drifted Qs regenerated; v10.64.45 Track-R 1547 Hazzard refs realigned; v10.64.42–44 Track-Q backup_set SECURITY DEFINER RPC + PDF externalization to GitHub Releases (-85% repo size); v10.64.30s–40 Tracks D/H/I/J/K/L/M/N/O/P — distractor regen + detector v3 + 110 curator overrides triangulated.
 - **Data**: JSON files in `data/` directory, loaded lazily at runtime
 - **Deployment**: Push to `main` → GitHub Actions validates → GitHub Pages live in ~60s
 
@@ -130,7 +130,7 @@ Any change to `o[]`, `c`, or `e` MUST quote the source PDF (Hazzard 8e / Harriso
 
 ### Single-File PWA
 
-All application logic lives in `shlav-a-mega.html` (~7,634 lines, 224 named functions) — no bundler, no framework, no build step. The file contains:
+All application logic lives in `shlav-a-mega.html` (~8,354 lines, 227 named functions) — no bundler, no framework, no build step. The file contains:
 - All CSS (1,000+ lines, responsive, RTL-aware, dark/light/study modes)
 - All JavaScript (ES6+, vanilla)
 - HTML structure
@@ -181,13 +181,13 @@ the full decomposition ledger and safe-next-steps list.
 
 ```
 /
-├── shlav-a-mega.html        # Main app (THE file — all HTML/CSS/JS, v10.64.108)
+├── shlav-a-mega.html        # Main app (THE file — all HTML/CSS/JS, v10.64.130)
 ├── index.html               # GitHub Pages redirect → shlav-a-mega.html
 ├── sw.js                    # Service worker (offline caching + background sync)
 ├── manifest.json            # PWA manifest
 │
 ├── data/                    # Lazy-loaded JSON data — single source of truth
-│   ├── questions.json       # 3,743 MCQs (primary runtime source, all carry `ref` + `e`)
+│   ├── questions.json       # 3,823 MCQs (primary runtime source, all carry `ref` + `e`)
 │   ├── notes.json           # 46 study topic notes
 │   ├── drugs.json           # 113 Beers/ACB drugs database
 │   ├── flashcards.json      # 159 high-yield flashcards
@@ -230,7 +230,7 @@ the full decomposition ledger and safe-next-steps list.
 ├── .github/
 │   └── workflows/ci.yml     # Validation CI — JSON schema, duplicates, version sync, etc.
 │
-├── tests/                          # 61 vitest files, 1,270 tests + 7 skipped (see Testing section)
+├── tests/                          # 85 vitest files, 1,596 tests + 7 skipped (see Testing section)
 │
 ├── supabase-setup.sql        # Supabase RLS schema
 ├── .mcp.json                 # MCP server config (Supabase)
@@ -258,14 +258,14 @@ All runtime data lives in `data/`. The app and service worker load exclusively f
   "t": "2022",  // exam year string
   "ti": 18,     // primary topic index (0–45, see TOPICS below)
   "tis": [18, 19],  // multi-tag topic indices (v10.41+)
-  "e": "...",   // pre-generated AI explanation (populated on all 3,743 Qs)
+  "e": "...",   // pre-generated AI explanation (populated on all 3,823 Qs)
   "ref": "..."  // Hazzard / Harrison chapter + title citation
 }
 ```
 
 #### Bilingual schema (v10.64.59-61)
 
-1,867 of 3,743 Qs (as of v10.64.108) are AI-generated from English
+1,867 of 3,823 Qs (as of v10.64.130) are AI-generated from English
 textbooks (Hazzard 1852, Harrison 294, GRS8 90 baseline; the count grew
 as more translations shipped). They carry paired Hebrew↔English variants:
 
@@ -374,7 +374,7 @@ No build step needed. Edit and refresh.
 
 ### Service Worker Versioning
 - `APP_VERSION` in `shlav-a-mega.html` must match the cache version in `sw.js` and `package.json` `version`
-- Currently all three at `10.64.108` (sw.js cache key: `shlav-a-v10.64.108`)
+- Currently all three at `10.64.130` (sw.js cache key: `shlav-a-v10.64.130`)
 - Update all three when making changes to ensure users get cache-busted (see workspace CLAUDE.md "version-trinity invariant")
 - The trinity guard lives in two places: strict pairwise alignment in `tests/appIntegrity.test.js`, and a version-agnostic re-derivation from `package.json` in `tests/visualOverhaul2026.test.js` (refactored v10.60 — used to hard-code the literal version string and went stale every release)
 
@@ -386,11 +386,11 @@ No build step needed. Edit and refresh.
 
 ### Testing
 ```bash
-npm test             # Run all tests (vitest, 1,270 tests across 61 files + 7 skipped)
+npm test             # Run all tests (vitest, 1,596 tests across 85 files + 7 skipped)
 npm run verify       # Pre-push gate (see below) — runs 7 checks in series
 ```
 
-**1,270 tests across 61 files (~21 tests per file avg)** — run `npm test` to see current count.
+**1,596 tests across 85 files (~19 tests per file avg)** — run `npm test` to see current count.
 
 #### Pre-push gate: `npm run verify`
 
@@ -402,7 +402,7 @@ Runs 7 checks in series. Failure of any blocks the deploy:
 4. `python3 scripts/check-innerhtml.py` — unsanitized innerHTML audit
 5. `python3 scripts/check-innerhtml-pieces.py` — fragment-level innerHTML audit (catches concatenation patterns)
 6. `cross-env HARRISON_HEBREW_BASELINE=0 node scripts/harrison-hebrew-baseline.cjs --strict` — Harrison Hebrew baseline ratchet (chapter-coverage regression guard)
-7. `vitest run` — full test suite (1,270 tests, ~19s)
+7. `vitest run` — full test suite (1,596 tests, ~3s on a warm cache)
 
 Run before every push. Step 7 dominates runtime. **Always run `npm run verify`,
 not just `npm test`** — the 6 non-vitest checks catch deploy-time bugs that the
@@ -415,7 +415,7 @@ test suite alone misses.
 - Modified data processing → edge case + boundary tests
 - After adding tests, update the test count in this section
 
-**Test file inventory (61 files, 1,270 tests + 7 skipped — 2026-05-10 added `integrityRatchet.test.js` +6 tests + a11y v10.64.86 sub-suite +4 tests):**
+**Test file inventory (85 files, 1,596 tests + 7 skipped — current as of v10.64.130; prior tally at v10.64.86 was 61 files / 1,270 tests):**
 
 | File | Tests | Description |
 |------|-------|-------------|
@@ -773,20 +773,20 @@ GitHub Actions runs CI → on pass, GitHub Pages updates within ~60 seconds.
 | Metric | Value |
 |---|---|
 | Main file | `shlav-a-mega.html` (~7,631 lines, ~580 KB) |
-| Named functions | 224 (228 incl. shared/*.js, the integrity-guard counting basis) |
-| Questions | 3,743 (IMA past exams + Hazzard/Harrison AI-generated + GRS8 imports; all carry `ref` + `e`) |
+| Named functions | 227 (231 incl. shared/*.js, the integrity-guard counting basis) |
+| Questions | 3,823 (IMA past exams + Hazzard/Harrison AI-generated + GRS8 imports; all carry `ref` + `e`) |
 | Topics | 46 |
 | Drugs | 113 |
 | Flashcards | 159 |
 | Study notes | 46 |
 | Hazzard chapters | 108 (in-app reader) |
 | Harrison chapters | 69 (in-app reader) |
-| Test suite | 1,270 tests across 61 files + 7 skipped (vitest) |
+| Test suite | 1,596 tests across 85 files + 7 skipped (vitest) |
 | Sibling repos | Mishpacha Mega (family med) + Pnimit Mega (internal med) — see workspace CLAUDE.md for shared invariants |
 | CI workflows | 7 (ci.yml, claude.yml, claude-code-review.yml, distractor-autopsy.yml, distractor-merge-pr.yml, integrity-guard.yml, weekly-audit.yml) |
 | Inline handlers | onclick=214, onchange=25, oninput=6 |
-| App version | v10.64.86 |
-| SW cache key | `shlav-a-v10.64.86` |
+| App version | v10.64.130 |
+| SW cache key | `shlav-a-v10.64.130` |
 
 
 ## Test Coverage Recommendations
@@ -809,7 +809,7 @@ GitHub Actions runs CI → on pass, GitHub Pages updates within ~60 seconds.
 ### Recommended Additions (Priority Order)
 
 1. **OSCE station validation** — Currently no OSCE data file; if reintroduced, validate scenario completeness, task arrays, tip arrays, and cross-reference with topic index
-2. **Explanation quality checks** — Test that all 3,743 `e` fields are non-empty, >= 50 chars, contain no HTML injection, and are valid Hebrew/English text
+2. **Explanation quality checks** — Test that all 3,823 `e` fields are non-empty, >= 50 chars, contain no HTML injection, and are valid Hebrew/English text
 3. **Hazzard chapter JSON** — Validate `hazzard_chapters.json` structure, chapter numbering, and cross-reference with notes.json `ch` field
 4. **Exam year tag consistency** — Validate that each `t` field matches known exam sessions, test distribution balance across years
 5. **Topic distribution balance** — Add quantitative tests: no single topic should have >15% or <1% of total questions

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -638,3 +638,124 @@ proposal) is docs-only and gates on Eias decision, not on automated checks.
 - Archive moves: R7/R13/R19/R20 → `~/archive/geriatrics-reference-content/`
   (with README documenting REFERENCE-ONLY classification)
 - Other repos touched this session: none (lane discipline — Geriatrics only)
+
+---
+
+## 2026-05-23 (continued) — RLS sanity pass + CLAUDE.md refresh
+
+Same-day continuation. Two cross-cutting cleanups: refresh stale codebase
+metrics in `CLAUDE.md` and run the deploy-primitives § 3 RLS sanity pass
+against the shared Supabase project.
+
+### CLAUDE.md refresh
+
+14 stale-number sites updated to current-state (v10.64.130 / 3,823 Qs / 85
+files / 1,596 tests + 7 skipped / 227 functions / 704 KB / 8,354 lines).
+Historical CHANGELOG narrative preserved (only the lead version + Q count
+in the Project Overview was refreshed; pre-v10.64.108 historical chain
+left intact). The line 649 stale-count "skeleton hardcodes '3,743' per the
+v10.64.41 fallback" note left alone — grep showed neither '3,743' nor
+'3,823' literally in `shlav-a-mega.html`, so that doc is describing
+deprecated code behavior and needs its own separate audit (out of scope
+for a numbers-refresh PR).
+
+### RLS sanity pass (deploy-primitives § 3) — CLEAN
+
+Run against project `krmlzwwelqvlfslwltol` (shared between Toranot /
+Geriatrics / InternalMedicine / FamilyMedicine / ward-helper) via
+Supabase MCP.
+
+**Q1 — every user-schema table has RLS on:** OK. All 20 public-schema
+user-data tables have `rowsecurity = true`. The 3 `rowsecurity = false`
+entries (`supabase_migrations.schema_migrations`, `topology.layer`,
+`topology.topology`) are system/extension-owned, not user-data holes.
+
+**Q2 — RLS-on tables with at least one policy:** 5 tables have RLS-on
+with 0 policies (deny-all). Verified all 5 are documented or
+RPC-protected server-only:
+
+| Table | Access pattern | Status |
+|---|---|---|
+| `app_config` | service_role only (deploy-primitives § 3 documented) | OK |
+| `toranot_config` | service_role only (deploy-primitives § 3 documented) | OK |
+| `app_users` | 7 SECURITY DEFINER RPCs (`auth_login_user`, `auth_register_user`, `auth_change_password`, `auth_set_api_key`, `auth_set_email`, `sync_api_key_from_backup`, `study_plan_upsert`) | OK |
+| `password_reset_tokens` | 2 SECURITY DEFINER RPCs (`auth_issue_reset_token`, `auth_reset_password_with_token`) | OK |
+| `study_plans` | 3 SECURITY DEFINER RPCs (`study_plan_get`, `study_plan_upsert`, `backup_get`) | OK |
+
+**Q3 — policy dump:** 46 policies across 18 RLS-on-with-policies tables.
+All inspected. Three pattern categories, all match documented intent:
+
+1. **auth.uid()-scoped (real RLS enforcement)** — `shared_shifts`,
+   `toranot_labs`, `toranot_patients_backup`, `toranot_state`,
+   `ward_helper_backup`. All user-owned data with explicit ownership checks.
+2. **anon-write + trigger defense (soft-token model per deploy-primitives § 3)**
+   — `*_leaderboard`, `*_feedback`, `*_backups`, `proxy_rate_limits`.
+   No `auth.uid()` ownership; defense is at the BEFORE-UPDATE trigger layer.
+3. **deny-all (intentional security)** — `synthetic_patients` (single policy
+   `ALL roles=public qual=false`).
+
+No red flags: no `qual = true` on authd policies, no missing `with_check`
+on writable policies (the implicit `qual→with_check` defaults are
+behaviorally equivalent to explicit `with_check=true`).
+
+**Q4 — cross-app touch map:** 23 public-schema tables. No generic-named
+tables (`users`, `sessions`, `logs`) that would carry cross-app collision
+risk. Each app has its own prefixed table family (`shlav_*`, `pnimit_*`,
+`mishpacha_*`, `samega_*`, `toranot_*`, `ward_helper_*`) plus 6 shared
+(`answer_reports`, `app_config`, `app_users`, `password_reset_tokens`,
+`proxy_rate_limits`, `synthetic_patients`).
+
+### Trigger inventory (defense-in-depth confirmation)
+
+Verified the documented BEFORE-UPDATE triggers are live on all expected
+tables:
+
+| Trigger | Tables |
+|---|---|
+| `backups_monotonic_update_trg` | `mishpacha_backups`, `pnimit_backups`, `samega_backups` |
+| `trg_sync_api_key_*` (AFTER INSERT+UPDATE) | `mishpacha_backups`, `pnimit_backups`, `samega_backups` |
+| `leaderboard_monotonic_stats_trg` | `mishpacha_leaderboard`, `pnimit_leaderboard`, **`shlav_leaderboard`** |
+| `proxy_rate_limits_monotonic_count_trg` | `proxy_rate_limits` |
+| `trg_proxy_rate_limit_monotonic` | `proxy_rate_limits` (duplicate — see below) |
+| `feedback_notify_webhook_trg` | `mishpacha_feedback`, `pnimit_feedback`, `shlav_feedback` |
+
+### Two doc/cleanup items found (not security holes)
+
+1. **`deploy-primitives § 3` is stale on `shlav_leaderboard`** — it says
+   "Not yet on `shlav_leaderboard` — pending Geri lane coordination". The
+   trigger IS deployed now (visible in the inventory above). The
+   primitives doc should be refreshed in a Toranot-repo PR (lane
+   discipline — this audit is in the Geriatrics repo; primitives lives
+   under `~/.claude/skills/` which is workspace-cross-cutting).
+
+2. **`proxy_rate_limits` has TWO monotonic-count triggers** —
+   `proxy_rate_limits_monotonic_count_trg` and
+   `trg_proxy_rate_limit_monotonic`. Likely a re-deploy duplicate. Not a
+   security risk (both enforce the same invariant in the same direction)
+   but redundant. Investigation + cleanup is a Toranot-lane task (the
+   proxy is Toranot-owned), not Geriatrics.
+
+### Items NOT cross-checked this pass
+
+- Drift between repo `supabase/migrations/` migration files and live DB
+  state — not part of the § 3 sanity pass; would need separate
+  `migrations.test.js`-style ratchet.
+- `auto-audit` probe RLS verification — that lives in a different repo
+  and runs on its own cron.
+
+### IMPROVEMENTS.md PR
+
+Both deltas (CLAUDE.md refresh + this entry) land in a single docs-only PR
+to avoid scope creep across files:
+- Branch: `claude/refresh-docs-2026-05-23`
+- Target: `origin/main` HEAD `b067b36`
+- Files modified: `CLAUDE.md` (14 stale-number sites refreshed),
+  `IMPROVEMENTS.md` (this entry).
+
+### Next-pass items
+
+- Toranot-lane PR: refresh `deploy-primitives § 3` shlav_leaderboard
+  trigger status; investigate proxy_rate_limits trigger duplicate.
+- Out-of-scope this pass but worth tracking: the line 649 stale-count
+  trap doc (HTML literal no longer matches the doc's claim — separate
+  audit).


### PR DESCRIPTION
## Summary

Two cross-cutting docs cleanups in one PR (both docs-only, no code, no data):

### 1. `CLAUDE.md` refresh (14 stale-number sites)

- App version: v10.64.108 → **v10.64.130**
- Q count: 3,743 → **3,823**
- Test suite: 1,270 / 61 files → **1,596 / 85 files** (+7 skipped)
- Functions: 224 → **227** (231 incl. shared/*.js)
- File metrics: 636 KB / 7,634 lines → **704 KB / 8,354 lines**
- SW cache key: `shlav-a-v10.64.86` → **`shlav-a-v10.64.130`**

Historical CHANGELOG narrative preserved — only the Project Overview lead
sentence refreshed. Pre-v10.64.108 historical chain left intact as
breadcrumbs.

**Out of scope:** the line 649 "skeleton hardcodes '3,743' per the v10.64.41
fallback" note. Grep showed neither '3,743' nor '3,823' as a string literal
in `shlav-a-mega.html`, so that note describes deprecated code behavior and
needs its own separate audit.

### 2. `IMPROVEMENTS.md` append — 2026-05-23 RLS sanity pass

Per `deploy-primitives § 3` mandate to record the pass in IMPROVEMENTS.md
even when clean (audit trail for week-over-week regression detection).

**Verdict: CLEAN.** No RLS holes on shared project `krmlzwwelqvlfslwltol`.

- Q1: 20 user-data tables all have RLS on. 3 RLS-off are
  extension/system-owned (topology, supabase_migrations).
- Q2: 5 RLS-on / 0-policy tables (`app_config`, `toranot_config`,
  `app_users`, `password_reset_tokens`, `study_plans`) all verified
  server-only via SECURITY DEFINER RPCs.
- Q3: 46 policies, 3 documented patterns (auth.uid()-scoped /
  anon-write+trigger-defense / deny-all). No red flags.
- Q4: 23 public tables, no generic-named cross-app risk.

Defense-in-depth triggers confirmed live on `*_backups`,
`*_leaderboard` (incl. shlav), `proxy_rate_limits`, `*_feedback`.

**Two doc/cleanup items found (NOT security holes, Toranot-lane work):**

1. `deploy-primitives § 3` is stale on `shlav_leaderboard` — it says
   "Not yet on `shlav_leaderboard` — pending Geri lane coordination",
   but the `leaderboard_monotonic_stats_trg` IS deployed now.
2. `proxy_rate_limits` has TWO monotonic-count triggers
   (`proxy_rate_limits_monotonic_count_trg` and
   `trg_proxy_rate_limit_monotonic`) — likely re-deploy duplicate.

Both items belong to the Toranot lane (proxy/primitives ownership), not
Geriatrics. Tracked in IMPROVEMENTS.md "Next-pass items" for follow-up.

## Test plan

- [ ] CI green (docs-only change should not affect any check)
- [ ] Eias reviews the audit trail entry and decides whether to act on
  the two Toranot-lane cleanup items now or later