### PR TITLE
test(regulatory): tagger-idempotency test no longer mutates working tree

### DIFF
--- a/tests/regulatoryTags.test.js
+++ b/tests/regulatoryTags.test.js
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { readFileSync, existsSync } from 'fs';
+import { readFileSync, existsSync, writeFileSync } from 'fs';
 import { resolve } from 'path';
 import { execSync } from 'child_process';
 import { loadQuestionsHydrated } from './_helpers/loadQuestionsHydrated.js';
@@ -63,10 +63,26 @@ describe('regulatory.json artifact', () => {
   });
 
   it('tagger script is idempotent (running again produces same set)', () => {
-    const before = JSON.parse(readFileSync(REG_PATH, 'utf-8'));
-    execSync('node scripts/tag_regulatory.cjs', { cwd: ROOT, stdio: 'pipe' });
-    const after = JSON.parse(readFileSync(REG_PATH, 'utf-8'));
-    expect(after.sort((a, b) => a - b)).toEqual(before.sort((a, b) => a - b));
+    // Capture original bytes BEFORE running the tagger so we can restore
+    // them in finally — the tagger uses `JSON.stringify(tagged)` (compact
+    // form) whereas the committed file may be spaced/pretty-printed, so
+    // even when the SET of indices is identical the on-disk BYTES differ.
+    // Without this restore, every `vitest run` mutates the working tree
+    // and pollutes unrelated PRs with a stray `data/regulatory.json` diff.
+    const beforeBytes = readFileSync(REG_PATH);
+    const before = JSON.parse(beforeBytes.toString('utf-8'));
+    try {
+      execSync('node scripts/tag_regulatory.cjs', { cwd: ROOT, stdio: 'pipe' });
+      const after = JSON.parse(readFileSync(REG_PATH, 'utf-8'));
+      expect(after.sort((a, b) => a - b)).toEqual(before.sort((a, b) => a - b));
+    } finally {
+      // Restore exact original bytes — including whitespace and trailing-newline
+      // shape — so the working tree is clean regardless of how the tagger
+      // chose to format its output. Idempotency in VALUES is what the test
+      // asserts; preserving on-disk FORMAT is a separate concern (committed
+      // formatting is the source of truth).
+      writeFileSync(REG_PATH, beforeBytes);
+    }
   });
 });
 


### PR DESCRIPTION
## What this fixes

The `"tagger script is idempotent (running again produces same set)"` test
in `tests/regulatoryTags.test.js` shells out to `node scripts/tag_regulatory.cjs`,
which writes `data/regulatory.json` with `JSON.stringify(tagged) + '\n'`
(compact, no spaces). The committed copy is formatted with spaces. The
test compares VALUE sets — identical, assertion passes — but the on-disk
BYTES diverge.

**Effect:** every `vitest run` (CI or local) leaves a 1-line whitespace
diff on `data/regulatory.json` in the working tree. Polluted my working
tree while preparing PR #280 — had to soft-reset to drop the
regulatory.json drift before the addInitScript-only commit could ship.

**Latent risk:** idempotency becomes a stateful property of "who ran
vitest last," and a future PR could quietly bake the compact format
into the committed copy.

## Fix

Capture the file bytes before the tagger runs; restore in `finally`.
Test still asserts VALUE-set equality; on-disk FORMAT is restored
regardless of tagger output style.

```diff
+    const beforeBytes = readFileSync(REG_PATH);
     const before = JSON.parse(beforeBytes.toString('utf-8'));
+    try {
       execSync('node scripts/tag_regulatory.cjs', { cwd: ROOT, stdio: 'pipe' });
       const after = JSON.parse(readFileSync(REG_PATH, 'utf-8'));
       expect(after.sort(...)).toEqual(before.sort(...));
+    } finally {
+      writeFileSync(REG_PATH, beforeBytes);
+    }
```

## Verification

Two consecutive `vitest run tests/regulatoryTags.test.js` runs both
green; `git status` after each shows only the intentional test-file
modification, never `data/regulatory.json`.

```
$ npx vitest run tests/regulatoryTags.test.js   # run 1
 Test Files  1 passed (1)
      Tests  10 passed (10)
$ git status --short
 M tests/regulatoryTags.test.js                  # only the intended change

$ npx vitest run tests/regulatoryTags.test.js   # run 2
 Test Files  1 passed (1)
      Tests  10 passed (10)
$ git status --short
 M tests/regulatoryTags.test.js                  # still only the intended change
```
