### PR TITLE
perf(quiz): gate aiAutopsy fallback on _disReady + render-trigger on DIS land (v10.64.132)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.131",
+  "version": "10.64.132",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -1267,6 +1267,20 @@ const _disPromise = (async () => {
     console.warn('distractors.json deferred load failed:', err.message);
   } finally {
     _disReady = true;
+    // v10.64.132: trigger a re-render when DIS lands so users sitting on
+    // a post-answer view with the "⏳ טוען הסבר על מסיחים..." placeholder
+    // see the curated Distractor Autopsy populate without navigating
+    // away and back. Mirrors the _qzPromise post-completion pattern
+    // above. Without this trigger, the placeholder is permanent for the
+    // current question — and the autopsy fallback (line ~3421) used to
+    // burn a paid aiAutopsy() call during the deferred-fetch window,
+    // also fixed in this revision.
+    try {
+      if (typeof S !== 'undefined' && typeof render === 'function') {
+        const tabsThatNeedDis = ['quiz', 'track'];
+        if (!S.tab || tabsThatNeedDis.includes(S.tab)) render();
+      }
+    } catch (e) { console.warn('post-DIS rerender skipped:', e.message); }
   }
 })();
 // Mirrors _disPromise: idle-defer the explanations payload (~4.6 MB) so the boot
@@ -3418,7 +3432,15 @@ if(_dist){
   h+=`<div style="font-size:11px;line-height:1.7;color:rgb(var(--fg));unicode-bidi:plaintext" dir="auto">${_aiTxt}</div>`;
 }else{
   h+=`<div style="font-size:11px;color:rgb(var(--fg3));padding:4px 0">⏳ טוען הסבר על מסיחים...</div>`;
-  setTimeout(()=>{ if(!_exCache['autopsy_'+_qIdx])aiAutopsy(_qIdx); },100);
+  // v10.64.132: gate the paid aiAutopsy() fallback on _disReady. When the
+  // deferred distractors.json fetch is still in-flight, the curated
+  // rationale is about to arrive — don't burn a remote AI call on a
+  // question we're about to be able to render locally. _disPromise's
+  // post-completion render() call (line ~1268) will re-enter this
+  // branch with _dist populated. Pre-existing behavior for genuinely
+  // missing entries (_disReady && DIS[idx] undefined) is unchanged —
+  // fallback proceeds with aiAutopsy as before.
+  if (_disReady) setTimeout(()=>{ if(!_exCache['autopsy_'+_qIdx])aiAutopsy(_qIdx); },100);
 }
 h+=`</div>`;
 }
@@ -7205,8 +7227,9 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.131';
+const APP_VERSION='10.64.132';
 const CHANGELOG={
+'10.64.132':['perf(quiz): gate aiAutopsy() fallback on _disReady — mirrors the Codex P2 fix shipped to InternalMedicine #124 and FamilyMedicine #71 today. Without the guard, answering a question during the deferred distractors.json fetch window triggered the legacy on-demand AI autopsy via setTimeout, burning a paid Anthropic API call AND showing AI-generated rationales instead of the curated DIS-row content that was about to arrive. Also added a post-DIS-load render() trigger in _disPromise (mirrors the existing _qzPromise post-completion pattern) so users sitting on a post-answer view with the loading placeholder see the curated Distractor Autopsy populate without navigating away. Trinity 10.64.131 → 10.64.132. Tests pass (1610). Pre-existing behavior for genuinely-missing DIS entries unchanged.'],
 '10.64.131':['fix(library-reader): graceful chapter-not-indexed branch. 100 questions across 15 Harrison chapters (81,86,83,92,84,98,13,23,85,87,116,131,180,281,284) cite chapters not present in harrison_chapters.json. Pre-fix: clicking the cite button set harChOpen=N but the if-chain fell through to the full chapter-list view (no error). Post-fix: explicit branch shows back button, clear content-not-yet-indexed message, live cite count, and a drill-down deep-link (har-ch:X). Parallel branch for Hazzard.','test: brace balance verified; vitest 1610 passed.','perf: zero-cost (new branch only renders on the previously-silent fall-through path).'],
 '10.64.130':['docs: complete the v10.64.129 web-Claude-audit corrections — v127 entry "VALIDATED" wording softened to match v126+v128 polarity (word-target-dominates weakly supported, topic-density is the framing that did not hold). v129 deliberately scoped to a subset of corrections by web-Claude (lane-discipline carve-out: v127 wording fix was the open item); this entry closes it. Also bumps package-lock.json from 10.64.112 → 10.64.130 (17-version drift on main since v112; surfaced during web-Claude audit npm install).','meta: pattern-confirming case for filesystem-grounded fresh-eye review (banked in v10.64.129) — the v127 fix here is exactly the kind of one-line cleanup web-Claude flagged but deliberately did not unilaterally apply. Cross-lane carve-outs preserve user decision authority on scope; terminal-lane closes them after explicit authorization.','test: no test impact; CHANGELOG-only + lockfile housekeeping. npm run verify expected green.'],
 '10.64.129':['docs: CHANGELOG-correction follow-up — no app behavior change. Web Claude independent audit 2026-05-14 (two-Claude pattern, filesystem-grounded fresh-eye review) found three banked claims in the v124-128 truncation rollout overstated. Corrected in place: (1) v128 model verdict — "topic-density framing CONFIRMED" was not supported; the 5 cluster medians span only 65 chars with no monotonic relationship to ti and the pre-sealed bands were too wide to discriminate, so the band-hit rate was a width artifact; (2) v127 infra line — PR-number factual error #227 → #223; (3) v126 — annotated that v127/v128 marked the word-target-dominates refinement REFUTED, but that refutation was itself unsound — word-target-dominates is the reading the n=5 data weakly supports, topic-density is the framing that did not hold.','meta: pattern note — filesystem-grounded fresh-eye review (independent instance with repo access) caught framing overclaims that transcript-only review missed. Worth routing major workstream verdicts through this gate before declaring findings durable. Trinity bumped 10.64.128 → 10.64.129 per CHANGELOG-edit-bumps-trinity precedent (v100/v101).'],

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -1256,16 +1256,34 @@ const _qzPromise = (async () => {
   }
 })();
 const _disPromise = (async () => {
+  // v10.64.132 (Codex P2 follow-up): use AbortController + watchdog so a
+  // stalled fetch can't pin _disReady=false forever. Without this, a
+  // hung-network DIS fetch would leave answered questions stuck on the
+  // "⏳ טוען..." placeholder AND prevent the aiAutopsy fallback from
+  // ever firing (because _disReady never flips). 12s budget is generous
+  // (idle-callback already gave 3s of slack; real-world DIS fetch is
+  // typically <2s even on Slow-3G); if it expires, we fall through to
+  // the AI-autopsy path with no curated rationale — same UX as a
+  // genuinely-missing DIS entry.
+  const _disCtrl = (typeof AbortController === 'function') ? new AbortController() : null;
+  const DIS_FETCH_TIMEOUT_MS = 12000;
+  const _disWatchdog = setTimeout(() => {
+    if (_disCtrl && !_disReady) {
+      console.warn('distractors.json fetch watchdog fired after', DIS_FETCH_TIMEOUT_MS, 'ms — aborting');
+      try { _disCtrl.abort(); } catch {}
+    }
+  }, DIS_FETCH_TIMEOUT_MS);
   try {
     if (typeof requestIdleCallback === 'function') {
       await new Promise(res => requestIdleCallback(res, { timeout: 3000 }));
     }
-    const r = await fetch('./data/distractors.json');
+    const r = await fetch('./data/distractors.json', _disCtrl ? { signal: _disCtrl.signal } : undefined);
     if (r.ok) DIS = await r.json();
     else console.warn('distractors.json unavailable:', r.status);
   } catch (err) {
-    console.warn('distractors.json deferred load failed:', err.message);
+    console.warn('distractors.json deferred load failed:', err && err.message);
   } finally {
+    clearTimeout(_disWatchdog);
     _disReady = true;
     // v10.64.132: trigger a re-render when DIS lands so users sitting on
     // a post-answer view with the "⏳ טוען הסבר על מסיחים..." placeholder
@@ -1274,7 +1292,9 @@ const _disPromise = (async () => {
     // above. Without this trigger, the placeholder is permanent for the
     // current question — and the autopsy fallback (line ~3421) used to
     // burn a paid aiAutopsy() call during the deferred-fetch window,
-    // also fixed in this revision.
+    // also fixed in this revision. On watchdog-abort path, _disReady
+    // still flips → aiAutopsy fallback engages on the next render
+    // (same as pre-PR behavior for fetch failures).
     try {
       if (typeof S !== 'undefined' && typeof render === 'function') {
         const tabsThatNeedDis = ['quiz', 'track'];

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.131';
+const CACHE='shlav-a-v10.64.132';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 // CRITICAL_URLS = the bare-minimum app shell required for offline boot.
 // Anything else (data/*.json, fonts, icons) is best-effort in the install


### PR DESCRIPTION
## Same fix as InternalMedicine #124 / FamilyMedicine #71 — applied to Shlav A

All three study apps (Pnimit / Mishpacha / Shlav A) share the same deferred-distractors load pattern. The Codex P2 review on IM #124 / FM #71 today caught a race window I just verified also exists here: the post-answer fallback at `shlav-a-mega.html:3421` schedules a paid `aiAutopsy()` call when `DIS && DIS[idx]` is null, which is indistinguishable from a genuinely-missing entry during the `_disPromise` in-flight window (between page load and `_disReady=true`).

Result: fast-answering users on slower networks burn an Anthropic API call AND see AI-generated text instead of the curated DIS rationale thats about to arrive.

## Two changes, both narrow

### 1. Gate `aiAutopsy()` setTimeout on `_disReady`

```diff
  }else{
    h+=`<div ...>⏳ טוען הסבר על מסיחים...</div>`;
-   setTimeout(()=>{ if(!_exCache[autopsy_+_qIdx])aiAutopsy(_qIdx); },100);
+   if (_disReady) setTimeout(()=>{ if(!_exCache[autopsy_+_qIdx])aiAutopsy(_qIdx); },100);
  }
```

### 2. Trigger re-render when DIS lands

Mirrors the existing `_qzPromise` post-completion pattern (line ~1248) so users sitting on the loading placeholder see the curated rationale populate when DIS arrives — no manual navigate-away-and-back.

```diff
   } finally {
     _disReady = true;
+    // Re-render quiz/track views if DIS landed while user is on one
+    try { if (S?.tab in {quiz:1,track:1} && typeof render===function) render(); } catch (e) { ... }
   }
```

## Out of scope

Line 2432 — the on-wrong-answer `aiAutopsy` pre-warm fires regardless of `_disReady` (pre-existing pattern since at least v10.64.110). Thats a separate pre-warm path, not the deferred-fetch race introduced by the LCP refactor. Out of scope to keep diff narrow; flag for a follow-up if cost matters.

## Tests

- Full suite: **1610 passed / 7 skipped**
- CHANGELOG entry added for v10.64.132 (changelogDrift guard satisfied)
- Trinity bumped 131 → 132 (package.json + APP_VERSION + sw.js CACHE all aligned)