### PR TITLE
fix(ui): flexbox header — icons no longer overlap title (v10.64.139)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geriatrics",
-  "version": "10.64.130",
+  "version": "10.64.139",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geriatrics",
-      "version": "10.64.130",
+      "version": "10.64.139",
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.5",
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.138",
+  "version": "10.64.139",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -222,23 +222,21 @@ button.pill{font-family:inherit;font-size:11px;font-weight:600;line-height:inher
 ::-webkit-scrollbar{width:4px}::-webkit-scrollbar-thumb{background:#cbd5e1;border-radius:2px}
 @media(min-width:768px){.ct{padding:20px 16px 88px;max-width:800px}.tabs button{min-width:64px;font-size:11px}.hdr h1{font-size:18px}}
 @media(min-width:1024px){.ct{max-width:900px}.card{padding:16px}}
-.dm-btn{position:absolute;top:50%;transform:translateY(-50%);font-size:18px;width:36px;height:36px;display:inline-flex;align-items:center;justify-content:center;padding:0;opacity:.9;background:rgba(255,255,255,0.12);border-radius:50%;border:none;cursor:pointer;color:#fff}
+.hdr-bar{display:flex;align-items:flex-start;justify-content:space-between;gap:10px}
+.hdr-titleblock{min-width:0;flex:1 1 auto}
+.dm-row{display:flex;align-items:center;gap:5px;flex:0 0 auto;flex-wrap:wrap;justify-content:flex-end;max-width:60%}
+.dm-btn{position:static;transform:none;font-size:16px;width:32px;height:32px;display:inline-flex;align-items:center;justify-content:center;padding:0;opacity:.9;background:rgba(255,255,255,0.12);border-radius:50%;border:none;cursor:pointer;color:#fff;flex:0 0 auto}
 .dm-btn:hover{opacity:1;background:rgba(0,0,0,0.12)}
 body.dark .dm-btn{background:rgba(255,255,255,0.08);color:#fff}
 body.dark .dm-btn:hover{background:rgba(255,255,255,0.18)}
-.dm-btn:active{transform:translateY(-50%) scale(.92)}
+.dm-btn:active{transform:scale(.92)}
 /* v10.64.94 phone header declutter: inline h1 22px + 5x36px buttons at top:50% (centered) collide with title AND the timestamp <p> on ≤480px viewports. Anchor buttons to a fixed top below the safe-area inset (not centered), shrink to 32px, tighten the inline right: offsets, override inline h1 to 17px, hide redundant Local-only sync pill (account chip + Settings tab convey same info). Desktop ≥481px unchanged — placed AFTER the base .dm-btn rule so the canonical white-on-tint contrast rule (a11yIssue125 regex guard) stays the first match. */
 /* v10.64.96 RTL property fix — v95 used padding-inline-end:172px which in RTL writing-mode adds padding to the LEFT (inline-end = the END of inline flow = left in RTL), not the right where the absolutely-positioned icons live. Live geometry confirmed h1 text was at left 224-344 vs icons at 176-352 — still overlapping by 120px. Switched to physical padding-right:172px so the reserved space is on the actual right edge of h1 regardless of writing direction. */
 @media(max-width:480px){
-  .hdr h1{font-size:17px!important;font-weight:700!important;letter-spacing:-.02em!important;padding-right:172px!important;padding-inline-end:0!important;line-height:1.25!important}
+  .hdr h1{font-size:17px!important;font-weight:700!important;letter-spacing:-.02em!important;line-height:1.25!important}
   .hdr h1 span:not(#headerVer){display:none!important}
-  .dm-btn{width:32px!important;height:32px!important;font-size:14px!important;top:calc(env(safe-area-inset-top) + 10px)!important;transform:none!important}
+  .dm-btn{width:30px!important;height:30px!important;font-size:13px!important}
   .dm-btn:active{transform:scale(.92)!important}
-  .hdr button[data-action="toggle-study"]{right:8px!important}
-  .hdr button[data-action="toggle-dark"]{right:44px!important}
-  .hdr button[data-action="toggle-lang"]{right:80px!important;font-size:11px!important}
-  .hdr button[data-action="show-help"]{right:116px!important;font-size:14px!important}
-  .hdr button[data-action="goto-account"]{right:152px!important;font-size:14px!important}
   #syncPill{display:none!important}
 }
 .tabs button{min-height:44px}
@@ -874,9 +872,19 @@ upd();setInterval(upd,30000);
 
 <a href="#ct" class="skip-link">Skip to content</a>
 <div class="hdr" style="position:relative">
+<div class="hdr-bar">
+<div class="hdr-titleblock">
 <h1 style="font-size:22px;font-weight:800;letter-spacing:-.01em;color:#fff">Shlav A Mega <span style="font-size:11px;font-weight:600;color:#5eead4;vertical-align:middle;letter-spacing:0">Geriatrics</span> <span id="headerVer" style="font-size:11px;font-weight:700;color:#047857;background:#ecfdf5;padding:2px 7px;border-radius:8px;vertical-align:middle;letter-spacing:.02em;border:1px solid rgb(var(--green-brd))"></span></h1>
-<button class="dm-btn" data-action="toggle-study" title="Sepia / Study Mode (warm light)" aria-label="Toggle sepia study mode" style="right:12px">☀</button><button class="dm-btn" data-action="toggle-dark" title="Dark Mode" aria-label="Toggle dark mode" style="right:56px">🌙</button><button class="dm-btn" data-action="toggle-lang" id="hdr-lang-btn" title="Toggle Hebrew / English (translated AI questions only)" aria-label="EN — toggle question language" style="right:100px;font-size:11px;font-weight:700">EN</button><button class="dm-btn" data-action="show-help" title="Help" aria-label="Help" style="right:144px;font-size:15px;font-weight:700">?</button><button class="dm-btn" data-action="goto-account" id="hdr-account-btn" title="Account" aria-label="Account / Login" style="right:188px;font-size:14px;font-weight:700">👤</button>
 <p id="hdr-sub">Loading...</p>
+</div>
+<div class="dm-row">
+<button class="dm-btn" data-action="goto-account" id="hdr-account-btn" title="Account" aria-label="Account / Login" style="font-size:14px;font-weight:700">👤</button>
+<button class="dm-btn" data-action="show-help" title="Help" aria-label="Help" style="font-size:15px;font-weight:700">?</button>
+<button class="dm-btn" data-action="toggle-lang" id="hdr-lang-btn" title="Toggle Hebrew / English (translated AI questions only)" aria-label="EN — toggle question language" style="font-size:11px;font-weight:700">EN</button>
+<button class="dm-btn" data-action="toggle-dark" title="Dark Mode" aria-label="Toggle dark mode">🌙</button>
+<button class="dm-btn" data-action="toggle-study" title="Sepia / Study Mode (warm light)" aria-label="Toggle sepia study mode">☀</button>
+</div>
+</div>
 <div id="syncPill" class="sync-pill" role="status" aria-live="polite" style="position:absolute;top:4px;left:6px;font-size:9px;padding:2px 7px;border-radius:10px;background:rgb(var(--bg2));color:rgb(var(--fg2));border:1px solid rgb(var(--brd));cursor:pointer;user-select:none;display:none" title="Sync status — click for details" onclick="showSyncStatus()"></div>
 </div>
 
@@ -7278,8 +7286,9 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.138';
+const APP_VERSION='10.64.139';
 const CHANGELOG={
+'10.64.139':['fix(ui): header restructured to flexbox (.hdr-bar) — the .dm-btn toolbar icons (study/dark/lang/help/account) moved from position:absolute right:Npx into a flex .dm-row, so they no longer overlap the title and the timestamp line. Supersedes the v94/95/96 padding-right/RTL reservation hacks (which still left ~120px overlap per the live-geometry note). Mobile media-query right: overrides and the h1 padding-right:172px reservation removed as moot under flex. .dm-btn base a11y rule (white text on white-tint) preserved as the first match. Ported from FM v1.25.4. Trinity 10.64.138 to 10.64.139.'],
 '10.64.138':['fix(data): reopened the BPH / postvoid-residual question (idx 3618, GRS8 Q#203) that was quarantined 2026-05-24 pending a verbatim source. The GRS8 source confirms the keyed answer D (measure postvoid residual urine BEFORE adjusting medications), to exclude diphenhydramine-induced urinary retention; a normal PVR averts the need to stop the diphenhydramine that gives good symptom control, so the proposed flip to stopping diphenhydramine is explicitly rejected by the GRS8 rationale. Answer c unchanged (D); broken, status, and broken_reason removed so the question re-enters the pool. The broken-quarantined ratchet drops to one remaining parked question (idx 2096, still awaiting a verbatim Harrison Ch 286 / Hazzard Ch 74 disposition quote for low-risk elderly chest pain after negative serial troponins). Trinity 10.64.137 to 10.64.138.'],
 '10.64.137':['fix(data): dedup audit — soft-retired 195 exact-duplicate question copies (identical stem, options, and answer; kept the better-explained copy of each pair) plus the duplicate of the giant-cell-arteritis question. A new dup flag marks the retired copies, and buildPool now excludes them from every quiz and exam pool exactly like the existing broken flag, so array indices, the chapter cache, and saved progress are all preserved (questions stay in place and simply never enter a pool). Also fixed the flawed GCA question (index 2525): it carried two valid ACR-1990 options, so temporal-artery tenderness was replaced with a clear non-criterion distractor (thrombocytopenia), leaving biopsy as the single correct answer, and the explanation was rewritten to match. 1610 tests green, regen check clean.'],
 '10.64.136':['fix(data): keep tumor-agnostic therapy-toxicity questions at general oncology Ch 88. Follow-up to #297. The solid-tumor rules matched any tumor named in the stem, so cancer-therapy complication questions were routed to the organ chapter even though the cancer is only background: q2185 (immune-mediated myopericarditis) and q2180 (radiation-induced pericarditis) went to lung Ch 91, and q1957 / q1961 (checkpoint-inhibitor immune-related adverse events managed by stopping the drug and starting steroids) likewise. Added a trailing re-assert rule (gated topic 26, stem-matched) returning these to Ch 88, since therapy-induced toxicity is tumor-agnostic supportive care; q3715 (general malignant pericarditis) also moved to 88, correcting a stale Ch 95 tag. Tumor-progression complications stay organ-specific: cord compression (q780, q2822), SVC syndrome (q2176), and mCRPC palliative radiation (q1947); q823 (NSCLC outcomes) stays at Ch 91. Trinity 10.64.135 to 10.64.136. 1610 tests green, regen check clean.'],

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.138';
+const CACHE='shlav-a-v10.64.139';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 // CRITICAL_URLS = the bare-minimum app shell required for offline boot.
 // Anything else (data/*.json, fonts, icons) is best-effort in the install

--- a/tests/auditPhases.test.js
+++ b/tests/auditPhases.test.js
@@ -92,7 +92,7 @@ describe("Phase 2 — sw-update.js extraction", () => {
 // ── Phase 3: Shell-level inline handler delegation ──
 describe("Phase 3 — data-action delegation", () => {
   it("header buttons use data-action instead of onclick", () => {
-    const headerMatch = html.match(/<div class="hdr"[\s\S]*?<\/div>/);
+    const headerMatch = html.match(/<div class="hdr"[\s\S]*?<div class="ct"/);  // full nested flex header (v10.64.139): capture through to the main content div
     expect(headerMatch).not.toBeNull();
     const header = headerMatch[0];
     expect(header).toContain('data-action="toggle-study"');


### PR DESCRIPTION
Ports FM v1.25.4. .dm-btn icons were absolute right:12-188, overlapping the RTL title+timestamp; v94/95/96 padding/RTL hacks still left ~120px overlap. Now flex items in .hdr-bar/.dm-row; moot mobile overrides removed. a11y dm-btn rule preserved. 1610/1610 green; verify chain clean.