### PR TITLE
feat(cross-repo): regen Pnimit+Mishpacha from IM/FM manifests + normalize frequency_pct precision

### DIFF
--- a/data/syllabus_data.json
+++ b/data/syllabus_data.json
@@ -990,7 +990,7 @@
           "troponin"
         ],
         "n_questions": 131,
-        "frequency_pct": 8.4,
+        "frequency_pct": 8.42,
         "weight": 2.02
       },
       {
@@ -1009,7 +1009,7 @@
           "prevention"
         ],
         "n_questions": 130,
-        "frequency_pct": 8.4,
+        "frequency_pct": 8.35,
         "weight": 2.01
       },
       {
@@ -1037,7 +1037,7 @@
           "sotatercept"
         ],
         "n_questions": 105,
-        "frequency_pct": 6.7,
+        "frequency_pct": 6.75,
         "weight": 1.62
       },
       {
@@ -1064,7 +1064,7 @@
           "MDS"
         ],
         "n_questions": 93,
-        "frequency_pct": 6,
+        "frequency_pct": 5.98,
         "weight": 1.43
       },
       {
@@ -1088,7 +1088,7 @@
           "varices"
         ],
         "n_questions": 88,
-        "frequency_pct": 5.7,
+        "frequency_pct": 5.66,
         "weight": 1.36
       },
       {
@@ -1112,7 +1112,7 @@
           "crystal"
         ],
         "n_questions": 79,
-        "frequency_pct": 5.1,
+        "frequency_pct": 5.08,
         "weight": 1.22
       },
       {
@@ -1135,7 +1135,7 @@
           "NT-proBNP"
         ],
         "n_questions": 68,
-        "frequency_pct": 4.4,
+        "frequency_pct": 4.37,
         "weight": 1.05
       },
       {
@@ -1159,7 +1159,7 @@
           "viral"
         ],
         "n_questions": 64,
-        "frequency_pct": 4.1,
+        "frequency_pct": 4.11,
         "weight": 0.99
       },
       {
@@ -1180,7 +1180,7 @@
           "tubular"
         ],
         "n_questions": 62,
-        "frequency_pct": 4,
+        "frequency_pct": 3.98,
         "weight": 0.96
       },
       {
@@ -1199,7 +1199,7 @@
           "prosthetic"
         ],
         "n_questions": 59,
-        "frequency_pct": 3.8,
+        "frequency_pct": 3.79,
         "weight": 0.91
       },
       {
@@ -1220,7 +1220,7 @@
           "resuscitat"
         ],
         "n_questions": 57,
-        "frequency_pct": 3.7,
+        "frequency_pct": 3.66,
         "weight": 0.88
       },
       {
@@ -1252,7 +1252,7 @@
           "melanoma"
         ],
         "n_questions": 54,
-        "frequency_pct": 3.5,
+        "frequency_pct": 3.47,
         "weight": 0.83
       },
       {
@@ -1267,7 +1267,7 @@
           "anesthes"
         ],
         "n_questions": 54,
-        "frequency_pct": 3.5,
+        "frequency_pct": 3.47,
         "weight": 0.83
       },
       {
@@ -1283,7 +1283,7 @@
           "immunodeficien"
         ],
         "n_questions": 53,
-        "frequency_pct": 3.4,
+        "frequency_pct": 3.41,
         "weight": 0.82
       },
       {
@@ -1301,7 +1301,7 @@
           "vomit"
         ],
         "n_questions": 53,
-        "frequency_pct": 3.4,
+        "frequency_pct": 3.41,
         "weight": 0.82
       },
       {
@@ -1318,7 +1318,7 @@
           "mesenteric"
         ],
         "n_questions": 53,
-        "frequency_pct": 3.4,
+        "frequency_pct": 3.41,
         "weight": 0.82
       },
       {
@@ -1342,7 +1342,7 @@
           "respiratory"
         ],
         "n_questions": 52,
-        "frequency_pct": 3.3,
+        "frequency_pct": 3.34,
         "weight": 0.8
       },
       {
@@ -1364,7 +1364,7 @@
           "prostate"
         ],
         "n_questions": 52,
-        "frequency_pct": 3.3,
+        "frequency_pct": 3.34,
         "weight": 0.8
       },
       {
@@ -1381,7 +1381,7 @@
           "hypervolemia"
         ],
         "n_questions": 52,
-        "frequency_pct": 3.3,
+        "frequency_pct": 3.34,
         "weight": 0.8
       },
       {
@@ -1405,7 +1405,7 @@
           "GLP-1"
         ],
         "n_questions": 41,
-        "frequency_pct": 2.6,
+        "frequency_pct": 2.63,
         "weight": 0.63
       },
       {
@@ -1430,7 +1430,7 @@
           "coma"
         ],
         "n_questions": 36,
-        "frequency_pct": 2.3,
+        "frequency_pct": 2.31,
         "weight": 0.56
       },
       {
@@ -1454,7 +1454,7 @@
           "amiodarone"
         ],
         "n_questions": 34,
-        "frequency_pct": 2.2,
+        "frequency_pct": 2.19,
         "weight": 0.52
       },
       {
@@ -1473,7 +1473,7 @@
           "aldosterone synthase"
         ],
         "n_questions": 30,
-        "frequency_pct": 1.9,
+        "frequency_pct": 1.93,
         "weight": 0.46
       }
     ]
@@ -1489,7 +1489,7 @@
         "he": "ילדים — מחלות חדות וזיהומים",
         "keywords": [],
         "n_questions": 115,
-        "frequency_pct": 10.8,
+        "frequency_pct": 10.84,
         "weight": 2.93
       },
       {
@@ -1498,7 +1498,7 @@
         "he": "ראומטולוגיה וטרשת שלד-שריר",
         "keywords": [],
         "n_questions": 100,
-        "frequency_pct": 9.4,
+        "frequency_pct": 9.43,
         "weight": 2.54
       },
       {
@@ -1507,7 +1507,7 @@
         "he": "רפואה מבוססת ראיות, תקשורת ומערכת משפחתית",
         "keywords": [],
         "n_questions": 75,
-        "frequency_pct": 7.1,
+        "frequency_pct": 7.07,
         "weight": 1.91
       },
       {
@@ -1516,7 +1516,7 @@
         "he": "בריאות האישה וגינקולוגיה",
         "keywords": [],
         "n_questions": 68,
-        "frequency_pct": 6.4,
+        "frequency_pct": 6.41,
         "weight": 1.73
       },
       {
@@ -1525,7 +1525,7 @@
         "he": "מחלות זיהומיות וחיסונים (מבוגרים)",
         "keywords": [],
         "n_questions": 50,
-        "frequency_pct": 4.7,
+        "frequency_pct": 4.71,
         "weight": 1.27
       },
       {
@@ -1534,7 +1534,7 @@
         "he": "גריאטריה (נפילות, קוגניציה, ריבוי תרופות)",
         "keywords": [],
         "n_questions": 46,
-        "frequency_pct": 4.3,
+        "frequency_pct": 4.34,
         "weight": 1.17
       },
       {
@@ -1543,7 +1543,7 @@
         "he": "הריון ולידה",
         "keywords": [],
         "n_questions": 42,
-        "frequency_pct": 4,
+        "frequency_pct": 3.96,
         "weight": 1.07
       },
       {
@@ -1552,7 +1552,7 @@
         "he": "גסטרו והפטולוגיה",
         "keywords": [],
         "n_questions": 41,
-        "frequency_pct": 3.9,
+        "frequency_pct": 3.86,
         "weight": 1.04
       },
       {
@@ -1561,7 +1561,7 @@
         "he": "נוירולוגיה (שבץ, כאבי ראש, דמנציה)",
         "keywords": [],
         "n_questions": 41,
-        "frequency_pct": 3.9,
+        "frequency_pct": 3.86,
         "weight": 1.04
       },
       {
@@ -1570,7 +1570,7 @@
         "he": "רפואה מונעת וקידום בריאות",
         "keywords": [],
         "n_questions": 41,
-        "frequency_pct": 3.9,
+        "frequency_pct": 3.86,
         "weight": 1.04
       },
       {
@@ -1579,7 +1579,7 @@
         "he": "חירום במרפאה",
         "keywords": [],
         "n_questions": 39,
-        "frequency_pct": 3.7,
+        "frequency_pct": 3.68,
         "weight": 0.99
       },
       {
@@ -1588,7 +1588,7 @@
         "he": "ריאות (אסטמה, COPD, תסחיף)",
         "keywords": [],
         "n_questions": 38,
-        "frequency_pct": 3.6,
+        "frequency_pct": 3.58,
         "weight": 0.97
       },
       {
@@ -1597,7 +1597,7 @@
         "he": "בריאות הנפש — מצב רוח, חרדה, פסיכוזה",
         "keywords": [],
         "n_questions": 32,
-        "frequency_pct": 3,
+        "frequency_pct": 3.02,
         "weight": 0.81
       },
       {
@@ -1606,7 +1606,7 @@
         "he": "אנדוקרינולוגיה — סוכרת",
         "keywords": [],
         "n_questions": 31,
-        "frequency_pct": 2.9,
+        "frequency_pct": 2.92,
         "weight": 0.79
       },
       {
@@ -1615,7 +1615,7 @@
         "he": "יתר לחץ דם ודיסליפידמיה",
         "keywords": [],
         "n_questions": 29,
-        "frequency_pct": 2.7,
+        "frequency_pct": 2.73,
         "weight": 0.74
       },
       {
@@ -1624,7 +1624,7 @@
         "he": "המטולוגיה וקרישה",
         "keywords": [],
         "n_questions": 28,
-        "frequency_pct": 2.6,
+        "frequency_pct": 2.64,
         "weight": 0.71
       },
       {
@@ -1633,7 +1633,7 @@
         "he": "ילדים — מתבגרים ובריאות הנפש",
         "keywords": [],
         "n_questions": 28,
-        "frequency_pct": 2.6,
+        "frequency_pct": 2.64,
         "weight": 0.71
       },
       {
@@ -1642,7 +1642,7 @@
         "he": "נפרולוגיה, UTI ואורולוגיה",
         "keywords": [],
         "n_questions": 27,
-        "frequency_pct": 2.5,
+        "frequency_pct": 2.54,
         "weight": 0.69
       },
       {
@@ -1651,7 +1651,7 @@
         "he": "אנדוקרינולוגיה — בלוטת תריס ואחר",
         "keywords": [],
         "n_questions": 24,
-        "frequency_pct": 2.3,
+        "frequency_pct": 2.26,
         "weight": 0.61
       },
       {
@@ -1660,7 +1660,7 @@
         "he": "ילדים — יילוד והתפתחות",
         "keywords": [],
         "n_questions": 24,
-        "frequency_pct": 2.3,
+        "frequency_pct": 2.26,
         "weight": 0.61
       },
       {
@@ -1669,7 +1669,7 @@
         "he": "אי-ספיקת לב ומסתמים",
         "keywords": [],
         "n_questions": 23,
-        "frequency_pct": 2.2,
+        "frequency_pct": 2.17,
         "weight": 0.59
       },
       {
@@ -1678,7 +1678,7 @@
         "he": "דרמטולוגיה",
         "keywords": [],
         "n_questions": 22,
-        "frequency_pct": 2.1,
+        "frequency_pct": 2.07,
         "weight": 0.56
       },
       {
@@ -1687,7 +1687,7 @@
         "he": "אלרגיה ואימונולוגיה",
         "keywords": [],
         "n_questions": 21,
-        "frequency_pct": 2,
+        "frequency_pct": 1.98,
         "weight": 0.53
       },
       {
@@ -1696,7 +1696,7 @@
         "he": "קרדיולוגיה למבוגר — מחלת לב איסכמית והפרעות קצב",
         "keywords": [],
         "n_questions": 20,
-        "frequency_pct": 1.9,
+        "frequency_pct": 1.89,
         "weight": 0.51
       },
       {
@@ -1705,7 +1705,7 @@
         "he": "בריאות הגבר",
         "keywords": [],
         "n_questions": 20,
-        "frequency_pct": 1.9,
+        "frequency_pct": 1.89,
         "weight": 0.51
       },
       {
@@ -1714,7 +1714,7 @@
         "he": "כאב, פליאציה וסוף החיים",
         "keywords": [],
         "n_questions": 20,
-        "frequency_pct": 1.9,
+        "frequency_pct": 1.89,
         "weight": 0.51
       },
       {
@@ -1723,7 +1723,7 @@
         "he": "התמכרויות והתנהגות בריאותית",
         "keywords": [],
         "n_questions": 16,
-        "frequency_pct": 1.5,
+        "frequency_pct": 1.51,
         "weight": 0.41
       }
     ]

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "verify": "node --check src/sw-update.js && python3 scripts/check-version-sync.py && python3 scripts/check-brace-balance.py && python3 scripts/check-inline-js.py && python3 scripts/check-innerhtml.py && python3 scripts/check-innerhtml-pieces.py && cross-env HARRISON_HEBREW_BASELINE=0 node scripts/harrison-hebrew-baseline.cjs --strict && vitest run",
     "regen:derived": "node scripts/regen_derived.cjs",
     "regen:check": "node scripts/regen_derived.cjs --check",
-    "image:check": "node scripts/add-image-question.cjs --help"
+    "image:check": "node scripts/add-image-question.cjs --help",
+    "regen:cross-repo": "node scripts/regen_cross_repo_syllabus.cjs",
+    "regen:cross-repo:check": "node scripts/regen_cross_repo_syllabus.cjs --check"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.1.5",

--- a/scripts/regen_cross_repo_syllabus.cjs
+++ b/scripts/regen_cross_repo_syllabus.cjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+/**
+ * regen_cross_repo_syllabus.cjs — keep Pnimit/Mishpacha sections of
+ * syllabus_data.json in sync with the corpus manifests published by
+ * Eiasash/InternalMedicine and Eiasash/FamilyMedicine.
+ *
+ * Companion to:
+ *   - Eiasash/InternalMedicine#123  (manifest emitter + cross-repo verifier)
+ *   - Eiasash/FamilyMedicine#70     (same, Mishpacha)
+ *   - this repo's scripts/regen_derived.cjs (in-repo Geri section regen)
+ *
+ * Closes the cross-repo extension of the denominator-invalidates-all-ratios
+ * bug class (originally PR #259). This is the AUTO-FIX path of the loop:
+ * the IM/FM gate FAILS PR merges that would silently break Geri's syllabus,
+ * and THIS script is what Geri runs to absorb the new IM/FM corpus state
+ * into syllabus_data.json.
+ *
+ * Sources (in order of fallback):
+ *   1. --from-local=PATH or env IM_REPO_PATH / FM_REPO_PATH (read
+ *      $PATH/data/.corpus_manifest.json from local clones)
+ *   2. https://raw.githubusercontent.com/Eiasash/{InternalMedicine,FamilyMedicine}/main/data/.corpus_manifest.json
+ *
+ * What gets regenerated:
+ *   syllabus_data.json.Pnimit.total_questions_analyzed
+ *   syllabus_data.json.Pnimit.topics[*].n_questions
+ *   syllabus_data.json.Pnimit.topics[*].frequency_pct
+ *   syllabus_data.json.Mishpacha.{same fields}
+ *
+ * What is PRESERVED (untouched):
+ *   - Geri section (regen_derived.cjs owns it)
+ *   - weight (opaque; product-tuned)
+ *   - keywords, en, he (Geri-side authoritative)
+ *   - topic order, total_topics
+ *   - any field not explicitly in the regen list above
+ *
+ * If IM/FM manifests contain topic IDs not in the local syllabus section,
+ * or vice versa, that's a STRUCTURAL drift (new topics added, not just
+ * counts) and we FAIL — the human must reconcile topic-id namespaces.
+ *
+ * Modes:
+ *   node scripts/regen_cross_repo_syllabus.cjs           regen in place
+ *   node scripts/regen_cross_repo_syllabus.cjs --check   diff-only, exit 1 on drift
+ *   --verbose      print per-topic diff details on drift
+ *   --from-local-im=PATH / --from-local-fm=PATH    read manifests from local paths
+ *
+ * Env vars (lower precedence than CLI):
+ *   IM_REPO_PATH, FM_REPO_PATH
+ *
+ * Exit codes:
+ *   0  no drift (--check) / regen successful (default)
+ *   1  drift detected (--check) / regen failed (default)
+ *   2  unexpected error (manifest unreachable, structural drift, malformed JSON)
+ */
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+
+const ROOT = path.resolve(__dirname, '..');
+const SYL_PATH = path.join(ROOT, 'data', 'syllabus_data.json');
+
+const argv = process.argv.slice(2);
+const CHECK = argv.includes('--check');
+const VERBOSE = argv.includes('--verbose');
+function arg(flag) {
+  const found = argv.find(a => a.startsWith(flag + '='));
+  return found ? found.slice(flag.length + 1) : null;
+}
+const IM_LOCAL = arg('--from-local-im') || process.env.IM_REPO_PATH || null;
+const FM_LOCAL = arg('--from-local-fm') || process.env.FM_REPO_PATH || null;
+
+const SOURCES = {
+  Pnimit: {
+    repo: 'InternalMedicine',
+    url: 'https://raw.githubusercontent.com/Eiasash/InternalMedicine/main/data/.corpus_manifest.json',
+    local: IM_LOCAL ? path.resolve(IM_LOCAL, 'data', '.corpus_manifest.json') : null,
+  },
+  Mishpacha: {
+    repo: 'FamilyMedicine',
+    url: 'https://raw.githubusercontent.com/Eiasash/FamilyMedicine/main/data/.corpus_manifest.json',
+    local: FM_LOCAL ? path.resolve(FM_LOCAL, 'data', '.corpus_manifest.json') : null,
+  },
+};
+
+function fetchJson(url, timeoutMs = 15000) {
+  return new Promise((resolve, reject) => {
+    const req = https.get(url, { headers: { 'User-Agent': 'regen-cross-repo-syllabus/1' } }, (res) => {
+      if (res.statusCode === 404) {
+        reject(new Error(`manifest not yet published (HTTP 404 from ${url}) — has the companion PR landed?`));
+        res.resume(); return;
+      }
+      if (res.statusCode !== 200) {
+        reject(new Error(`HTTP ${res.statusCode} from ${url}`));
+        res.resume(); return;
+      }
+      let body = '';
+      res.setEncoding('utf-8');
+      res.on('data', (c) => { body += c; });
+      res.on('end', () => {
+        try { resolve(JSON.parse(body)); }
+        catch (e) { reject(new Error(`malformed JSON from ${url}: ${e.message}`)); }
+      });
+    });
+    req.on('error', reject);
+    req.setTimeout(timeoutMs, () => req.destroy(new Error(`timeout (${timeoutMs}ms) fetching ${url}`)));
+  });
+}
+
+async function loadManifest(section, source) {
+  if (source.local) {
+    if (!fs.existsSync(source.local)) {
+      throw new Error(`${section}: local manifest path does not exist: ${source.local}`);
+    }
+    console.log(`[${section}] loading from local: ${source.local}`);
+    return JSON.parse(fs.readFileSync(source.local, 'utf-8'));
+  }
+  console.log(`[${section}] fetching from ${source.url}`);
+  return fetchJson(source.url);
+}
+
+function validateManifest(section, manifest) {
+  if (manifest.schema !== 'corpus-manifest-v1') {
+    throw new Error(`${section}: unexpected manifest schema "${manifest.schema}" (expected corpus-manifest-v1)`);
+  }
+  if (typeof manifest.total_questions !== 'number' || !Array.isArray(manifest.topics)) {
+    throw new Error(`${section}: malformed manifest (missing total_questions or topics array)`);
+  }
+}
+
+/**
+ * Pure function — takes a section object + manifest, returns new section.
+ * Mutates: total_questions_analyzed, topics[*].n_questions, topics[*].frequency_pct.
+ * Preserves: topic order, all other fields. Fails on structural drift.
+ */
+function regenSection(sectionName, oldSection, manifest) {
+  const out = JSON.parse(JSON.stringify(oldSection));
+  if (!Array.isArray(out.topics)) {
+    throw new Error(`${sectionName}: existing section has no topics array`);
+  }
+  const total = manifest.total_questions;
+  const manifestById = new Map(manifest.topics.map(t => [t.id, t.n_questions]));
+
+  // Structural-drift check: every existing topic id must exist in manifest, and vice versa.
+  const sylIds = new Set(out.topics.map(t => t.id));
+  const manIds = new Set(manifest.topics.map(t => t.id));
+  const onlyInSyl = [...sylIds].filter(id => !manIds.has(id));
+  const onlyInMan = [...manIds].filter(id => !sylIds.has(id));
+  if (onlyInSyl.length || onlyInMan.length) {
+    const msg = [`${sectionName}: STRUCTURAL DRIFT (topic-id sets differ — manual reconciliation required)`];
+    if (onlyInSyl.length) msg.push(`  IDs in syllabus but not in ${SOURCES[sectionName].repo} manifest: ${onlyInSyl.join(', ')}`);
+    if (onlyInMan.length) msg.push(`  IDs in ${SOURCES[sectionName].repo} manifest but not in syllabus: ${onlyInMan.join(', ')}`);
+    throw new Error(msg.join('\n'));
+  }
+
+  out.total_questions_analyzed = total;
+  for (const topic of out.topics) {
+    const n = manifestById.get(topic.id);
+    topic.n_questions = n;
+    topic.frequency_pct = Math.round((n / total) * 100 * 100) / 100;
+  }
+  return out;
+}
+
+function diffSection(sectionName, oldSection, newSection) {
+  const diffs = [];
+  if (oldSection.total_questions_analyzed !== newSection.total_questions_analyzed) {
+    diffs.push({ field: 'total_questions_analyzed', old: oldSection.total_questions_analyzed, new: newSection.total_questions_analyzed });
+  }
+  const oldById = new Map(oldSection.topics.map(t => [t.id, t]));
+  for (const newTopic of newSection.topics) {
+    const oldTopic = oldById.get(newTopic.id);
+    if (!oldTopic) continue; // structural drift already failed earlier
+    if (oldTopic.n_questions !== newTopic.n_questions) {
+      diffs.push({ field: `topic ${newTopic.id}.n_questions`, old: oldTopic.n_questions, new: newTopic.n_questions });
+    }
+    if (oldTopic.frequency_pct !== newTopic.frequency_pct) {
+      diffs.push({ field: `topic ${newTopic.id}.frequency_pct`, old: oldTopic.frequency_pct, new: newTopic.frequency_pct });
+    }
+  }
+  return diffs;
+}
+
+async function main() {
+  const syllabus = JSON.parse(fs.readFileSync(SYL_PATH, 'utf-8'));
+
+  const updatedSyllabus = JSON.parse(JSON.stringify(syllabus));
+  const allDiffs = {};
+
+  for (const sectionName of Object.keys(SOURCES)) {
+    if (!syllabus[sectionName]) {
+      console.error(`FATAL: syllabus_data.json has no ${sectionName} section`);
+      process.exit(2);
+    }
+    let manifest;
+    try {
+      manifest = await loadManifest(sectionName, SOURCES[sectionName]);
+      validateManifest(sectionName, manifest);
+    } catch (e) {
+      console.error(`FATAL: ${sectionName}: ${e.message}`);
+      process.exit(2);
+    }
+    let newSection;
+    try {
+      newSection = regenSection(sectionName, syllabus[sectionName], manifest);
+    } catch (e) {
+      console.error(`FATAL: ${e.message}`);
+      process.exit(2);
+    }
+    const diffs = diffSection(sectionName, syllabus[sectionName], newSection);
+    allDiffs[sectionName] = diffs;
+    updatedSyllabus[sectionName] = newSection;
+  }
+
+  const totalDiffs = Object.values(allDiffs).reduce((a, d) => a + d.length, 0);
+
+  if (CHECK) {
+    if (totalDiffs === 0) {
+      console.log(`OK: Pnimit + Mishpacha sections in syllabus_data.json are in sync with IM + FM manifests.`);
+      process.exit(0);
+    }
+    console.error(`DRIFT: ${totalDiffs} field(s) in syllabus_data.json differ from IM/FM manifests:`);
+    for (const [section, diffs] of Object.entries(allDiffs)) {
+      if (diffs.length === 0) continue;
+      console.error(`  [${section}] ${diffs.length} drift(s):`);
+      const show = VERBOSE ? diffs : diffs.slice(0, 5);
+      for (const d of show) console.error(`    ${d.field}: ${d.old} → ${d.new}`);
+      if (!VERBOSE && diffs.length > 5) console.error(`    (+${diffs.length - 5} more — rerun with --verbose)`);
+    }
+    console.error(`\nRun: node scripts/regen_cross_repo_syllabus.cjs   to absorb IM/FM corpus state.`);
+    process.exit(1);
+  }
+
+  // Default mode: write
+  const out = JSON.stringify(updatedSyllabus, null, 2) + '\n';
+  fs.writeFileSync(SYL_PATH, out);
+  if (totalDiffs === 0) {
+    console.log(`No-op: Pnimit + Mishpacha already in sync (file rewritten byte-identical, normalized).`);
+  } else {
+    console.log(`Updated syllabus_data.json: ${totalDiffs} field(s) absorbed from IM/FM manifests.`);
+    for (const [section, diffs] of Object.entries(allDiffs)) {
+      if (diffs.length > 0) console.log(`  [${section}] ${diffs.length} drift(s) resolved`);
+    }
+  }
+}
+
+main().catch((e) => {
+  console.error(`FATAL: unexpected error: ${e.message}`);
+  process.exit(2);
+});

--- a/scripts/regen_cross_repo_syllabus.cjs
+++ b/scripts/regen_cross_repo_syllabus.cjs
@@ -119,11 +119,46 @@ async function loadManifest(section, source) {
 }
 
 function validateManifest(section, manifest) {
+  const errors = [];
   if (manifest.schema !== 'corpus-manifest-v1') {
-    throw new Error(`${section}: unexpected manifest schema "${manifest.schema}" (expected corpus-manifest-v1)`);
+    errors.push(`unexpected schema "${manifest.schema}" (expected corpus-manifest-v1)`);
   }
-  if (typeof manifest.total_questions !== 'number' || !Array.isArray(manifest.topics)) {
-    throw new Error(`${section}: malformed manifest (missing total_questions or topics array)`);
+  if (!Number.isInteger(manifest.total_questions) || manifest.total_questions < 0) {
+    errors.push(`total_questions must be a non-negative integer (got ${JSON.stringify(manifest.total_questions)})`);
+  }
+  if (!Array.isArray(manifest.topics)) {
+    errors.push(`topics must be an array (got ${typeof manifest.topics})`);
+  } else {
+    let sumN = 0;
+    const idsSeen = new Set();
+    for (let i = 0; i < manifest.topics.length; i++) {
+      const t = manifest.topics[i];
+      if (!t || typeof t !== 'object') {
+        errors.push(`topics[${i}] is not an object`);
+        continue;
+      }
+      if (!Number.isInteger(t.id)) {
+        errors.push(`topics[${i}].id must be integer (got ${JSON.stringify(t.id)})`);
+      } else if (idsSeen.has(t.id)) {
+        errors.push(`topics[${i}].id ${t.id} duplicated`);
+      } else {
+        idsSeen.add(t.id);
+      }
+      if (!Number.isInteger(t.n_questions) || t.n_questions < 0) {
+        errors.push(`topics[${i}].n_questions must be non-negative integer (got ${JSON.stringify(t.n_questions)})`);
+      } else {
+        sumN += t.n_questions;
+      }
+    }
+    // Sum-vs-total consistency check (sum can be ≤ total — some questions may
+    // have missing/non-integer ti and be excluded from per-topic counts in the
+    // emitter; sum > total signals a real corruption)
+    if (Number.isInteger(manifest.total_questions) && sumN > manifest.total_questions) {
+      errors.push(`sum of topic n_questions (${sumN}) exceeds total_questions (${manifest.total_questions})`);
+    }
+  }
+  if (errors.length) {
+    throw new Error(`invalid manifest:\n  - ${errors.join('\n  - ')}`);
   }
 }
 
@@ -156,7 +191,9 @@ function regenSection(sectionName, oldSection, manifest) {
   for (const topic of out.topics) {
     const n = manifestById.get(topic.id);
     topic.n_questions = n;
-    topic.frequency_pct = Math.round((n / total) * 100 * 100) / 100;
+    // Guard against total=0 (valid edge case — empty corpus). frequency_pct is
+    // undefined for empty corpus; emit 0 rather than NaN.
+    topic.frequency_pct = total > 0 ? Math.round((n / total) * 100 * 100) / 100 : 0;
   }
   return out;
 }


### PR DESCRIPTION
## Summary

Closes the **AUTO-FIX path** of the cross-repo denominator-bug loop. Companion to:

- [Eiasash/InternalMedicine#123](https://github.com/Eiasash/InternalMedicine/pull/123) — manifest emitter + Pnimit verifier (BLOCKING)
- [Eiasash/FamilyMedicine#70](https://github.com/Eiasash/FamilyMedicine/pull/70) — same for Mishpacha (BLOCKING)

The IM/FM PRs are the **detection** half (fail-closed gate blocks merges that silently break Geri's syllabus). **This** PR is the **absorption** half: when IM/FM corpora legitimately change, run `npm run regen:cross-repo` here to update Pnimit/Mishpacha sections.

## New script

`scripts/regen_cross_repo_syllabus.cjs` reads IM + FM `data/.corpus_manifest.json`, updates Pnimit + Mishpacha sections in `data/syllabus_data.json`.

Fields regenerated (per section): `total_questions_analyzed`, `topics[*].n_questions`, `topics[*].frequency_pct`.

Fields PRESERVED: Geri section (owned by `regen_derived.cjs`), `weight`, `keywords`, `en`, `he`, topic order, `total_topics`.

Fail-closed paths: HTTP 404, network timeout, malformed manifest, structural drift (topic-id sets differ — manual reconciliation needed).

## npm scripts

- `regen:cross-repo` — regen Pnimit+Mishpacha from IM/FM main (manual)
- `regen:cross-repo:check` — fail-closed drift gate (NOT wired into CI in this PR)

## Side effect: 50-field precision normalization

First dry-run found 50 drift hits — **all** `frequency_pct` rounding. Pnimit/Mishpacha were 1-decimal (`8.4`); Geri section + new regen are 2-decimal (`8.42`, matching `regen_derived.cjs` convention).

This PR normalizes Pnimit/Mishpacha to 2-decimal. All shifts within ±0.05 percentage points. **No counts changed**, only display precision.

No tests pin Pnimit/Mishpacha `frequency_pct` (Geri-section pins in `studyPlanAlgorithm.test.js` + `regenDerived.test.js` both unaffected).

## CI wiring decision

`regen:cross-repo:check` is **deliberately NOT wired into ci.yml** in this PR. It needs network AND IM/FM manifests on main. Wiring it now would 404 in CI (IM/FM PRs not merged). Follow-up PR after IM/FM merge will wire it.

## Merge order

1. `Eiasash/InternalMedicine#123`
2. `Eiasash/FamilyMedicine#70`
3. This PR
4. Follow-up: add `regen:cross-repo:check` to Geri ci.yml

## Verification

```
$ IM_REPO_PATH=... FM_REPO_PATH=... node scripts/regen_cross_repo_syllabus.cjs --check
OK: Pnimit + Mishpacha sections in syllabus_data.json are in sync with IM + FM manifests.

$ node scripts/regen_derived.cjs --check
regen_derived: no drift. All 3 derived files match canonical state.
```

Generated with Claude Opus 4.7