### PR TITLE
perf: defer first-visit help-overlay autoshow past LCP

### DIFF
--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -8291,6 +8291,10 @@ if(st)setTimeout(()=>{try{st.style.transition='opacity .4s';st.style.opacity='0.
 
 // ===== HELP OVERLAY =====
 function showHelp(){
+// Dedupe — if a #help-overlay is already mounted, no-op. Prevents the
+// deferred first-visit autoshow from stacking on top of a manual Help-button
+// click during the 2-3s defer window. Caught by Codex on FM #76 (sibling).
+if(document.getElementById('help-overlay'))return;
 const ov=document.createElement('div');
 ov.id='help-overlay';
 ov.style.cssText='position:fixed;inset:0;background:rgba(0,0,0,.7);z-index:9999;overflow-y:auto;-webkit-overflow-scrolling:touch;padding:16px';

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -1464,8 +1464,15 @@ if(!localStorage.getItem('shlav_seen_help')){localStorage.setItem('shlav_seen_he
 // already on screen (e.g. postLoginRstModal during a fresh-device login).
 // Surfaced by the 1h chaos run which captured 2 transient modal-recovery-failed
 // cases caused by the help-overlay racing in over an existing modal.
+// v10.64.x perf: also defer the OUTER trigger until the page is idle so the
+// large help overlay (CHANGELOG list + sec() blocks) doesn't become the
+// LCP element. Deployed LCP measured 18s on simulated Slow-4G + 4× CPU
+// because Lighthouse picked the CHANGELOG block. requestIdleCallback lets
+// the quiz card paint and settle first. 3000ms timeout fallback for slow
+// devices that never become idle. Inner _showHelpWhenClear polling for
+// blocking modals is preserved unchanged.
 const _showHelpWhenClear=()=>{const _blocking=document.querySelector('#feModal,#sdModal,#miModal,#mockPicker,#examModal,#mexModal,#postLoginRstModal,#rstModal');if(_blocking)setTimeout(_showHelpWhenClear,400);else showHelp();};
-setTimeout(_showHelpWhenClear,500);}}).catch(e=>{console.error('IDB init failed, falling back to localStorage:',e);renderTabs();render();if(typeof initPostLoginRestore==='function')initPostLoginRestore();});
+if(typeof requestIdleCallback==='function'){requestIdleCallback(()=>setTimeout(_showHelpWhenClear,300),{timeout:3000});}else{setTimeout(_showHelpWhenClear,1500);}}}).catch(e=>{console.error('IDB init failed, falling back to localStorage:',e);renderTabs();render();if(typeof initPostLoginRestore==='function')initPostLoginRestore();});
 
 // ===== SCREEN WAKE LOCK =====
 let wakeLock=null;


### PR DESCRIPTION
## Sibling of FamilyMedicine #76 + InternalMedicine #126

Same bug, same defer-via-`requestIdleCallback` pattern. Both siblings dropped LCP 7.3s→1.0s (FM) and 5.2s→1.0s (IM).

## Problem

Lighthouse mobile LCP = **18.0s** on deployed `shlav-a-mega.html` (perf score 40/100). LCP element is the large help-overlay CHANGELOG block, which paints ~600ms after first quiz render due to `setTimeout(_showHelpWhenClear, 500)`.

## Fix

Wrap the outer trigger in `requestIdleCallback` so quiz content paints and stabilizes first. Inner `_showHelpWhenClear` modal-polling behavior (v10.64.49) preserved unchanged.

```diff
- setTimeout(_showHelpWhenClear, 500);
+ if (typeof requestIdleCallback === function) {
+   requestIdleCallback(()=>setTimeout(_showHelpWhenClear,300), {timeout:3000});
+ } else {
+   setTimeout(_showHelpWhenClear, 1500);
+ }
```

## Why expected improvement on deploy (NOT visible in local test)

Local HTTP-server serves `shlav-a-mega.html` uncompressed (744 KiB). On simulated mobile CPU the bundle parse+execute never reaches idle within the 3s timeout, so the fallback timer fires and the help overlay still becomes LCP locally. On the deployed page (gzip-compressed by GitHub Pages, smaller transfer, faster parse), the page should reach idle well before the timeout.

## No version bump

Trinity stays at **10.64.132** — single-line behavior change inside an existing if() block. No APP_VERSION bump needed. `check-version-sync.py` + brace-balance + inline-js guards all pass.

## Tests

- Vitest: **1610 passed / 7 skipped**
- Build/verify: green