### PR TITLE
chore(audits): section D content + UI baseline reports

### DIFF
--- a/scripts/audits/SECTION_D_REPORT.md
+++ b/scripts/audits/SECTION_D_REPORT.md
@@ -69,8 +69,13 @@ The harder problem is that questions store mixed-script content as raw strings w
 | **Unique hex colors** | 152 | High; semantic mapping would compress to ~12 |
 | **Total hex color literals** | 905 | Mostly raw, not via token |
 | **CSS color-token occurrences** | 128 | 12.4% of color usage — 87.6% migration debt |
-| **`.btn` class definitions** | 7 | Partial system exists (`.btn`, `.btn-primary`, etc.) |
-| **`.btn` class usages** | 85 | 85 token-driven buttons vs 138 inline — system is real but adoption is partial |
+| **`.btn` class definitions** | 7 | `.btn`, `.btn-primary`, etc. |
+| **Total `<button>` tags** | **182** | The real population for migration math |
+| **`<button>` with `.btn*` class** | 78 | **42.9% adoption rate** |
+| **`<button>` with inline style** | 138 | |
+| **`<button>` with both class AND inline** | 60 | Mixed — class adopted but inline overrides remain |
+| **Fully migrated (class-only)** | 18 | **Only 9.9%** — real "done" count |
+| **Inline-only (no class)** | 78 | 42.9% un-migrated |
 | **`--tap-min` definitions** | 1 | Token exists |
 | **`--tap-min` `var()` refs** | 1 | Dead-weight — never propagated to buttons |
 | **Unique padding values** | 80 | Needs base-unit normalization (4px or 8px) |

--- a/scripts/audits/SECTION_D_REPORT.md
+++ b/scripts/audits/SECTION_D_REPORT.md
@@ -1,0 +1,106 @@
+# Shlav A Mega — Section D Audit Report
+
+**Generated:** see `sectionD_report.json` / `sectionD_ui_report.json` for machine-readable.
+**Source files:** `data/questions.json` (3,823 Qs), `shlav-a-mega.html` (705.6 KB, 8,379 lines).
+**Scope:** Investigate-only. ZERO code/data mutations. Surfaces real numbers before any D-bucket PR.
+
+---
+
+## Headline numbers
+
+| Check | Count | % of total | Memory said | Verdict |
+|---|---|---|---|---|
+| **D1.** Hazzard ch 2-6 / 34 / 62 cited (EXCLUDED by P005-2026) | **217** | 5.68% | not tracked | **new finding — real content gap** |
+| **D2.** `c_accept` length-1 redundancy | 0 | 0% | — | clean, no work |
+| **D3.** `c_accept` multi-correct (length ≥ 2) | 48 | 1.26% | ~50 | matches ±2 |
+| **D4.** Missing `e_en` (English explanation) | **1,876** | 49.07% | 49% / ~1876 | exact match |
+| **D5.** `q_en` (English question) coverage | 1,947 | 50.93% | ~51% | exact match |
+| **D7.** Harrison chapters cited but not indexed | 14 chs / 99 Qs | 2.59% | 15 chs / 100 Qs | matches ±1 |
+| **D8.** RTL/LTR-mixed stems (Hebrew + Latin) | **2,969** | **77.66%** | not tracked | **typographic-hierarchy candidate pool** |
+| **D9.** `broken` flag set | 24 | 0.63% | 24 | exact match |
+| **D10.** Empty `ref` field | 80 | 2.09% | not tracked | new finding |
+
+---
+
+## D1 — Hazzard-excluded chapter orphans (217 Qs)
+
+Excluded chapters per P005-2026: **2, 3, 4, 5, 6, 34, 62**. These questions cite material that is no longer in scope. Two paths forward:
+
+1. Re-`ref` to a valid in-scope chapter (preferred where the question topic is still in scope).
+2. Add a `_syllabus_orphan: true` flag and exclude from the default question pool (preferred where topic is genuinely out of scope).
+
+Chapter histogram of orphan citations is in `sectionD_report.json` → `D1_syllabus_orphan_hazzard_excluded.excluded_chs_with_cites`.
+
+## D4 — English-explanation gap (1,876 Qs)
+
+49.07% of questions have no `e_en`. This is a content-generation task. Cost-bounded batch via `/api/claude` proxy is feasible:
+
+- **Estimate:** 1,876 questions × ~600 input tokens × ~400 output tokens ≈ 1.9M total tokens. At Sonnet 4.5 pricing (~$3/M input + $15/M output) → roughly **$15–25 total**. Cheap.
+- **Risk:** Memory rule R6b — rescued/AI-generated medical content can fabricate citations. Any batch run must be sample-validated against Hazzard 8e / Harrison 22e source text, not just face-validated. Recommend: pilot 50 Qs → manual spot-check 10 → tune prompt → proceed.
+
+## D7 — Harrison missing chapters (99 Qs across 14 chapters)
+
+Memory listed 15 chapters; audit finds 14 in the cited set. Either one was added since the memory update or the regex caught one differently. Full missing list in `sectionD_report.json` → `D7_harrison_chapter_gap.missing_chapters`. Graceful UX already shipped via #285; content fill needs textbook input from Eias (one chapter at a time).
+
+## D8 — RTL/LTR-mix typographic pool (2,969 Qs)
+
+77.66% of questions mix Hebrew and Latin scripts in the stem. Font-stack inspection of `shlav-a-mega.html`: Inter and Heebo both loaded. The typographic-hierarchy fix is one CSS rule:
+
+```css
+/* Wrap Latin runs inside Hebrew with Inter, leave Hebrew on Heebo */
+[lang="he"] :where(en, [lang="en"], code, .lat) { font-family: 'Inter', system-ui, sans-serif; }
+```
+
+The harder problem is that questions store mixed-script content as raw strings without `<span lang="en">` wrapping. Two options:
+
+- **Cheap:** CSS `unicode-bidi: plaintext` + a font stack that lists Inter *before* Heebo — browser picks per-glyph. Risk: Hebrew metric mismatch in mixed lines.
+- **Correct:** Render-time pass that wraps Latin runs in `<span lang="en">`. ~10 lines of JS. Recommended.
+
+---
+
+## UI / CSS surface (from `sectionD_ui_report.json`)
+
+| Metric | Value | Interpretation |
+|---|---|---|
+| **File size** | 705.6 KB | Single-file PWA |
+| **Inline-styled `<button>` tags** | 138 | Migration target for `.btn` class system |
+| **Total `style=` attributes** | 789 | Broad inline-style use |
+| **`onclick` handlers** | 222 | Acceptable inline-handler pattern |
+| **Unique hex colors** | 152 | High; semantic mapping would compress to ~12 |
+| **Total hex color literals** | 905 | Mostly raw, not via token |
+| **CSS color-token occurrences** | 128 | 12.4% of color usage — 87.6% migration debt |
+| **`.btn` class definitions** | 7 | Partial system exists (`.btn`, `.btn-primary`, etc.) |
+| **`.btn` class usages** | 85 | 85 token-driven buttons vs 138 inline — system is real but adoption is partial |
+| **`--tap-min` definitions** | 1 | Token exists |
+| **`--tap-min` `var()` refs** | 1 | Dead-weight — never propagated to buttons |
+| **Unique padding values** | 80 | Needs base-unit normalization (4px or 8px) |
+| **Font sizes under 12px (distinct)** | 7 | Readability risk on phone — top offenders in JSON |
+| **Native `confirm()`** | 2 | Inline-modal-replacement candidates |
+| **Native `alert()`** | 0 | Clean |
+| **Top 5 raw colors** | `#fff` 92, `#dc2626` 78, `#059669` 59, `#e2e8f0` 32, `#d97706` 28 | Map cleanly to fg / danger / good / border / warn |
+
+---
+
+## Recommended ship slices (Section D)
+
+Per the captain-mode directive — **no mega-PRs, one slice per PR**:
+
+1. **PR S1 (this PR):** audit scripts + reports. **Zero behavior change.** ← *you are here*
+2. **PR S2:** quiz Check / Next button migration to `.btn` / `.btn-primary` (hot-path, daily-visible). Remove ~10 inline styles, no other changes.
+3. **PR S3:** mixed-script typographic fix — CSS rule + (optional) render-time `<span lang="en">` wrapper for Latin runs. Visible on every screen.
+4. **PR S4:** quiz-card color migration (semantic tokens for top 5 colors only). Smallest visible color slice.
+5. **PR S5 (data, separate cycle):** D1 syllabus-orphan resolution — 217 Qs re-ref'd or flagged.
+6. **PR S6 (data, separate cycle):** D4 e_en pilot batch (50 Qs) → expand only after spot-check.
+
+Each slice ships independently, self-merges per CLAUDE.md authority.
+
+---
+
+## Reproducibility
+
+```bash
+node scripts/audits/sectionD_content_audit.cjs   # writes sectionD_report.json
+node scripts/audits/sectionD_ui_audit.cjs        # writes sectionD_ui_report.json
+```
+
+Both are deterministic, run in <1s, zero deps.

--- a/scripts/audits/sectionD_content_audit.cjs
+++ b/scripts/audits/sectionD_content_audit.cjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+/**
+ * Section D content-quality audit — produces a report; ZERO mutations.
+ * Surfaces real prevalence numbers before any UI/data PR ships.
+ *
+ * Checks:
+ *  D1. Syllabus-orphan refs: Hazzard ch 2-6, 34, 62 are EXCLUDED per P005-2026
+ *  D2. c_accept redundancy: length 1 entries (functionally equivalent to plain `c`)
+ *  D3. c_accept coverage: questions with c_accept (multi-correct prevalence)
+ *  D4. e_en (English explanation) coverage gap
+ *  D5. q_en (English question) coverage
+ *  D6. Hazzard chapter histogram (which chapters get cited most)
+ *  D7. Harrison chapter histogram (gap with harrison_chapters.json keys)
+ *  D8. RTL/LTR mix: questions with embedded Latin characters in Hebrew stems
+ *  D9. broken-flag (tis) usage — sanity check on 24 quarantined number from memory
+ *  D10. ref-empty questions
+ */
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const questions = JSON.parse(fs.readFileSync(path.join(ROOT, 'data/questions.json'), 'utf8'));
+const harrisonChapters = JSON.parse(fs.readFileSync(path.join(ROOT, 'harrison_chapters.json'), 'utf8'));
+const hazzardChapters = JSON.parse(fs.readFileSync(path.join(ROOT, 'data/hazzard_chapters.json'), 'utf8'));
+
+const HAZZARD_EXCLUDED = new Set([2, 3, 4, 5, 6, 34, 62]);
+const total = questions.length;
+
+const rxHazzard = /Hazzard.*?(?:Ch|chapter|פרק)\s*(\d+)/i;
+const rxHarrison = /Harrison.*?(?:Ch|chapter|פרק)\s*(\d+)/i;
+const rxHebrew = /[\u0590-\u05FF]/;
+const rxLatin = /[A-Za-z]/;
+
+let syllabusOrphan = [];
+let cAcceptRedundant = [];
+let cAcceptMulti = 0;
+let withCAccept = 0;
+let withQEn = 0;
+let withEEn = 0;  // explanations stored separately, check explanations.json
+let hazzardCites = {};
+let harrisonCites = {};
+let mixedRTL = 0;
+let refEmpty = 0;
+let brokenFlag = 0;
+let cAcceptLen1 = [];
+
+// Load explanations.json for e_en check
+let explanations = {};
+try {
+  explanations = JSON.parse(fs.readFileSync(path.join(ROOT, 'data/explanations.json'), 'utf8'));
+} catch (e) {
+  console.error('explanations.json missing or invalid');
+}
+
+questions.forEach((q, idx) => {
+  // D10: ref-empty
+  if (!q.ref || !q.ref.trim()) refEmpty++;
+
+  // D1: syllabus-orphan
+  if (q.ref) {
+    const m = q.ref.match(rxHazzard);
+    if (m) {
+      const ch = parseInt(m[1], 10);
+      hazzardCites[ch] = (hazzardCites[ch] || 0) + 1;
+      if (HAZZARD_EXCLUDED.has(ch)) {
+        syllabusOrphan.push({ idx, ti: q.ti, ref: q.ref, ch });
+      }
+    }
+    const h = q.ref.match(rxHarrison);
+    if (h) {
+      const ch = parseInt(h[1], 10);
+      harrisonCites[ch] = (harrisonCites[ch] || 0) + 1;
+    }
+  }
+
+  // D2/D3: c_accept
+  if (Array.isArray(q.c_accept)) {
+    withCAccept++;
+    if (q.c_accept.length === 1) {
+      cAcceptLen1.push({ idx, ti: q.ti, c_accept: q.c_accept, c: q.c });
+    } else if (q.c_accept.length > 1) {
+      cAcceptMulti++;
+    }
+  }
+
+  // D5: q_en
+  if (q.q_en && q.q_en.trim()) withQEn++;
+
+  // D8: RTL/LTR mix in q
+  if (q.q && rxHebrew.test(q.q) && rxLatin.test(q.q)) mixedRTL++;
+
+  // D9: broken flag
+  if (q.broken || q.broken_flag) brokenFlag++;
+});
+
+// D4: e_en lives INSIDE question objects (verified — 1947 / 3823 = 50.93%)
+questions.forEach((q) => {
+  if (q.e_en && String(q.e_en).trim()) withEEn++;
+});
+
+const out = {
+  generated_at: new Date().toISOString(),
+  total_questions: total,
+  harrison_chapters_indexed: Object.keys(harrisonChapters).length,
+  hazzard_chapters_indexed: Object.keys(hazzardChapters).length,
+  explanations_count: Array.isArray(explanations) ? explanations.length : Object.keys(explanations).length,
+
+  D1_syllabus_orphan_hazzard_excluded: {
+    count: syllabusOrphan.length,
+    pct: ((syllabusOrphan.length / total) * 100).toFixed(2) + '%',
+    excluded_chs_with_cites: [...new Set(syllabusOrphan.map(s => s.ch))].sort((a,b) => a-b),
+    sample: syllabusOrphan.slice(0, 5),
+  },
+
+  D2_cAccept_redundant_length_1: {
+    count: cAcceptLen1.length,
+    pct: ((cAcceptLen1.length / total) * 100).toFixed(2) + '%',
+    sample: cAcceptLen1.slice(0, 5),
+    note: 'c_accept with single element is functionally identical to just `c` — remove or merge',
+  },
+
+  D3_cAccept_multi_correct_actual: {
+    questions_with_cAccept_field: withCAccept,
+    multi_correct_pct: ((cAcceptMulti / total) * 100).toFixed(2) + '%',
+    multi_count: cAcceptMulti,
+    note: 'Memory said 50 still-multi-accept. Actual count is ' + cAcceptMulti,
+  },
+
+  D4_eEn_coverage_gap: {
+    with_e_en: withEEn,
+    without_e_en: total - withEEn,
+    coverage_pct: ((withEEn / total) * 100).toFixed(2) + '%',
+    gap_pct: (((total - withEEn) / total) * 100).toFixed(2) + '%',
+    note: 'Memory said 49% lack e_en (~1876). Actual gap: ' + (total - withEEn),
+  },
+
+  D5_qEn_coverage: {
+    with_q_en: withQEn,
+    coverage_pct: ((withQEn / total) * 100).toFixed(2) + '%',
+  },
+
+  D6_hazzard_top_chapters: Object.entries(hazzardCites)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 15)
+    .map(([ch, n]) => ({ ch: parseInt(ch), n })),
+
+  D7_harrison_chapter_gap: (() => {
+    const cited = Object.keys(harrisonCites).map(Number).sort((a, b) => a - b);
+    const indexed = new Set(Object.keys(harrisonChapters).map(Number));
+    const missing = cited.filter(c => !indexed.has(c));
+    const missingWithCounts = missing.map(c => ({ ch: c, n: harrisonCites[c] }));
+    const totalAffected = missing.reduce((s, c) => s + harrisonCites[c], 0);
+    return {
+      chapters_cited: cited.length,
+      chapters_indexed: indexed.size,
+      missing_chapter_count: missing.length,
+      missing_chapters: missing,
+      questions_affected: totalAffected,
+      pct_questions_affected: ((totalAffected / total) * 100).toFixed(2) + '%',
+      missing_with_counts: missingWithCounts,
+    };
+  })(),
+
+  D8_rtl_ltr_mix: {
+    count: mixedRTL,
+    pct: ((mixedRTL / total) * 100).toFixed(2) + '%',
+    note: 'Stems with both Hebrew and Latin chars — typographic-hierarchy candidates',
+  },
+
+  D9_broken_flag: {
+    count: brokenFlag,
+    note: 'Memory said 24 quarantined. Actual count: ' + brokenFlag,
+  },
+
+  D10_ref_empty: {
+    count: refEmpty,
+    pct: ((refEmpty / total) * 100).toFixed(2) + '%',
+  },
+};
+
+const reportPath = path.join(ROOT, 'scripts/audits/sectionD_report.json');
+fs.writeFileSync(reportPath, JSON.stringify(out, null, 2));
+console.log('Report written:', reportPath);
+console.log('\n=== HEADLINES ===');
+console.log('Total Qs:', total);
+console.log('D1 Hazzard-excluded-ch orphans:', out.D1_syllabus_orphan_hazzard_excluded.count, '(' + out.D1_syllabus_orphan_hazzard_excluded.pct + ')');
+console.log('D2 c_accept length-1 redundant:', out.D2_cAccept_redundant_length_1.count);
+console.log('D3 actual multi-correct c_accept:', out.D3_cAccept_multi_correct_actual.multi_count);
+console.log('D4 e_en gap:', out.D4_eEn_coverage_gap.without_e_en, '(' + out.D4_eEn_coverage_gap.gap_pct + ')');
+console.log('D5 q_en coverage:', out.D5_qEn_coverage.coverage_pct);
+console.log('D7 Harrison missing chapters affecting Qs:', out.D7_harrison_chapter_gap.missing_chapter_count, 'chapters,', out.D7_harrison_chapter_gap.questions_affected, 'Qs');
+console.log('D8 RTL/LTR mix:', out.D8_rtl_ltr_mix.count, '(' + out.D8_rtl_ltr_mix.pct + ')');
+console.log('D9 broken-flag:', out.D9_broken_flag.count);
+console.log('D10 ref-empty:', out.D10_ref_empty.count);

--- a/scripts/audits/sectionD_report.json
+++ b/scripts/audits/sectionD_report.json
@@ -1,0 +1,228 @@
+{
+  "generated_at": "2026-05-26T16:27:45.113Z",
+  "total_questions": 3823,
+  "harrison_chapters_indexed": 69,
+  "hazzard_chapters_indexed": 108,
+  "explanations_count": 3823,
+  "D1_syllabus_orphan_hazzard_excluded": {
+    "count": 217,
+    "pct": "5.68%",
+    "excluded_chs_with_cites": [
+      2,
+      3,
+      34,
+      62
+    ],
+    "sample": [
+      {
+        "idx": 10,
+        "ti": 27,
+        "ref": "Hazzard Ch 3 — IMMUNOLOGY AND INFLAMMATION· Harrison Ch 295 — Approach to the Patient with Disease of the Respiratory System",
+        "ch": 3
+      },
+      {
+        "idx": 14,
+        "ti": 27,
+        "ref": "Hazzard Ch 3 — IMMUNOLOGY AND INFLAMMATION · Harrison Ch 315 — Sepsis and Septic Shock",
+        "ch": 3
+      },
+      {
+        "idx": 34,
+        "ti": 27,
+        "ref": "Hazzard Ch 3 — IMMUNOLOGY AND INFLAMMATION · Harrison Ch 315 — Sepsis and Septic Shock",
+        "ch": 3
+      },
+      {
+        "idx": 52,
+        "ti": 26,
+        "ref": "Hazzard Ch 3 — IMMUNOLOGY AND INFLAMMATION · Harrison Ch 315 — Sepsis and Septic Shock",
+        "ch": 3
+      },
+      {
+        "idx": 55,
+        "ti": 27,
+        "ref": "Hazzard Ch 3 — IMMUNOLOGY AND INFLAMMATION· Harrison Ch 243 — Approach to the Patient with Possible Cardiovascular Disease",
+        "ch": 3
+      }
+    ]
+  },
+  "D2_cAccept_redundant_length_1": {
+    "count": 0,
+    "pct": "0.00%",
+    "sample": [],
+    "note": "c_accept with single element is functionally identical to just `c` — remove or merge"
+  },
+  "D3_cAccept_multi_correct_actual": {
+    "questions_with_cAccept_field": 48,
+    "multi_correct_pct": "1.26%",
+    "multi_count": 48,
+    "note": "Memory said 50 still-multi-accept. Actual count is 48"
+  },
+  "D4_eEn_coverage_gap": {
+    "with_e_en": 1947,
+    "without_e_en": 1876,
+    "coverage_pct": "50.93%",
+    "gap_pct": "49.07%",
+    "note": "Memory said 49% lack e_en (~1876). Actual gap: 1876"
+  },
+  "D5_qEn_coverage": {
+    "with_q_en": 1947,
+    "coverage_pct": "50.93%"
+  },
+  "D6_hazzard_top_chapters": [
+    {
+      "ch": 22,
+      "n": 293
+    },
+    {
+      "ch": 58,
+      "n": 161
+    },
+    {
+      "ch": 3,
+      "n": 135
+    },
+    {
+      "ch": 7,
+      "n": 116
+    },
+    {
+      "ch": 59,
+      "n": 112
+    },
+    {
+      "ch": 67,
+      "n": 109
+    },
+    {
+      "ch": 72,
+      "n": 109
+    },
+    {
+      "ch": 68,
+      "n": 93
+    },
+    {
+      "ch": 61,
+      "n": 92
+    },
+    {
+      "ch": 43,
+      "n": 88
+    },
+    {
+      "ch": 40,
+      "n": 81
+    },
+    {
+      "ch": 47,
+      "n": 78
+    },
+    {
+      "ch": 83,
+      "n": 72
+    },
+    {
+      "ch": 27,
+      "n": 71
+    },
+    {
+      "ch": 1,
+      "n": 70
+    }
+  ],
+  "D7_harrison_chapter_gap": {
+    "chapters_cited": 49,
+    "chapters_indexed": 69,
+    "missing_chapter_count": 14,
+    "missing_chapters": [
+      13,
+      23,
+      81,
+      83,
+      84,
+      85,
+      86,
+      87,
+      92,
+      98,
+      116,
+      131,
+      180,
+      284
+    ],
+    "questions_affected": 99,
+    "pct_questions_affected": "2.59%",
+    "missing_with_counts": [
+      {
+        "ch": 13,
+        "n": 1
+      },
+      {
+        "ch": 23,
+        "n": 1
+      },
+      {
+        "ch": 81,
+        "n": 18
+      },
+      {
+        "ch": 83,
+        "n": 19
+      },
+      {
+        "ch": 84,
+        "n": 13
+      },
+      {
+        "ch": 85,
+        "n": 1
+      },
+      {
+        "ch": 86,
+        "n": 22
+      },
+      {
+        "ch": 87,
+        "n": 1
+      },
+      {
+        "ch": 92,
+        "n": 17
+      },
+      {
+        "ch": 98,
+        "n": 2
+      },
+      {
+        "ch": 116,
+        "n": 1
+      },
+      {
+        "ch": 131,
+        "n": 1
+      },
+      {
+        "ch": 180,
+        "n": 1
+      },
+      {
+        "ch": 284,
+        "n": 1
+      }
+    ]
+  },
+  "D8_rtl_ltr_mix": {
+    "count": 2969,
+    "pct": "77.66%",
+    "note": "Stems with both Hebrew and Latin chars — typographic-hierarchy candidates"
+  },
+  "D9_broken_flag": {
+    "count": 24,
+    "note": "Memory said 24 quarantined. Actual count: 24"
+  },
+  "D10_ref_empty": {
+    "count": 80,
+    "pct": "2.09%"
+  }
+}

--- a/scripts/audits/sectionD_ui_audit.cjs
+++ b/scripts/audits/sectionD_ui_audit.cjs
@@ -66,7 +66,41 @@ const smallFonts = Object.entries(sizes).filter(([_, v]) => v.px < 12).sort((a, 
 
 // === btn class system check ===
 const hasBtnClass = (html.match(/\.btn(?:-[a-z]+)?\s*\{/g) || []).length;
-const usesBtnClass = (html.match(/class\s*=\s*["'][^"']*\bbtn(?:-[a-z]+)?\b[^"']*["']/g) || []).length;
+
+// P2 fix (Codex review on PR #286): the prior regex
+//   /class\s*=\s*["'][^"']*\bbtn(?:-[a-z]+)?\b[^"']*["']/g
+// matched any `class="...btn..."` string in the source — including JS
+// template literals, comments, and tooltip strings — so the count was
+// inflated. Restrict to `class=` attributes inside actual <button> tags.
+// Same regex pattern but anchored on <button ...> tag context, captured
+// across attribute order to handle both `<button class="..." onclick="...">`
+// and `<button onclick="..." class="...">`.
+const buttonsWithBtnClass = (() => {
+  const buttonRx = /<button\b[^>]*>/gi;
+  const classBtnRx = /class\s*=\s*["'][^"']*\bbtn(?:-[a-z]+)?\b[^"']*["']/i;
+  let count = 0;
+  let m;
+  while ((m = buttonRx.exec(html)) !== null) {
+    if (classBtnRx.test(m[0])) count++;
+  }
+  return count;
+})();
+// Buttons that have BOTH a btn* class AND inline style — overlap set,
+// used to compute the migration-debt percentage without double-counting.
+const buttonsBothClassAndInline = (() => {
+  const buttonRx = /<button\b[^>]*>/gi;
+  const classBtnRx = /class\s*=\s*["'][^"']*\bbtn(?:-[a-z]+)?\b[^"']*["']/i;
+  const inlineStyleRx = /\bstyle\s*=\s*["']/i;
+  let count = 0;
+  let m;
+  while ((m = buttonRx.exec(html)) !== null) {
+    if (classBtnRx.test(m[0]) && inlineStyleRx.test(m[0])) count++;
+  }
+  return count;
+})();
+// Legacy raw-text count, kept for diagnostic only — surfaces the gap
+// between source-text matches and real button-tag matches.
+const rawClassBtnTextMatches = (html.match(/class\s*=\s*["'][^"']*\bbtn(?:-[a-z]+)?\b[^"']*["']/g) || []).length;
 
 // === Touch-target audit: buttons with explicit min-height ===
 const minHeightInButtons = (html.match(/<button[^>]*min-height/g) || []).length;
@@ -108,9 +142,32 @@ const out = {
   },
   button_class_system: {
     btn_class_definitions: hasBtnClass,
-    btn_class_usages: usesBtnClass,
-    inline_styled_buttons: buttonInline.length,
-    migration_pct_if_class_exists: hasBtnClass > 0 ? ((usesBtnClass / (usesBtnClass + buttonInline.length)) * 100).toFixed(1) + '%' : 'N/A — no .btn class defined',
+    // Real-population counts (Codex review fix: was source-text scan before):
+    button_tags_total: (html.match(/<button\b/g) || []).length,
+    button_tags_with_btn_class: buttonsWithBtnClass,
+    button_tags_with_inline_style: buttonInline.length,
+    button_tags_with_both: buttonsBothClassAndInline,
+    // Non-overlapping migration percentages:
+    //   adoption: share of <button> tags that have at least one btn* class
+    //   class_only: share that have btn* class AND no inline style (fully migrated)
+    //   inline_only: share that have inline style AND no btn* class (un-migrated)
+    btn_class_adoption_pct: (() => {
+      const total = (html.match(/<button\b/g) || []).length;
+      return total > 0 ? ((buttonsWithBtnClass / total) * 100).toFixed(1) + '%' : 'N/A';
+    })(),
+    fully_migrated_pct: (() => {
+      const total = (html.match(/<button\b/g) || []).length;
+      const fullyMigrated = buttonsWithBtnClass - buttonsBothClassAndInline;
+      return total > 0 ? ((fullyMigrated / total) * 100).toFixed(1) + '%' : 'N/A';
+    })(),
+    inline_only_pct: (() => {
+      const total = (html.match(/<button\b/g) || []).length;
+      const inlineOnly = buttonInline.length - buttonsBothClassAndInline;
+      return total > 0 ? ((inlineOnly / total) * 100).toFixed(1) + '%' : 'N/A';
+    })(),
+    // Diagnostic only — gap between raw text scan and real-tag scan:
+    raw_class_btn_text_matches: rawClassBtnTextMatches,
+    raw_minus_real: rawClassBtnTextMatches - buttonsWithBtnClass,
   },
   padding_distribution: {
     unique_padding_values: Object.keys(padValues).length,
@@ -139,7 +196,7 @@ console.log('Unique hex colors:', out.hex_color_usage.unique_colors, '/ total oc
 console.log('Top 5 colors:', out.hex_color_usage.top_20.slice(0, 5).map(c => `${c.color}=${c.count}`).join(' '));
 console.log('Semantic token usages total:', out.semantic_token_usage.total);
 console.log('--tap-min defined:', out.tap_target.tap_min_definitions, '/ var() references:', out.tap_target.tap_min_var_references);
-console.log('.btn class system:', hasBtnClass > 0 ? `${hasBtnClass} defs / ${usesBtnClass} usages` : 'NOT DEFINED');
+console.log('.btn class system:', hasBtnClass > 0 ? `${hasBtnClass} defs / ${buttonsWithBtnClass} button-tags-w-class (of ${(html.match(/<button\b/g) || []).length} total <button>)` : 'NOT DEFINED');
 console.log('Unique padding values:', out.padding_distribution.unique_padding_values);
 console.log('Distinct font sizes <12px:', out.font_size_below_12px.distinct);
 console.log('Native confirm():', out.destructive_native_dialogs.confirm_calls, 'alert():', out.destructive_native_dialogs.alert_calls);

--- a/scripts/audits/sectionD_ui_audit.cjs
+++ b/scripts/audits/sectionD_ui_audit.cjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * Section D UI/CSS audit on shlav-a-mega.html. ZERO mutations.
+ * Surfaces real numbers before button-system / color-system / spacing PRs.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const HTML_PATH = path.join(ROOT, 'shlav-a-mega.html');
+const html = fs.readFileSync(HTML_PATH, 'utf8');
+const lines = html.split('\n');
+
+// === Inline style audit ===
+const inlineStyleRx = /style\s*=\s*["'][^"']*["']/g;
+const inlineStyles = html.match(inlineStyleRx) || [];
+
+// Inline <button> tags with style=
+const buttonInlineStyleRx = /<button[^>]*\bstyle\s*=\s*["'][^"']*["'][^>]*>/g;
+const buttonInline = html.match(buttonInlineStyleRx) || [];
+
+// onclick handlers
+const onclickRx = /\bonclick\s*=\s*["'][^"']*["']/g;
+const onclicks = html.match(onclickRx) || [];
+
+// === Color hex audit ===
+const hexColorRx = /#[0-9a-fA-F]{3,8}\b/g;
+const hexColors = html.match(hexColorRx) || [];
+const hexColorCounts = {};
+hexColors.forEach(c => { hexColorCounts[c.toLowerCase()] = (hexColorCounts[c.toLowerCase()] || 0) + 1; });
+const topColors = Object.entries(hexColorCounts).sort((a, b) => b[1] - a[1]).slice(0, 20);
+
+// === Semantic-token usage ===
+const semTokens = ['--danger', '--good', '--info', '--err', '--ok', '--success', '--warn', '--app-primary', '--app-accent', '--red-fg', '--red-bg', '--green-fg', '--green-bg', '--yellow-fg', '--yellow-bg', '--blue-fg', '--blue-bg'];
+const semUsage = {};
+semTokens.forEach(t => {
+  const matches = html.match(new RegExp(`var\\(${t}\\)`, 'g')) || [];
+  semUsage[t] = matches.length;
+});
+
+// --tap-min usage
+const tapMinDef = (html.match(/--tap-min\s*:\s*\d+px/g) || []).length;
+const tapMinRef = (html.match(/var\(--tap-min\)/g) || []).length;
+
+// === Padding ad-hoc values ===
+const paddingRx = /padding\s*:\s*([^;"]+)/g;
+const padValues = {};
+let m;
+while ((m = paddingRx.exec(html)) !== null) {
+  const v = m[1].trim();
+  padValues[v] = (padValues[v] || 0) + 1;
+}
+const topPaddings = Object.entries(padValues).sort((a, b) => b[1] - a[1]).slice(0, 15);
+
+// === Font-size audit (small fonts) ===
+const fontSizeRx = /font-size\s*:\s*(\d+(?:\.\d+)?)(px|rem|em)/g;
+const sizes = {};
+let f;
+while ((f = fontSizeRx.exec(html)) !== null) {
+  const px = f[2] === 'px' ? parseFloat(f[1]) : (f[2] === 'rem' ? parseFloat(f[1]) * 16 : parseFloat(f[1]) * 16);
+  const key = `${f[1]}${f[2]}`;
+  sizes[key] = sizes[key] || { count: 0, px };
+  sizes[key].count++;
+}
+const smallFonts = Object.entries(sizes).filter(([_, v]) => v.px < 12).sort((a, b) => b[1].count - a[1].count);
+
+// === btn class system check ===
+const hasBtnClass = (html.match(/\.btn(?:-[a-z]+)?\s*\{/g) || []).length;
+const usesBtnClass = (html.match(/class\s*=\s*["'][^"']*\bbtn(?:-[a-z]+)?\b[^"']*["']/g) || []).length;
+
+// === Touch-target audit: buttons with explicit min-height ===
+const minHeightInButtons = (html.match(/<button[^>]*min-height/g) || []).length;
+
+// === confirm() / alert() calls ===
+const confirmCalls = (html.match(/\bconfirm\s*\(/g) || []).length;
+const alertCalls = (html.match(/\balert\s*\(/g) || []).length;
+
+// === Inter / Heebo font usage ===
+const interImport = html.includes('Inter') ? 'loaded' : 'NOT loaded';
+const heeboImport = html.includes('Heebo') ? 'loaded' : 'NOT loaded';
+const langAttrUsage = (html.match(/lang\s*=\s*["'](en|he)["']/g) || []).length;
+
+const out = {
+  generated_at: new Date().toISOString(),
+  file: 'shlav-a-mega.html',
+  file_size_bytes: Buffer.byteLength(html, 'utf8'),
+  line_count: lines.length,
+
+  inline_styles_total: inlineStyles.length,
+  inline_styled_buttons: buttonInline.length,
+  onclick_handlers: onclicks.length,
+
+  hex_color_usage: {
+    total_hex_literals: hexColors.length,
+    unique_colors: Object.keys(hexColorCounts).length,
+    top_20: topColors.map(([c, n]) => ({ color: c, count: n })),
+  },
+  semantic_token_usage: {
+    by_token: semUsage,
+    total: Object.values(semUsage).reduce((a, b) => a + b, 0),
+    note: 'Compare semantic-token usage vs raw hex usage — ratio reflects migration debt',
+  },
+  tap_target: {
+    tap_min_definitions: tapMinDef,
+    tap_min_var_references: tapMinRef,
+    buttons_with_min_height: minHeightInButtons,
+    note: '--tap-min token exists but is largely unreferenced inside <button> tags',
+  },
+  button_class_system: {
+    btn_class_definitions: hasBtnClass,
+    btn_class_usages: usesBtnClass,
+    inline_styled_buttons: buttonInline.length,
+    migration_pct_if_class_exists: hasBtnClass > 0 ? ((usesBtnClass / (usesBtnClass + buttonInline.length)) * 100).toFixed(1) + '%' : 'N/A — no .btn class defined',
+  },
+  padding_distribution: {
+    unique_padding_values: Object.keys(padValues).length,
+    top_15: topPaddings.map(([v, n]) => ({ value: v, count: n })),
+  },
+  font_size_below_12px: {
+    distinct: smallFonts.length,
+    breakdown: smallFonts.slice(0, 10).map(([k, v]) => ({ size: k, count: v.count })),
+  },
+  destructive_native_dialogs: {
+    confirm_calls: confirmCalls,
+    alert_calls: alertCalls,
+  },
+  fonts: { inter: interImport, heebo: heeboImport, lang_attribute_usages: langAttrUsage },
+};
+
+const reportPath = path.join(ROOT, 'scripts/audits/sectionD_ui_report.json');
+fs.writeFileSync(reportPath, JSON.stringify(out, null, 2));
+console.log('UI report written:', reportPath);
+console.log('\n=== UI HEADLINES ===');
+console.log('File size:', (out.file_size_bytes / 1024).toFixed(1), 'KB,', out.line_count, 'lines');
+console.log('Inline-styled <button> tags:', out.inline_styled_buttons);
+console.log('Total inline style= attrs:', out.inline_styles_total);
+console.log('onclick handlers:', out.onclick_handlers);
+console.log('Unique hex colors:', out.hex_color_usage.unique_colors, '/ total occurrences:', out.hex_color_usage.total_hex_literals);
+console.log('Top 5 colors:', out.hex_color_usage.top_20.slice(0, 5).map(c => `${c.color}=${c.count}`).join(' '));
+console.log('Semantic token usages total:', out.semantic_token_usage.total);
+console.log('--tap-min defined:', out.tap_target.tap_min_definitions, '/ var() references:', out.tap_target.tap_min_var_references);
+console.log('.btn class system:', hasBtnClass > 0 ? `${hasBtnClass} defs / ${usesBtnClass} usages` : 'NOT DEFINED');
+console.log('Unique padding values:', out.padding_distribution.unique_padding_values);
+console.log('Distinct font sizes <12px:', out.font_size_below_12px.distinct);
+console.log('Native confirm():', out.destructive_native_dialogs.confirm_calls, 'alert():', out.destructive_native_dialogs.alert_calls);

--- a/scripts/audits/sectionD_ui_report.json
+++ b/scripts/audits/sectionD_ui_report.json
@@ -1,0 +1,237 @@
+{
+  "generated_at": "2026-05-26T16:29:02.531Z",
+  "file": "shlav-a-mega.html",
+  "file_size_bytes": 722560,
+  "line_count": 8379,
+  "inline_styles_total": 789,
+  "inline_styled_buttons": 138,
+  "onclick_handlers": 222,
+  "hex_color_usage": {
+    "total_hex_literals": 905,
+    "unique_colors": 152,
+    "top_20": [
+      {
+        "color": "#fff",
+        "count": 92
+      },
+      {
+        "color": "#dc2626",
+        "count": 78
+      },
+      {
+        "color": "#059669",
+        "count": 59
+      },
+      {
+        "color": "#e2e8f0",
+        "count": 32
+      },
+      {
+        "color": "#d97706",
+        "count": 28
+      },
+      {
+        "color": "#1e293b",
+        "count": 23
+      },
+      {
+        "color": "#0f172a",
+        "count": 21
+      },
+      {
+        "color": "#334155",
+        "count": 21
+      },
+      {
+        "color": "#7c3aed",
+        "count": 21
+      },
+      {
+        "color": "#f59e0b",
+        "count": 20
+      },
+      {
+        "color": "#3b82f6",
+        "count": 18
+      },
+      {
+        "color": "#ecfdf5",
+        "count": 16
+      },
+      {
+        "color": "#64748b",
+        "count": 13
+      },
+      {
+        "color": "#fef2f2",
+        "count": 13
+      },
+      {
+        "color": "#0891b2",
+        "count": 13
+      },
+      {
+        "color": "#10b981",
+        "count": 12
+      },
+      {
+        "color": "#92400e",
+        "count": 12
+      },
+      {
+        "color": "#ef4444",
+        "count": 11
+      },
+      {
+        "color": "#991b1b",
+        "count": 11
+      },
+      {
+        "color": "#dcfce7",
+        "count": 10
+      }
+    ]
+  },
+  "semantic_token_usage": {
+    "by_token": {
+      "--danger": 0,
+      "--good": 0,
+      "--info": 0,
+      "--err": 0,
+      "--ok": 0,
+      "--success": 0,
+      "--warn": 0,
+      "--app-primary": 17,
+      "--app-accent": 0,
+      "--red-fg": 11,
+      "--red-bg": 20,
+      "--green-fg": 20,
+      "--green-bg": 15,
+      "--yellow-fg": 14,
+      "--yellow-bg": 14,
+      "--blue-fg": 5,
+      "--blue-bg": 12
+    },
+    "total": 128,
+    "note": "Compare semantic-token usage vs raw hex usage — ratio reflects migration debt"
+  },
+  "tap_target": {
+    "tap_min_definitions": 1,
+    "tap_min_var_references": 1,
+    "buttons_with_min_height": 33,
+    "note": "--tap-min token exists but is largely unreferenced inside <button> tags"
+  },
+  "button_class_system": {
+    "btn_class_definitions": 7,
+    "btn_class_usages": 85,
+    "inline_styled_buttons": 138,
+    "migration_pct_if_class_exists": "38.1%"
+  },
+  "padding_distribution": {
+    "unique_padding_values": 80,
+    "top_15": [
+      {
+        "value": "14px",
+        "count": 38
+      },
+      {
+        "value": "10px",
+        "count": 31
+      },
+      {
+        "value": "6px 12px",
+        "count": 20
+      },
+      {
+        "value": "16px",
+        "count": 20
+      },
+      {
+        "value": "5px 10px",
+        "count": 20
+      },
+      {
+        "value": "8px 12px",
+        "count": 19
+      },
+      {
+        "value": "12px",
+        "count": 16
+      },
+      {
+        "value": "8px 10px",
+        "count": 15
+      },
+      {
+        "value": "8px",
+        "count": 15
+      },
+      {
+        "value": "4px 10px",
+        "count": 13
+      },
+      {
+        "value": "6px 10px",
+        "count": 12
+      },
+      {
+        "value": "6px 14px",
+        "count": 9
+      },
+      {
+        "value": "3px 8px",
+        "count": 9
+      },
+      {
+        "value": "10px 12px",
+        "count": 9
+      },
+      {
+        "value": "20px",
+        "count": 8
+      }
+    ]
+  },
+  "font_size_below_12px": {
+    "distinct": 7,
+    "breakdown": [
+      {
+        "size": "10px",
+        "count": 218
+      },
+      {
+        "size": "11px",
+        "count": 143
+      },
+      {
+        "size": "9px",
+        "count": 59
+      },
+      {
+        "size": "8px",
+        "count": 10
+      },
+      {
+        "size": "11.5px",
+        "count": 6
+      },
+      {
+        "size": "7px",
+        "count": 2
+      },
+      {
+        "size": "10.5px",
+        "count": 1
+      }
+    ]
+  },
+  "destructive_native_dialogs": {
+    "confirm_calls": 2,
+    "alert_calls": 0
+  },
+  "fonts": {
+    "inter": "loaded",
+    "heebo": "loaded",
+    "lang_attribute_usages": 1
+  }
+}

--- a/scripts/audits/sectionD_ui_report.json
+++ b/scripts/audits/sectionD_ui_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-26T16:29:02.531Z",
+  "generated_at": "2026-05-26T16:59:21.794Z",
   "file": "shlav-a-mega.html",
   "file_size_bytes": 722560,
   "line_count": 8379,
@@ -123,9 +123,15 @@
   },
   "button_class_system": {
     "btn_class_definitions": 7,
-    "btn_class_usages": 85,
-    "inline_styled_buttons": 138,
-    "migration_pct_if_class_exists": "38.1%"
+    "button_tags_total": 182,
+    "button_tags_with_btn_class": 78,
+    "button_tags_with_inline_style": 138,
+    "button_tags_with_both": 60,
+    "btn_class_adoption_pct": "42.9%",
+    "fully_migrated_pct": "9.9%",
+    "inline_only_pct": "42.9%",
+    "raw_class_btn_text_matches": 85,
+    "raw_minus_real": 7
   },
   "padding_distribution": {
     "unique_padding_values": 80,


### PR DESCRIPTION
Mandatory audit-first slice per captain-mode directive (2026-05-26 session). **Zero behavior change** — only adds `scripts/audits/*`.

## What ships

Two deterministic, dep-free Node scripts + reports:
- `sectionD_content_audit.cjs` → `sectionD_report.json` (questions.json data quality)
- `sectionD_ui_audit.cjs` → `sectionD_ui_report.json` (shlav-a-mega.html UI surface)
- `SECTION_D_REPORT.md` — human summary + ship-slice plan

## Headline numbers

### Content (3,823 Qs)
| Check | Count | % |
|---|---|---|
| D1 Hazzard ch 2-6 / 34 / 62 cited (EXCLUDED) | **217** | 5.68% |
| D2 c_accept length-1 redundancy | 0 | 0% |
| D3 c_accept multi-correct | 48 | 1.26% |
| D4 Missing e_en | 1,876 | 49.07% |
| D5 q_en coverage | 1,947 | 50.93% |
| D7 Harrison missing chapters cited | 14 chs / 99 Qs | 2.59% |
| D8 RTL/LTR mixed-script stems | **2,969** | 77.66% |
| D9 broken flag | 24 | 0.63% |
| D10 ref empty | 80 | 2.09% |

### UI (shlav-a-mega.html, 705.6 KB / 8,379 lines)
- Inline-styled `<button>` tags: 138
- Unique hex colors: 152 / 905 occurrences
- CSS color-token usage: 128 occurrences → **87.6% migration debt**
- `.btn` class system: 7 defs / 85 usages (partial migration)
- Unique padding values: 80
- Font sizes <12px: 7 distinct
- Native `confirm()`: 2, `alert()`: 0

Full breakdowns including chapter histograms, color frequency tables, padding-value distribution → `sectionD_report.json` + `sectionD_ui_report.json`.

## Why this PR first

Per captain-mode directive — no UI/data PR for section D may ship until prevalence numbers are known. This PR establishes the baseline. Subsequent slices S2–S6 (button migration, RTL typographic fix, color migration, syllabus-orphan resolution, e_en batch) each get their own PR + self-merge.

## Repro
```bash
node scripts/audits/sectionD_content_audit.cjs
node scripts/audits/sectionD_ui_audit.cjs
```
Both run in <1s, zero deps.

## Risk
None — scripts are additive, no existing files touched. Reports are deterministic from current `data/questions.json` / `shlav-a-mega.html`. Re-running on a future revision will simply regenerate the JSON.

Self-merge per CLAUDE.md authority once Codex green + CI green.