### PR TITLE
fix(data): officialize broken-quarantine on idx 2096 + 3618 (c-flip-pending closure)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -386,11 +386,11 @@ No build step needed. Edit and refresh.
 
 ### Testing
 ```bash
-npm test             # Run all tests (vitest, 1,596 tests across 85 files + 7 skipped)
+npm test             # Run all tests (vitest, 1,602 tests across 86 files + 7 skipped)
 npm run verify       # Pre-push gate (see below) — runs 7 checks in series
 ```
 
-**1,596 tests across 85 files (~19 tests per file avg)** — run `npm test` to see current count.
+**1,602 tests across 86 files (~19 tests per file avg)** — run `npm test` to see current count.
 
 #### Pre-push gate: `npm run verify`
 
@@ -474,6 +474,7 @@ test suite alone misses.
 | `tests/pastExamCoverage.test.js` | 14 | v10.63.1 past-exam coverage — every IMA session 2021-Dec→2025-Jun present in dataset |
 | `tests/remapExplanationLetters.test.js` | 10 | v10.64.22 — `remapExplanationLetters` fix for bare label refs ("א' שגויה") (#144) |
 | `tests/honestStats.test.js` | 17 | honestStats CI guard (sibling-synced with Pnimit + FM) — accuracy denominator must include skips correctly |
+| `tests/brokenQuarantinedRatchet.test.js` | 6 | 2026-05-24 broken-quarantined ratchet — pins idx 2096 + 3618 as explicit `status: "broken-quarantined"` (chaos-doctor c-flip suggestions where existing q.e_en defends current c and no verbatim Hazzard PDF quote per v9.81 obtained). Prevents silent un-quarantine via automated "fix wrong answers" passes |
 
 **Test coverage by area:**
 
@@ -781,7 +782,7 @@ GitHub Actions runs CI → on pass, GitHub Pages updates within ~60 seconds.
 | Study notes | 46 |
 | Hazzard chapters | 108 (in-app reader) |
 | Harrison chapters | 69 (in-app reader) |
-| Test suite | 1,596 tests across 85 files + 7 skipped (vitest) |
+| Test suite | 1,602 tests across 86 files + 7 skipped (vitest) |
 | Sibling repos | Mishpacha Mega (family med) + Pnimit Mega (internal med) — see workspace CLAUDE.md for shared invariants |
 | CI workflows | 7 (ci.yml, claude.yml, claude-code-review.yml, distractor-autopsy.yml, distractor-merge-pr.yml, integrity-guard.yml, weekly-audit.yml) |
 | Inline handlers | onclick=214, onchange=25, oninput=6 |

--- a/tests/brokenQuarantinedRatchet.test.js
+++ b/tests/brokenQuarantinedRatchet.test.js
@@ -1,0 +1,68 @@
+// brokenQuarantinedRatchet — pins the explicit quarantine state of Qs that
+// the chaos-doctor + Opus cold-validate suggested a c-flip on, but where
+// the existing q.e_en defends the current c and no verbatim Hazzard PDF
+// quote (per v9.81 rule) has been obtained to resolve the disagreement.
+//
+// 2026-05-24 entries (PR for P2 of the audit-8 R1.5 carryover batch):
+//   - idx 2096: Cardiology, Hazzard Ch 74 / Harrison Ch 286, conf 85
+//   - idx 3618: Urology,    Hazzard Ch 38 / GRS8 Ch 49-53,   conf 70
+//
+// Reopen path: obtain verbatim PDF quote, flip c (or confirm c stays),
+// remove status field + delete this ratchet entry, set broken=false.
+//
+// This test exists so an automated "fix wrong answers" pass cannot silently
+// re-enter the chaos-doctor's flip suggestion as a c-edit — see the
+// `Curator-override re-flip` Known Trap in CLAUDE.md for the analogous
+// pattern that produced the curator-overrides ratchet.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const Q_PATH = resolve(process.cwd(), 'data', 'questions.json');
+const questions = JSON.parse(readFileSync(Q_PATH, 'utf-8'));
+
+describe('broken-quarantined ratchet', () => {
+  const quarantined = questions
+    .map((q, idx) => ({ idx, q }))
+    .filter(({ q }) => q.status === 'broken-quarantined');
+
+  it('has exactly 2 quarantined Qs (as of 2026-05-24)', () => {
+    expect(quarantined.length).toBe(2);
+  });
+
+  it('every status=broken-quarantined Q is also broken=true', () => {
+    for (const { idx, q } of quarantined) {
+      expect(q.broken, `idx ${idx} status=broken-quarantined but broken!=true`).toBe(true);
+    }
+  });
+
+  it('every status=broken-quarantined Q has a QUARANTINED-prefixed broken_reason', () => {
+    for (const { idx, q } of quarantined) {
+      expect(
+        typeof q.broken_reason === 'string' && q.broken_reason.startsWith('QUARANTINED '),
+        `idx ${idx} broken_reason does not start with 'QUARANTINED ': ${q.broken_reason?.slice(0, 60)}`
+      ).toBe(true);
+    }
+  });
+
+  it('quarantine reasons reference the v9.81 PDF-verbatim rule', () => {
+    for (const { idx, q } of quarantined) {
+      expect(
+        q.broken_reason.includes('v9.81 rule'),
+        `idx ${idx} broken_reason missing v9.81 rule reference`
+      ).toBe(true);
+    }
+  });
+
+  it('the 2 expected indices (2096, 3618) carry the quarantine', () => {
+    const indices = quarantined.map(({ idx }) => idx).sort((a, b) => a - b);
+    expect(indices).toEqual([2096, 3618]);
+  });
+
+  it('the 2 quarantined Qs cite their original textbook references intact', () => {
+    expect(questions[2096].ref).toContain('Hazzard Ch 74');
+    expect(questions[2096].ref).toContain('Harrison Ch 286');
+    expect(questions[3618].ref).toContain('Hazzard Ch 38');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the 2 c-flip-pending broken MCQs (P2 of the audit-8 R1.5 carryover batch). Both stay `broken: true`; resolution is to **officialize the quarantine** rather than continue letting them sit in a half-decided "pending" state.

| idx | Topic | Original ref | chaos-doctor conf | Resolution |
|---|---|---|---|---|
| 2096 | Cardiology (ti=17) | Hazzard Ch 74 / Harrison Ch 286 | 85 | quarantined |
| 3618 | Urology (ti=11) | Hazzard Ch 38 / GRS8 Ch 49-53 | 70 | quarantined |

## Why quarantine, not flip

Each Q's existing `q.e_en` field defends the **current** `c` with clinically-reasoned text. The chaos-doctor v4 + Opus cold-validate runs recommended flipping. Two AI sources disagree on each Q.

Per the v9.81 rule (authoritative since the v9.81 idx 510 incident), changes to `o[]`/`c`/`e` require a verbatim Hazzard / Harrison / GRS8 PDF quote. No such quote has been obtained for either Q. PDF-hunting through the 157 MB of externalized Hazzard parts without page-mapping wasn't session-doable in this budget.

## Schema

Adds optional `status: "broken-quarantined"` field on the 2 Qs. Existing renderer ignores unknown fields, so no UI change. `broken_reason` rewritten to drop "pending" framing.

## Ratchet test

`tests/brokenQuarantinedRatchet.test.js` (6 tests) pins:
- exactly 2 broken-quarantined Qs
- both have `broken: true`
- `broken_reason` starts with `QUARANTINED ` and references `v9.81 rule`
- indices are 2096 + 3618
- original `ref` strings remain intact (no `ref`-flip happened)

Analogous to the existing `curatorOverridesRatchet` pattern for the 110 IMA-vs-textbook disagreements. Prevents silent un-quarantine via automated passes.

## Verify

- `npm run regen:check`: exit 0 (Q count unchanged 3823; new optional `status` field doesn't affect `q.ti`/`q.c`/derived data).
- Full `npm run verify`: 86 files / 1,602 passed / 7 skipped / 0 failed.

## CLAUDE.md auto-expand

Test count bumped: `1,596 / 85 files` → `1,602 / 86 files`. Test inventory entry added.

## Reopen path

For either Q: obtain verbatim Hazzard PDF quote → flip (or confirm) `c` → remove the `status` field + delete the matching ratchet entry → set `broken: false`. The quarantine is intentionally reversible.

## Lane

P2 of session 2026-05-24 carryover handoff. HALT after merge per rule #2 — awaiting greenlight for P3 (proxy_rate_limits duplicate trigger cleanup).