### PR TITLE
feat(audit8): r1.5 mechanism-discrimination captures + phase1late baseline trigger

### DIFF
--- a/scripts/audit8/r15LongProbe.mjs
+++ b/scripts/audit8/r15LongProbe.mjs
@@ -24,6 +24,7 @@
 //   R15_PROBE_LABEL                free-form label embedded in the timeline
 //   R15_PROBE_READ_PAUSE_MS        delay between attempts (default 2500)
 //   R15_PROBE_PHASE1_CONTROL_MIN   minute at which Phase-1 control is captured (default 30)
+//   R15_PROBE_PHASE1_LATE_MIN      minute at which Phase-1 late baseline is captured (default 200)
 //   R15_PROBE_RED_OK_MIN_THRESHOLD     ok/min threshold for the ok-window (default 1)
 //   R15_PROBE_RED_OK_WINDOW_MINUTES    contiguous ok-minutes required (default 60)
 //   R15_PROBE_RED_SKIP_MIN_THRESHOLD   pre-pick-skip/min threshold for the streak (default 5)
@@ -45,10 +46,12 @@ import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { extractQuestion, ensureOnPracticeQuiz } from '../chaos-doctor-bot-v4.mjs';
+import { hashStem, normStem } from '../lib/hashStem.mjs';
 import {
   DEFAULT_CONFIG,
   shouldTriggerFirstFailure,
   shouldCaptureControl,
+  shouldCapturePhase1Late,
   detectRedCrossing,
   buildMinuteRecord,
 } from './r15LongProbeLogic.mjs';
@@ -60,6 +63,7 @@ export {
   DEFAULT_CONFIG,
   shouldTriggerFirstFailure,
   shouldCaptureControl,
+  shouldCapturePhase1Late,
   detectRedCrossing,
   buildMinuteRecord,
 };
@@ -76,6 +80,7 @@ function loadConfig() {
     label: process.env.R15_PROBE_LABEL || DEFAULT_CONFIG.label,
     readPauseMs: Math.max(100, Number(process.env.R15_PROBE_READ_PAUSE_MS || DEFAULT_CONFIG.readPauseMs)),
     phase1ControlMinute: Math.max(1, Number(process.env.R15_PROBE_PHASE1_CONTROL_MIN || DEFAULT_CONFIG.phase1ControlMinute)),
+    phase1LateMinute: Math.max(1, Number(process.env.R15_PROBE_PHASE1_LATE_MIN || DEFAULT_CONFIG.phase1LateMinute)),
     redOkMinThreshold: Math.max(0, Number(process.env.R15_PROBE_RED_OK_MIN_THRESHOLD || DEFAULT_CONFIG.redOkMinThreshold)),
     redOkWindowMinutes: Math.max(1, Number(process.env.R15_PROBE_RED_OK_WINDOW_MINUTES || DEFAULT_CONFIG.redOkWindowMinutes)),
     redSkipMinThreshold: Math.max(0, Number(process.env.R15_PROBE_RED_SKIP_MIN_THRESHOLD || DEFAULT_CONFIG.redSkipMinThreshold)),
@@ -126,6 +131,82 @@ async function snapshotServiceWorkerCount(page) {
       return regs.length;
     } catch (_) { return null; }
   }).catch(() => null);
+}
+
+// R1.5-doc Class B discriminator (PWA page-state accumulation: event-listener
+// growth, render-buffer drift). Cumulative DOM mutation count since the
+// observer was installed just after initial nav. A sharp delta between
+// phase1control / phase1late / firstfail captures says "structural drift
+// at the transition"; a flat delta + same DOM node count says "structure
+// stable, look at Class A heap or Class C connection state."
+async function snapshotMutationCount(page) {
+  return await page.evaluate(() => {
+    try {
+      const c = window.__r15MutationCount;
+      const installedAt = window.__r15MutationCounterInstalledAt;
+      return { count: typeof c === 'number' ? c : null, installedAt: installedAt || null };
+    } catch (_) { return null; }
+  }).catch(() => null);
+}
+
+// R1.5-doc Class C discriminator (Connection/proxy/CDN). Cache API entries
+// per cache. A new cache key appearing between captures suggests the SW
+// swapped to a different version mid-run; an entry-count surge suggests
+// the SW re-fetched the practice surface (possible CDN edge rotation).
+async function snapshotCacheKeys(page) {
+  return await page.evaluate(async () => {
+    try {
+      if (!('caches' in window)) return null;
+      const keys = await caches.keys();
+      const out = {};
+      for (const k of keys) {
+        try {
+          const c = await caches.open(k);
+          const reqs = await c.keys();
+          out[k] = { entryCount: reqs.length };
+        } catch (_) { out[k] = { error: 'open-failed' }; }
+      }
+      return out;
+    } catch (_) { return null; }
+  }).catch(() => null);
+}
+
+// R1.5-doc Class C discriminator (the precise script URL of the active
+// service worker). The existing snapshotPersistentState captures
+// registrations, but the controller — the SW that actually owns the
+// page — is a separate handle. If `scriptURL` changes between captures,
+// a SW update took control of the page mid-run; that's a plausible
+// Phase-2 trigger absent from the current capture set.
+async function snapshotControllerUrl(page) {
+  return await page.evaluate(() => {
+    try {
+      if (!navigator.serviceWorker) return null;
+      const c = navigator.serviceWorker.controller;
+      return c ? { scriptURL: c.scriptURL, state: c.state } : null;
+    } catch (_) { return null; }
+  }).catch(() => null);
+}
+
+// Install the MutationObserver counter once after initial nav. Counts
+// every mutation on document.documentElement. Idempotent — re-running
+// is a no-op. Caveat: if a hard reload happens (window context replaced
+// by SW navigation preload, etc.), the counter resets; that reset
+// itself is a Class B/C signal worth reading (snapshotMutationCount
+// returns installedAt so the diff can detect re-installations).
+async function installMutationCounter(page) {
+  await page.evaluate(() => {
+    if (typeof window.__r15MutationCount === 'number') return;
+    try {
+      window.__r15MutationCount = 0;
+      window.__r15MutationCounterInstalledAt = Date.now();
+      const obs = new MutationObserver((muts) => {
+        window.__r15MutationCount += muts.length;
+      });
+      obs.observe(document.documentElement, {
+        childList: true, subtree: true, attributes: true, characterData: true,
+      });
+    } catch (_) { /* tolerate */ }
+  }).catch(() => {});
 }
 
 async function snapshotPersistentState(page) {
@@ -203,6 +284,10 @@ async function writeCapture(outDir, prefix, parts) {
     fs.writeFile(path.join(outDir, `${prefix}-net.jsonl`), (parts.netBuf || []).map((e) => JSON.stringify(e)).join('\n')),
     fs.writeFile(path.join(outDir, `${prefix}-toranot.json`), JSON.stringify(parts.toranot || { absent: true }, null, 2)),
     fs.writeFile(path.join(outDir, `${prefix}-persist.json`), JSON.stringify(parts.persist || null, null, 2)),
+    fs.writeFile(path.join(outDir, `${prefix}-mutation.json`), JSON.stringify(parts.mutation || null, null, 2)),
+    fs.writeFile(path.join(outDir, `${prefix}-cache-keys.json`), JSON.stringify(parts.cacheKeys || null, null, 2)),
+    fs.writeFile(path.join(outDir, `${prefix}-controller.json`), JSON.stringify(parts.controller || null, null, 2)),
+    fs.writeFile(path.join(outDir, `${prefix}-extract-probe.json`), JSON.stringify(parts.extractProbe || null, null, 2)),
   ]);
 }
 
@@ -210,7 +295,15 @@ async function captureSet({ page, context, outDir, prefix, consoleBuf, netBuf })
   const dom = await page.content().catch(() => null);
   const perf = await snapshotPerf(page);
   const persist = await snapshotPersistentState(page);
+  const mutation = await snapshotMutationCount(page);
+  const cacheKeys = await snapshotCacheKeys(page);
+  const controller = await snapshotControllerUrl(page);
   await page.screenshot({ path: path.join(outDir, `${prefix}-screenshot.png`), fullPage: true }).catch(() => {});
+  // ExtractQuestion probe runs AFTER the screenshot so the screenshot
+  // captures the pre-probe page state. The probe is read-only; it does
+  // not advance the bot's quiz position (extractQuestion source verified
+  // at chaos-doctor-bot-v4.mjs:239-265).
+  const extractProbe = await probeExtractQuestion(page);
   let toranot = { absent: true };
   for (let i = netBuf.length - 1; i >= 0; i--) {
     const n = netBuf[i];
@@ -238,7 +331,50 @@ async function captureSet({ page, context, outDir, prefix, consoleBuf, netBuf })
     netBuf: netBuf.slice(),
     toranot,
     persist,
+    mutation,
+    cacheKeys,
+    controller,
+    extractProbe,
   });
+}
+
+// R1.5-doc Class B verification (NOT a class discriminator — a direct
+// observation of whether `extractQuestion` succeeds at capture time).
+// At phase1control we expect 5/5 successful extracts; at firstfail we
+// expect 5/5 nulls or near-zero stems. A mismatch (e.g., 3/5 success at
+// firstfail) says the page state is intermittent rather than locked,
+// which would re-open the R1.0b extractor-regression hypothesis the
+// R1.5 doc's bisect-window argument otherwise rules out. Hash-aware so
+// the diff can detect "same broken question repeating" vs "different
+// questions all extracting cleanly." extractQuestion is read-only
+// (verified at chaos-doctor-bot-v4.mjs:239-265 — locator.innerText
+// only, no clicks), so calling it 5x here does not advance the bot's
+// quiz position.
+async function probeExtractQuestion(page) {
+  const results = [];
+  for (let i = 0; i < 5; i++) {
+    const start = Date.now();
+    let r = null;
+    let err = null;
+    try {
+      r = await extractQuestion(page);
+    } catch (e) {
+      err = String((e && e.message) || e);
+    }
+    const stem = r && r.stem ? r.stem : null;
+    results.push({
+      attempt: i + 1,
+      ts: nowIso(),
+      elapsedMs: Date.now() - start,
+      ok: !!(r && r.options && r.options.length >= 2),
+      stemHash: stem ? hashStem(normStem(stem)) : null,
+      stemPrefix: stem ? stem.slice(0, 60) : null,
+      optionsCount: Array.isArray(r && r.options) ? r.options.length : 0,
+      error: err,
+    });
+    await sleep(200);
+  }
+  return results;
 }
 
 async function advance(page) {
@@ -336,6 +472,7 @@ async function main() {
   const recentTimeline = []; // last ~120 minutes; bounded to cap memory
 
   let controlCaptured = false;
+  let phase1LateCaptured = false;
   let firstFailCaptured = false;
   let redCrossingAt = null;
   let outcome = 'UNKNOWN';
@@ -347,6 +484,10 @@ async function main() {
     console.error('[r15LongProbe] initial nav failed', e);
     outcome = 'NAV-FAILED';
   }
+
+  // Install the MutationObserver counter so the snapshot helpers can
+  // read window.__r15MutationCount at each capture. Idempotent.
+  await installMutationCounter(page);
 
   const log = (..._args) => { /* bot's `log` callback — suppressed to keep stdout one-line-per-minute */ };
 
@@ -395,6 +536,7 @@ async function main() {
         perfMemory: await snapshotPerf(page),
         domNodeCount: await snapshotDomNodeCount(page),
         serviceWorkerCount: await snapshotServiceWorkerCount(page),
+        mutationCount: await snapshotMutationCount(page),
       });
       await timelineHandle.appendFile(JSON.stringify(rec) + '\n');
       recentTimeline.push(rec);
@@ -408,6 +550,23 @@ async function main() {
           controlCaptured = true;
         } catch (e) {
           console.error('[r15LongProbe] phase1control capture failed', e);
+        }
+      }
+
+      // Phase-1 late capture — bridges the observation gap between
+      // phase1control (min 30) and firstfail (~min 290 in the 2026-05-24
+      // calibration). Diff phase1control↔phase1late surfaces gradual
+      // drift (R1.5-doc Class A heap, Class B PWA listener accumulation);
+      // diff phase1late↔firstfail surfaces what changed AT the
+      // transition (R1.5-doc Class B page-state, Class C connection,
+      // Class D bot-profile-state corruption).
+      if (shouldCapturePhase1Late(minuteIndex, CONFIG, phase1LateCaptured)) {
+        console.log(`[r15LongProbe] minute ${minuteIndex}: Phase-1 late capture`);
+        try {
+          await captureSet({ page, context, outDir, prefix: 'phase1late', consoleBuf, netBuf });
+          phase1LateCaptured = true;
+        } catch (e) {
+          console.error('[r15LongProbe] phase1late capture failed', e);
         }
       }
 
@@ -465,6 +624,7 @@ async function main() {
     cumulativeOk,
     cumulativePrePickSkip,
     controlCaptured,
+    phase1LateCaptured,
     firstFailCaptured,
     redCrossingAt,
     outcome,

--- a/scripts/audit8/r15LongProbeLogic.mjs
+++ b/scripts/audit8/r15LongProbeLogic.mjs
@@ -21,6 +21,7 @@ export const DEFAULT_CONFIG = Object.freeze({
   label: 'r15-live-main',
   readPauseMs: 2500,
   phase1ControlMinute: 30,
+  phase1LateMinute: 200,
   redOkMinThreshold: 1,
   redOkWindowMinutes: 60,
   redSkipMinThreshold: 5,
@@ -98,6 +99,30 @@ export function shouldTriggerFirstFailure(history, config) {
 export function shouldCaptureControl(minuteIndex, config, alreadyCaptured) {
   if (alreadyCaptured) return false;
   return Number.isInteger(minuteIndex) && minuteIndex === config.phase1ControlMinute;
+}
+
+/**
+ * Phase-1 late trigger — bridges the 260-min observation gap between
+ * phase1control (min 30) and firstfail (~min 290 in the 2026-05-24
+ * calibration). Diff phase1control↔phase1late surfaces gradual drift
+ * (R1.5-doc Class A heap accumulation, Class B PWA listener/IDB-cursor
+ * leaks); diff phase1late↔firstfail surfaces what changed AT the
+ * transition (R1.5-doc Class B page-state, Class C connection/proxy/CDN,
+ * Class D bot-profile-state corruption).
+ *
+ * Default phase1LateMinute = 200; if Phase-2 onset arrives earlier (R3
+ * could plausibly land onset at min 60–150), the capture lands in early
+ * Phase-2 instead of late Phase-1 — still informative, just relabel
+ * mentally as a "phase2 settled" capture.
+ *
+ * @param {number} minuteIndex 0-based minute since probe start
+ * @param {object} config { phase1LateMinute }
+ * @param {boolean} alreadyCaptured whether this capture has fired
+ * @returns {boolean}
+ */
+export function shouldCapturePhase1Late(minuteIndex, config, alreadyCaptured) {
+  if (alreadyCaptured) return false;
+  return Number.isInteger(minuteIndex) && minuteIndex === config.phase1LateMinute;
 }
 
 /**
@@ -182,7 +207,7 @@ export function buildMinuteRecord(input) {
     minuteIndex, ts, cumulativeOk, cumulativePrePickSkip,
     prevCumulativeOk = 0, prevCumulativePrePickSkip = 0,
     lastExtractOutcome = null, perfMemory = null, domNodeCount = null,
-    serviceWorkerCount = null,
+    serviceWorkerCount = null, mutationCount = null,
   } = input;
   return {
     minuteIndex,
@@ -195,5 +220,6 @@ export function buildMinuteRecord(input) {
     perfMemory,
     domNodeCount,
     serviceWorkerCount,
+    mutationCount,
   };
 }

--- a/tests/audit8r15LongProbe.test.js
+++ b/tests/audit8r15LongProbe.test.js
@@ -12,6 +12,7 @@ import { fileURLToPath } from 'node:url';
 import {
   shouldTriggerFirstFailure,
   shouldCaptureControl,
+  shouldCapturePhase1Late,
   detectRedCrossing,
   buildMinuteRecord,
   DEFAULT_CONFIG,
@@ -192,6 +193,33 @@ describe('shouldCaptureControl (R1.5.2)', () => {
   });
 });
 
+describe('shouldCapturePhase1Late', () => {
+  const cfg = { phase1LateMinute: 200 };
+
+  it('fires exactly at the configured minute when not yet captured', () => {
+    expect(shouldCapturePhase1Late(200, cfg, false)).toBe(true);
+  });
+
+  it('does not fire before the configured minute', () => {
+    expect(shouldCapturePhase1Late(199, cfg, false)).toBe(false);
+    expect(shouldCapturePhase1Late(30, cfg, false)).toBe(false);
+  });
+
+  it('does not fire after the configured minute (single-shot semantics)', () => {
+    expect(shouldCapturePhase1Late(201, cfg, false)).toBe(false);
+    expect(shouldCapturePhase1Late(290, cfg, false)).toBe(false);
+  });
+
+  it('refuses to re-fire when already captured', () => {
+    expect(shouldCapturePhase1Late(200, cfg, true)).toBe(false);
+  });
+
+  it('refuses non-integer minute indices', () => {
+    expect(shouldCapturePhase1Late(200.5, cfg, false)).toBe(false);
+    expect(shouldCapturePhase1Late(NaN, cfg, false)).toBe(false);
+  });
+});
+
 describe('detectRedCrossing (R1.5.0)', () => {
   // Synthesize timelines with the bifurcation shape: N minutes of ok>thr,
   // then M minutes of skip>thr. The detector returns the boundaries.
@@ -344,6 +372,7 @@ describe('DEFAULT_CONFIG', () => {
     expect(DEFAULT_CONFIG.redOkMinThreshold).toBe(1);
     expect(DEFAULT_CONFIG.redSkipMinThreshold).toBe(5);
     expect(DEFAULT_CONFIG.phase1ControlMinute).toBe(30);
+    expect(DEFAULT_CONFIG.phase1LateMinute).toBe(200);
     expect(DEFAULT_CONFIG.firstFailStreakMinutes).toBe(3);
     expect(DEFAULT_CONFIG.minHours).toBe(6);
     expect(DEFAULT_CONFIG.maxHours).toBe(10);


### PR DESCRIPTION
## Why

Follow-up to fresh-eye review of AUDIT-9 PR #275 + PR #274 (`opus-consult-r15-bot-run.md`). Two findings drove this PR:

1. **260-min observation gap** between `phase1control` (min 30) and `firstfail` (~min 290 in the 2026-05-24 calibration). If anything drifts gradually between those points, there's no measurement of when. Adds a `phase1late` capture trigger at min 200.
2. **Current capture set under-covers 3 of the 5 R1.5-doc mechanism classes** (`docs/AUDIT8_G5_R1_5_MECHANISM_CAPTURE.md:47-51`). The existing `persist.json` covers Class A (heap) and Class D (bot-profile-state). Classes B (PWA structural drift), C (connection/proxy/CDN), and B-verification (loop-healthy/page-broken) had no dedicated discriminators. Adds four:
   - `mutation.json` — MutationObserver count since just after initial nav (Class B)
   - `cache-keys.json` — Cache API entries per cache (Class C)
   - `controller.json` — active SW scriptURL + state (Class C)
   - `extract-probe.json` — extractQuestion called 5× at capture (Class B verification)

## What

- `scripts/audit8/r15LongProbeLogic.mjs`: `phase1LateMinute: 200` in `DEFAULT_CONFIG`; new `shouldCapturePhase1Late` predicate (mirrors `shouldCaptureControl` shape); `mutationCount` threaded through `buildMinuteRecord`.
- `scripts/audit8/r15LongProbe.mjs`: 4 new snapshot helpers (`snapshotMutationCount`, `snapshotCacheKeys`, `snapshotControllerUrl`, `installMutationCounter`), `probeExtractQuestion` (Class B verification, read-only — extractQuestion verified at `scripts/chaos-doctor-bot-v4.mjs:239-265`), `captureSet` snapshots all 4 + the existing set, `writeCapture` emits 4 new artifact files per capture, `installMutationCounter` called once after initial nav, new `phase1late` trigger block in the main loop, per-minute records gain `mutationCount`, `summary.json` gains `phase1LateCaptured`. New env knob: `R15_PROBE_PHASE1_LATE_MIN`.
- `tests/audit8r15LongProbe.test.js`: new describe block for `shouldCapturePhase1Late` (5 cases), `DEFAULT_CONFIG` assertion pins `phase1LateMinute = 200`.

## Tests

- `tests/audit8r15LongProbe.test.js`: 29/29 pass (24 existing + 5 new).
- Full suite: 1610/1617 pass, 7 pre-existing skips, **zero regressions**.

## R1.5 spec impact

§R1.5.2 capture set is **extended additively**. Trigger predicates §R1.5.1 + §R1.5.1.1 are **unchanged**. The summary schema `r15-summary-v1` gains `phase1LateCaptured` — additive-only field. No retro-edit of any prior gate doc.

**`feedback_spec_provenance_append_only` framing question** (one of two decision-forks for human-merge review): does adding a per-capture artifact and a new trigger require an append-only §R1.5.2-REV1 to `docs/AUDIT8_G5_R1_5_MECHANISM_CAPTURE.md`? Argument yes: the gate doc says the capture set is bound (`docs/AUDIT8_G5_R1_5_MECHANISM_CAPTURE.md:77-84` enumerates the 7 artifact files). Argument no: additive captures within the same diff-vs-control protocol don't redefine the binding, they augment it. I lean **yes — author §R1.5.2-REV1** for the same reason §R1.5.1.1 was authored (the calibration anchor changed; the new captures are class-discrimination calibration anchors). That REV would land in a separate PR on a `docs/AUDIT*` path with fresh-eye review per audit-evidence-path convention.

## Decision-fork 2: summary schema bump?

The `r15-summary-v1` schema gains `phase1LateCaptured`. Additive-only, no rename, no removal. Strict reading of `feedback_spec_provenance_append_only` would say bump to `r15-summary-v2`; pragmatic reading says additive doesn't need a bump. Defaulted to **no bump** in this PR; if the call is yes-bump, one-line change at the `summary.schema` assignment.

## Mechanism-class taxonomy note (cross-doc drift surfaced for separate REV PR)

While writing class comments for the new captures, I discovered the brief I was reviewing against + AUDIT-9 (`docs/AUDIT9_PRE_REGISTERED_GATE.md:128`) use a different class taxonomy than the gate doc:

- **R1.5 doc**: A=process leak, B=PWA heap/listener accumulation, **C=connection/proxy/CDN**, **D=persistent bot-profile state (IDB/SW)**, E=novel.
- **Brief + AUDIT-9 inline**: A=process leak, B=page state, **C=DOM injection**, **D=extractor bug**, E=IDB.

The brief's "Class D = extractor bug" doesn't exist in the gate doc. The bisect-window argument at `docs/AUDIT8_G5_R1_5_MECHANISM_CAPTURE.md:35` already disposes of an extractor-regression hypothesis. This PR's code comments cite R1.5-doc class numbers (the ground truth). An append-only §A0-REV1 to AUDIT-9 pinning the gate-doc taxonomy as the binding one would close the drift — drafted in the consult thread, awaits a separate `docs/AUDIT*` PR.

## Authorship + merge

Authored by web-Claude consult during fresh-eye review of AUDIT-9 (the consult that produced this PR's rationale). **NOT a self-merge candidate** — terminal-Claude / fresh-eye reviewer expected on this PR before Eias merges, per the repo's convention for audit8-adjacent scripts.

## What this PR does NOT do

- Does **not** touch the R1.5 gate doc (separate PR; audit-evidence path).
- Does **not** modify the firstfail debounce (PR #274, merged) or the AUDIT-9 gate (PR #275, merged).
- Does **not** run the probe — instrumentation only. The next R1.5 run consumes these captures.