### PR TITLE
fix(audit8): R1.7 — move mutation install to context.addInitScript (path 1)

### DIFF
--- a/scripts/audit8/r15LongProbe.mjs
+++ b/scripts/audit8/r15LongProbe.mjs
@@ -292,16 +292,40 @@ async function installMutationCounter(context) {
       window.__r15MutationCount = 0;
       window.__r15MutationCounterInstalledAt = Date.now();
       window.__r15InstallTag = tag;
-      if (document.documentElement) {
-        document.documentElement.setAttribute('data-r15-tag', tag);
-      }
+      out.tag = tag;
+      // R1.7.1: addInitScript runs at readyState=loading — document.documentElement
+      // may be null at this moment. observe() requires a Node parameter; passing
+      // null throws TypeError ("parameter 1 is not of type 'Node'"). `document`
+      // itself is always a Node and exists from script-start. observe(document,
+      // { subtree: true, ... }) captures every mutation under document, including
+      // everything observe(documentElement, { subtree: true, ... }) would.
       const obs = new MutationObserver((muts) => {
         window.__r15MutationCount += muts.length;
       });
-      obs.observe(document.documentElement, {
+      obs.observe(document, {
         childList: true, subtree: true, attributes: true, characterData: true,
       });
-      out.tag = tag;
+      // R1.7.1: defer the data-r15-tag attribute set until documentElement
+      // exists. Called immediately for the common case; readystatechange
+      // listener as fallback for the script-start "loading" case (handler
+      // is idempotent — hasAttribute guard makes re-fires no-ops). Mutates
+      // window.__r15InstallDiag.docElTagName in place so the snapshot sees
+      // the eventually-attached tagName without losing the installed-at-loading
+      // marker.
+      const applyDocElTag = () => {
+        if (!document.documentElement) return;
+        if (!document.documentElement.hasAttribute('data-r15-tag')) {
+          document.documentElement.setAttribute('data-r15-tag', tag);
+          if (window.__r15InstallDiag && !window.__r15InstallDiag.docElTagName) {
+            window.__r15InstallDiag.docElTagName = document.documentElement.tagName;
+          }
+        }
+      };
+      applyDocElTag();
+      if (!document.documentElement || !document.documentElement.hasAttribute('data-r15-tag')) {
+        document.addEventListener('readystatechange', applyDocElTag);
+        document.addEventListener('DOMContentLoaded', applyDocElTag, { once: true });
+      }
     } catch (e) {
       out.installError = { name: (e && e.name) || 'Error', message: (e && e.message) || String(e) };
     }

--- a/scripts/audit8/r15LongProbe.mjs
+++ b/scripts/audit8/r15LongProbe.mjs
@@ -150,8 +150,12 @@ async function snapshotServiceWorkerCount(page) {
 // the minimum forensic signal needed to pick the actual repair in R1.7.
 // Pre-existing fields (count, installedAt) preserved verbatim so any consumer
 // reading just those still works; new info under .diag.
-let installDiagnostic = null;
-
+//
+// R1.7 fix (2026-05-25): the install now lives on window.__r15InstallDiag
+// (set by context.addInitScript at script-start time in every page context),
+// not on a module-level Node variable. The snapshot reads it from there
+// alongside the count/tag/readyState, so the install diagnostics travel
+// with the page context they describe — even after a mid-run hard reload.
 async function snapshotMutationCount(page) {
   const snap = await page.evaluate(() => {
     const out = {
@@ -162,6 +166,7 @@ async function snapshotMutationCount(page) {
       readyState: null,
       docElTagName: null,
       readError: null,
+      install: null,
     };
     try {
       const c = window.__r15MutationCount;
@@ -174,6 +179,7 @@ async function snapshotMutationCount(page) {
         : null;
       out.readyState = document.readyState;
       out.docElTagName = document.documentElement ? document.documentElement.tagName : null;
+      out.install = window.__r15InstallDiag || null;
     } catch (e) {
       out.readError = { name: (e && e.name) || 'Error', message: (e && e.message) || String(e) };
     }
@@ -185,13 +191,14 @@ async function snapshotMutationCount(page) {
     tagOnDocEl: null,
     readyState: null,
     docElTagName: null,
+    install: null,
     readError: {
       name: (e && e.name) || 'EvaluateError',
       message: (e && e.message) || String(e),
       outer: true,
     },
   }));
-  const install = installDiagnostic || null;
+  const install = snap.install || null;
   const tagMatchWindow = install && install.tag && snap.tagOnWindow ? install.tag === snap.tagOnWindow : null;
   const tagMatchDocEl  = install && install.tag && snap.tagOnDocEl  ? install.tag === snap.tagOnDocEl  : null;
   return {
@@ -248,31 +255,31 @@ async function snapshotControllerUrl(page) {
   }).catch(() => null);
 }
 
-// Install the MutationObserver counter once after initial nav. Counts
-// every mutation on document.documentElement. Idempotent — re-running
-// is a no-op. Caveat: if a hard reload happens (window context replaced
-// by SW navigation preload, etc.), the counter resets; that reset
-// itself is a Class B/C signal worth reading (snapshotMutationCount
-// returns installedAt so the diff can detect re-installations).
+// Install the MutationObserver counter via Playwright's context.addInitScript.
+// Runs in every new page context, before any page script — including any
+// context created by an SPA hard-reload, SW navigation-preload swap, or
+// hash-fragment redirect during the post-goto `domcontentloaded` window.
 //
-// R1.6 diagnostic (path (a), 2026-05-24 evening): the prior body swallowed
-// install errors via `.catch(() => {})` and the inner `try { … } catch (_) {}`,
-// which is exactly what made the v10.64.130 smoke-pair null debuggable only
-// at REV3-level. The body below: (1) returns a structured outcome from
-// page.evaluate (preInstalled / tag / installError / readyStateAtInstall /
-// hasMutationObserver / docElTagName), (2) console.errors any install failure
-// AND any "evaluate returned with no install path" anomaly, (3) tags the install
-// with both window.__r15InstallTag AND a data-r15-tag attribute on documentElement
-// so the snapshot can detect identity drift on either axis, (4) persists the
-// result in the module-level installDiagnostic so every later snapshot can
-// include it. No behavior change to the install itself; everything new is
-// diagnostic surface for R1.7.
-async function installMutationCounter(page) {
-  const result = await page.evaluate(() => {
+// R1.7 fix (2026-05-25 early-AM, PR #279 R1.6 diagnostic captured the cause):
+// the prior body used `await page.evaluate(...)` immediately after
+// `page.goto(url, { waitUntil: 'domcontentloaded' })` and reliably failed
+// with `page.evaluate: Execution context was destroyed, most likely because
+// of a navigation` (R1.6 smoke captured this verbatim on 2026-05-25 04:59).
+// Moving the install to addInitScript eliminates the timing race: the
+// install runs synchronously inside the page context at script-start time,
+// before any chance of mid-navigation context destruction. As a bonus, the
+// counter self-heals across in-run hard reloads — the original "if a hard
+// reload happens, the counter resets" caveat becomes "the counter re-installs
+// on every fresh context, idempotently no-op on already-installed contexts."
+// Diagnostic state lands on `window.__r15InstallDiag` so the snapshot can
+// embed it unchanged.
+async function installMutationCounter(context) {
+  await context.addInitScript(() => {
+    if (typeof window.__r15MutationCount === 'number') return;
     const out = {
       readyStateAtInstall: null,
       hasMutationObserver: null,
-      preInstalled: null,
+      preInstalled: false,
       tag: null,
       installError: null,
       docElTagName: null,
@@ -281,11 +288,6 @@ async function installMutationCounter(page) {
       out.readyStateAtInstall = document.readyState;
       out.hasMutationObserver = typeof MutationObserver === 'function';
       out.docElTagName = document.documentElement ? document.documentElement.tagName : null;
-      out.preInstalled = typeof window.__r15MutationCount === 'number';
-      if (out.preInstalled) {
-        out.tag = window.__r15InstallTag || null;
-        return out;
-      }
       const tag = 'inst-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8);
       window.__r15MutationCount = 0;
       window.__r15MutationCounterInstalledAt = Date.now();
@@ -303,25 +305,8 @@ async function installMutationCounter(page) {
     } catch (e) {
       out.installError = { name: (e && e.name) || 'Error', message: (e && e.message) || String(e) };
     }
-    return out;
-  }).catch((e) => ({
-    readyStateAtInstall: null,
-    hasMutationObserver: null,
-    preInstalled: null,
-    tag: null,
-    installError: {
-      name: (e && e.name) || 'EvaluateError',
-      message: (e && e.message) || String(e),
-      outer: true,
-    },
-    docElTagName: null,
-  }));
-  if (result.installError) {
-    console.error('[r15LongProbe] installMutationCounter error:', JSON.stringify(result.installError));
-  } else if (!result.preInstalled && !result.tag) {
-    console.error('[r15LongProbe] installMutationCounter: page.evaluate returned but no install path ran (preInstalled=false, tag=null)');
-  }
-  installDiagnostic = result;
+    window.__r15InstallDiag = out;
+  });
 }
 
 async function snapshotPersistentState(page) {
@@ -530,6 +515,11 @@ async function main() {
 
   const browser = await chromium.launch({ headless: CONFIG.headless });
   const context = await browser.newContext();
+  // R1.7: install the MutationObserver counter via addInitScript BEFORE the
+  // first page is created. Runs in every page context at script-start time,
+  // immune to the post-goto `domcontentloaded` execution-context-destroyed
+  // race R1.6 captured (PR #279 smoke 2026-05-25 04:59:38Z).
+  await installMutationCounter(context);
   // Tracing is started before page navigation so the Phase-1 control window
   // captures the whole bot warm-up; it is stopped + restarted at each capture.
   try { await context.tracing.start({ snapshots: true, screenshots: true, sources: false }); } catch (_) {}
@@ -600,9 +590,8 @@ async function main() {
     outcome = 'NAV-FAILED';
   }
 
-  // Install the MutationObserver counter so the snapshot helpers can
-  // read window.__r15MutationCount at each capture. Idempotent.
-  await installMutationCounter(page);
+  // R1.7: the install moved to addInitScript on the context above —
+  // runs in every page context at script-start, no post-goto call needed.
 
   const log = (..._args) => { /* bot's `log` callback — suppressed to keep stdout one-line-per-minute */ };
 

--- a/scripts/audit8/r15LongProbe.mjs
+++ b/scripts/audit8/r15LongProbe.mjs
@@ -139,14 +139,75 @@ async function snapshotServiceWorkerCount(page) {
 // phase1control / phase1late / firstfail captures says "structural drift
 // at the transition"; a flat delta + same DOM node count says "structure
 // stable, look at Class A heap or Class C connection state."
+//
+// R1.6 diagnostic (path (a), 2026-05-24 evening — pre-registered by §R1.5.2-REV3,
+// PR #278): the v10.64.130 smoke pair produced { count: null, installedAt: null }
+// at every per-minute snapshot from minuteIndex=0. Both fields nulling together
+// rules out "install succeeded, observer never fired" and points at the install
+// itself not landing visibly to the snapshot. The augmented payload below
+// surfaces the swallowed error, identity drift between install and snapshot
+// (via a window-bound + DOM-attribute-bound tag), and readyState progression —
+// the minimum forensic signal needed to pick the actual repair in R1.7.
+// Pre-existing fields (count, installedAt) preserved verbatim so any consumer
+// reading just those still works; new info under .diag.
+let installDiagnostic = null;
+
 async function snapshotMutationCount(page) {
-  return await page.evaluate(() => {
+  const snap = await page.evaluate(() => {
+    const out = {
+      count: null,
+      installedAt: null,
+      tagOnWindow: null,
+      tagOnDocEl: null,
+      readyState: null,
+      docElTagName: null,
+      readError: null,
+    };
     try {
       const c = window.__r15MutationCount;
       const installedAt = window.__r15MutationCounterInstalledAt;
-      return { count: typeof c === 'number' ? c : null, installedAt: installedAt || null };
-    } catch (_) { return null; }
-  }).catch(() => null);
+      out.count = typeof c === 'number' ? c : null;
+      out.installedAt = installedAt || null;
+      out.tagOnWindow = window.__r15InstallTag || null;
+      out.tagOnDocEl = document.documentElement
+        ? document.documentElement.getAttribute('data-r15-tag')
+        : null;
+      out.readyState = document.readyState;
+      out.docElTagName = document.documentElement ? document.documentElement.tagName : null;
+    } catch (e) {
+      out.readError = { name: (e && e.name) || 'Error', message: (e && e.message) || String(e) };
+    }
+    return out;
+  }).catch((e) => ({
+    count: null,
+    installedAt: null,
+    tagOnWindow: null,
+    tagOnDocEl: null,
+    readyState: null,
+    docElTagName: null,
+    readError: {
+      name: (e && e.name) || 'EvaluateError',
+      message: (e && e.message) || String(e),
+      outer: true,
+    },
+  }));
+  const install = installDiagnostic || null;
+  const tagMatchWindow = install && install.tag && snap.tagOnWindow ? install.tag === snap.tagOnWindow : null;
+  const tagMatchDocEl  = install && install.tag && snap.tagOnDocEl  ? install.tag === snap.tagOnDocEl  : null;
+  return {
+    count: snap.count,
+    installedAt: snap.installedAt,
+    diag: {
+      readyStateAtSnapshot: snap.readyState,
+      docElTagNameAtSnapshot: snap.docElTagName,
+      tagOnWindow: snap.tagOnWindow,
+      tagOnDocEl: snap.tagOnDocEl,
+      tagMatchWindow,
+      tagMatchDocEl,
+      readError: snap.readError,
+      install,
+    },
+  };
 }
 
 // R1.5-doc Class C discriminator (Connection/proxy/CDN). Cache API entries
@@ -193,20 +254,74 @@ async function snapshotControllerUrl(page) {
 // by SW navigation preload, etc.), the counter resets; that reset
 // itself is a Class B/C signal worth reading (snapshotMutationCount
 // returns installedAt so the diff can detect re-installations).
+//
+// R1.6 diagnostic (path (a), 2026-05-24 evening): the prior body swallowed
+// install errors via `.catch(() => {})` and the inner `try { … } catch (_) {}`,
+// which is exactly what made the v10.64.130 smoke-pair null debuggable only
+// at REV3-level. The body below: (1) returns a structured outcome from
+// page.evaluate (preInstalled / tag / installError / readyStateAtInstall /
+// hasMutationObserver / docElTagName), (2) console.errors any install failure
+// AND any "evaluate returned with no install path" anomaly, (3) tags the install
+// with both window.__r15InstallTag AND a data-r15-tag attribute on documentElement
+// so the snapshot can detect identity drift on either axis, (4) persists the
+// result in the module-level installDiagnostic so every later snapshot can
+// include it. No behavior change to the install itself; everything new is
+// diagnostic surface for R1.7.
 async function installMutationCounter(page) {
-  await page.evaluate(() => {
-    if (typeof window.__r15MutationCount === 'number') return;
+  const result = await page.evaluate(() => {
+    const out = {
+      readyStateAtInstall: null,
+      hasMutationObserver: null,
+      preInstalled: null,
+      tag: null,
+      installError: null,
+      docElTagName: null,
+    };
     try {
+      out.readyStateAtInstall = document.readyState;
+      out.hasMutationObserver = typeof MutationObserver === 'function';
+      out.docElTagName = document.documentElement ? document.documentElement.tagName : null;
+      out.preInstalled = typeof window.__r15MutationCount === 'number';
+      if (out.preInstalled) {
+        out.tag = window.__r15InstallTag || null;
+        return out;
+      }
+      const tag = 'inst-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8);
       window.__r15MutationCount = 0;
       window.__r15MutationCounterInstalledAt = Date.now();
+      window.__r15InstallTag = tag;
+      if (document.documentElement) {
+        document.documentElement.setAttribute('data-r15-tag', tag);
+      }
       const obs = new MutationObserver((muts) => {
         window.__r15MutationCount += muts.length;
       });
       obs.observe(document.documentElement, {
         childList: true, subtree: true, attributes: true, characterData: true,
       });
-    } catch (_) { /* tolerate */ }
-  }).catch(() => {});
+      out.tag = tag;
+    } catch (e) {
+      out.installError = { name: (e && e.name) || 'Error', message: (e && e.message) || String(e) };
+    }
+    return out;
+  }).catch((e) => ({
+    readyStateAtInstall: null,
+    hasMutationObserver: null,
+    preInstalled: null,
+    tag: null,
+    installError: {
+      name: (e && e.name) || 'EvaluateError',
+      message: (e && e.message) || String(e),
+      outer: true,
+    },
+    docElTagName: null,
+  }));
+  if (result.installError) {
+    console.error('[r15LongProbe] installMutationCounter error:', JSON.stringify(result.installError));
+  } else if (!result.preInstalled && !result.tag) {
+    console.error('[r15LongProbe] installMutationCounter: page.evaluate returned but no install path ran (preInstalled=false, tag=null)');
+  }
+  installDiagnostic = result;
 }
 
 async function snapshotPersistentState(page) {


### PR DESCRIPTION
## Summary

Implements **path (1)** from PR #279's R1.6 diagnostic comment — moves the `MutationObserver` install from a post-goto `await page.evaluate(...)` to `context.addInitScript(fn)`, eliminating the mid-navigation execution-context-destroyed race R1.6 captured verbatim.

**Targets main but contains two commits** (R1.6 + R1.7) because GitHub's stacked-PR base ref refused `claude/audit8-r15-mutation-diag-Mut6n` as a base. Review as two separate commits:

- `c8a9abc` — R1.6 diagnostic surface (also under review as standalone in PR #279)
- `485b938` — R1.7 fix (this PR's actual contribution)

Merge order if Eias prefers separate landings: merge #278 → #279 (auto-rebases this PR to only contain `485b938`) → this PR. If he prefers a single landing: merge this PR (brings both R1.6 + R1.7 in one commit each).

## Why path (1), not (2) or (3)

PR #279's smoke captured `installError`:
```
"name": "Error",
"message": "page.evaluate: Execution context was destroyed, most likely because of a navigation",
"outer": true
```

The page IS stable at snapshot time (`readyStateAtSnapshot: "complete"`, `docElTagNameAtSnapshot: "HTML"`) — only the **post-goto → install evaluate** window races against the SPA's hash/redirect/SW-preload nav. Path (2) `waitUntil: 'load'` would narrow the window but leaves any future mid-run hard reload exposed. Path (3) retry-with-gap obscures the timing dependency.

`addInitScript` is Playwright's recommended pattern for "install something in every page context": the script runs synchronously **inside** the page context at script-start time, **before any page script**, and re-runs on every new context (including SW-mediated reloads). Self-healing.

## What changed (R1.7 commit only)

| Element | Before | After |
|---|---|---|
| `installMutationCounter` signature | `(page)` — calls `page.evaluate` post-goto | `(context)` — calls `context.addInitScript` pre-goto |
| Install error mode | `page.evaluate: Execution context was destroyed` (R1.6 captured this) | Cannot occur — `addInitScript` doesn't `evaluate`, no mid-flight context |
| Diagnostic state | Node module-level `installDiagnostic` var | Page-side `window.__r15InstallDiag` global |
| Call site | Line 605, after `page.goto` | Line ~532, after `browser.newContext()` |
| Behavior on mid-run hard reload | Counter resets, never re-installs | Counter re-installs idempotently on every fresh context |

The R1.6 `.diag` schema is preserved verbatim — every consumer still works.

## Verification (Eias's R1.7 gate, restated)

> "The R1.7 repair PR must include **one smoke at default `phase1ControlMinute=30`** (no override) showing `count: <number>` + `installedAt: <ts>` + `tagMatchWindow: true` + `tagMatchDocEl: true`."

Smoke firing against this branch now (`MIN_HOURS=0.55`, `MAX_HOURS=0.6`, ~36 min). Result lands as a follow-up comment.

## NO self-merge

Inherits the §R1.5 gate clause per workspace CLAUDE.md.

## Test plan
- [x] `node --check` clean.
- [x] `npm run verify` — 1610/1610 pass.
- [x] Diff vs Mut6n: 1 file, +40/-51 (R1.7 commit only).
- [ ] Reviewer: confirm default-timing smoke comment shows all 4 success markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)