### PR TITLE
fix(a11y): allow user pinch-zoom — remove user-scalable=no + maximum-scale=1

### DIFF
--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -2,7 +2,7 @@
 <html lang="he" dir="rtl" data-skin="geriatrics" data-theme="light">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no,viewport-fit=cover">
+<meta name="viewport" content="width=device-width,initial-scale=1.0,viewport-fit=cover">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <meta name="mobile-web-app-capable" content="yes">


### PR DESCRIPTION
## Twin of FamilyMedicine PR #72

Same fix, same rationale, identical verbatim change. Both repos had the same viewport meta from inception and both block WCAG 1.4.4.

## What changed

```diff
- <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no,viewport-fit=cover">
+ <meta name="viewport" content="width=device-width,initial-scale=1.0,viewport-fit=cover">
```

## Why

`user-scalable=no` + `maximum-scale=1.0` disables pinch-zoom, blocking **WCAG 2.1 SC 1.4.4 (Resize Text, AA)** — users must be able to resize text up to 200% without loss of content or functionality.

InternalMedicine `pnimit-mega.html:5` already uses the clean form — operational reference.

## Scope

Single `<meta>` attribute. No JS, no CSS, no schema, no layout shift. No APP_VERSION bump needed.

## Tests

- Full suite: **1610 passed / 7 skipped**
- `check-version-sync.py`: green (10.64.131 aligned across HTML + SW + pkg)
- `check-brace-balance.py`: green
- `check-inline-js.py`: green