### PR TITLE
ci(cross-repo): wire regen:cross-repo:check into CI (post-#283 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,5 +278,15 @@ jobs:
       # ── Vitest Test Suite ──
       - name: Install test dependencies
         run: npm ci
+
+      # ── Cross-Repo Syllabus Sync (network) ──
+      # Verifies Pnimit + Mishpacha sections in syllabus_data.json match
+      # the manifests published by Eiasash/InternalMedicine and
+      # Eiasash/FamilyMedicine main. Fail-closed on network errors AND on
+      # any drift. Network step kept out of vitest (local-only) to avoid
+      # adding network latency to the test suite.
+      - name: Verify Pnimit+Mishpacha sections vs IM/FM manifests
+        run: node scripts/regen_cross_repo_syllabus.cjs --check
+
       - name: Run Vitest tests
         run: npx vitest run


### PR DESCRIPTION
## Summary

Follow-up to the cross-repo regen-gate trio merged today:

- Eiasash/InternalMedicine#123 (917a3d0) — manifest emitter + Pnimit verifier
- Eiasash/FamilyMedicine#70 (e754f07) — same for Mishpacha
- Eiasash/Geriatrics#283 (cbe9eeb) — regen_cross_repo_syllabus.cjs + precision normalize

With all three on main, the script can now successfully fetch IM/FM `data/.corpus_manifest.json` and verify Pnimit/Mishpacha sections match. Wiring the check into ci.yml closes the loop.

## What changes

Adds one CI step in `validate` job, placed after `npm ci` and before `vitest`:

```yaml
- name: Verify Pnimit+Mishpacha sections vs IM/FM manifests
  run: node scripts/regen_cross_repo_syllabus.cjs --check
```

## Why not in vitest

Vitest is local-only. The script needs network fetches to raw.githubusercontent.com. Adding it to vitest would penalize every developer's `npm test` with network latency. CI is the right home.

## Failure modes (already in script, just exposed via CI now)

- HTTP 404 → `'has the companion PR landed?'` message
- Network timeout / non-200 → exit 2
- Structural drift (topic-id sets differ) → exit 2, manual reconciliation
- Count drift → exit 1 with per-field diff

All fail-closed.

## Verified live

```
$ node scripts/regen_cross_repo_syllabus.cjs --check
[Pnimit] fetching from raw.githubusercontent.com/Eiasash/InternalMedicine/main/...
[Mishpacha] fetching from raw.githubusercontent.com/Eiasash/FamilyMedicine/main/...
OK: Pnimit + Mishpacha sections in syllabus_data.json are in sync with IM + FM manifests.
```

Generated with Claude Opus 4.7