### PR TITLE
fix(data): retag fabricated exam tags 2021-Jun + 2023-Sep to true sittings (booklet-matched) — v10.64.150

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.149",
+  "version": "10.64.150",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/harrison-hebrew-baseline.cjs
+++ b/scripts/harrison-hebrew-baseline.cjs
@@ -28,7 +28,7 @@ const OUT_PATH = path.join(ROOT, 'docs', 'harrison-hebrew-baseline.csv');
 
 // Mirrors Geriatrics regressionGuards.test.js PAST_EXAM_TAGS.
 const PAST_EXAM_TAGS = new Set([
-  '2020', '2021-Dec', '2021-Jun', '2022', '2023-Jun', '2023-Sep',
+  '2020', '2021-Dec', '2022', '2023-Jun',
   '2024-May', '2024-Sep', '2025-Jun',
 ]);
 

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -1066,9 +1066,14 @@ const LS='samega';
 // filter selections or tag-keyed fields get rewritten. Idempotent via
 // __tagMigrationV1 sentinel inside the state object.
 (function migrateExamYearTags(){
-  const MAP={'יוני 21':'2021-Jun','יוני 22':'2022-Jun-Basic','יוני 22 על':'2022-Jun-Subspec','יוני 23':'2023-Jun-Basic','יוני 23 על':'2023-Jun-Subspec','יוני 25':'2025-Jun','מאי 24':'2024-May-Basic','ספט 24':'2024-Sep-Basic','מאי 24 על':'2024-May-Subspec','ספט 24 על':'2024-Sep-Subspec','2022':'2022-Jun-Basic','2023-Jun':'2023-Jun-Basic','2024-May':'2024-May-Basic','2024-Sep':'2024-Sep-Basic','2023-ב':'2023-Sep','2025':'2025-Jun'};
-  // 2025-א cannot auto-migrate (split by classification) — drop from stored selections
-  const DROP=new Set(['2025-א']);
+  // v10.64.150: '2021-Jun' and '2023-Sep' were never real IMA sittings — booklet
+  // matching (Exams/Advanced/2021-12-21 + 2021-01_02__exam-2020) showed all 103
+  // '2021-Jun' Qs are the Dec-2021 sitting, and the 22 '2023-Sep' Qs split across
+  // 2020/2021-Dec/2023-Jun. So 'יוני 21' and the canonical '2021-Jun' now migrate to
+  // '2021-Dec'; '2023-ב'/'2023-Sep' can't map to one sitting → dropped from selections.
+  const MAP={'יוני 21':'2021-Dec','יוני 22':'2022-Jun-Basic','יוני 22 על':'2022-Jun-Subspec','יוני 23':'2023-Jun-Basic','יוני 23 על':'2023-Jun-Subspec','יוני 25':'2025-Jun','מאי 24':'2024-May-Basic','ספט 24':'2024-Sep-Basic','מאי 24 על':'2024-May-Subspec','ספט 24 על':'2024-Sep-Subspec','2022':'2022-Jun-Basic','2023-Jun':'2023-Jun-Basic','2024-May':'2024-May-Basic','2024-Sep':'2024-Sep-Basic','2025':'2025-Jun','2021-Jun':'2021-Dec'};
+  // 2025-א + 2023-ב/2023-Sep cannot auto-migrate (split by classification/sitting) — drop from stored selections
+  const DROP=new Set(['2025-א','2023-ב','2023-Sep']);
   const rename=(v)=>{if(typeof v!=='string')return v;if(DROP.has(v))return null;return Object.prototype.hasOwnProperty.call(MAP,v)?MAP[v]:v;};
   const walk=(obj)=>{
     if(Array.isArray(obj)){for(let i=obj.length-1;i>=0;i--){const w=rename(obj[i]);if(w===null)obj.splice(i,1);else if(w!==obj[i])obj[i]=w;else if(obj[i]&&typeof obj[i]==='object')walk(obj[i]);}return;}
@@ -1926,7 +1931,7 @@ function _topicSrcMatch(q){if(topicSrc==='all')return true;const ex=_isExamTag(q
 function setTopicSrc(s){if(!['all','exams','books'].includes(s))return;topicSrc=s;try{localStorage.setItem('samega_topic_src',s);}catch(e){}if(filt==='topic'){buildPool();}render();}
 // Canonical exam-session tags (ported from Pnimit's EXAM_YEARS). Bare 2020/2021/2022
 // month-unresolved — kept on whitelist so multi-select pills can still target them.
-const EXAM_YEARS=['2020','2021-Jun','2021-Dec','2022-Jun-Basic','2022-Jun-Subspec','2023-Jun-Basic','2023-Jun-Subspec','2023-Sep','2024-May-Basic','2024-May-Subspec','2024-Sep-Basic','2024-Sep-Subspec','2025-Jun-Basic']; // v10.64.11: orphan tags removed (all 48 deleted as fragment-dups)
+const EXAM_YEARS=['2020','2021-Dec','2022-Jun-Basic','2022-Jun-Subspec','2023-Jun-Basic','2023-Jun-Subspec','2024-May-Basic','2024-May-Subspec','2024-Sep-Basic','2024-Sep-Subspec','2025-Jun-Basic']; // v10.64.11: orphan tags removed (all 48 deleted as fragment-dups). v10.64.150: '2021-Jun'+'2023-Sep' removed — not real sittings (retagged to true booklet via Exams match)
 // Multi-select exam-year filter. Persisted across sessions (unlike Pnimit's runtime-only G.years).
 let selectedExamYears=(function(){
   try{const raw=localStorage.getItem('samega_exam_filter');if(!raw)return new Set();
@@ -5275,7 +5280,7 @@ const TOPIC_REF={
 
 function renderExamTrendCard(){
   // v10.55.0: real DB tags. Was matching only 225q (stale '2021','2022','2023-Jun')
-  const OLD_EX=new Set(['2020','2021-Jun','2021-Dec','2022-Jun-Basic','2022-Jun-Subspec','2022-Jun-orphan','2023-Jun-Basic','2023-Jun-Subspec','2023-Jun-orphan','2023-Sep']);
+  const OLD_EX=new Set(['2020','2021-Dec','2022-Jun-Basic','2022-Jun-Subspec','2022-Jun-orphan','2023-Jun-Basic','2023-Jun-Subspec','2023-Jun-orphan']);
   // v10.55.0: real DB tags. Was matching 0q (stale '2024-May','2024-Sep','2025-Jun')
   const NEW_EX=new Set(['2024-May-Basic','2024-May-Subspec','2024-Sep-Basic','2024-Sep-Subspec','2024-orphan','2025-Jun-Basic']);
   const TOPICS_L=TOPICS;
@@ -5996,7 +6001,7 @@ h+=`<div class="card track-wsm">`;
 h+=`<div onclick="S._wsmOpen=!S._wsmOpen;save();render()" class="track-wsm__head${_wsmOpen?' track-wsm__head--open':''}" role="button" tabindex="0" aria-expanded="${_wsmOpen?'true':'false'}" aria-label="Toggle weak spots map"><span class="track-wsm__title">🗺️ Weak Spots Map <span class="track-wsm__sub">· ${heatData.length} topic${heatData.length>1?'s':''} × ${years.length} exam${years.length>1?'s':''}</span></span><span class="track-wsm__chev">${_wsmOpen?'▲':'▼'}</span></div>`;
 if(_wsmOpen){
 h+=`<div class="track-wsm__scroll"><table class="track-wsm__table"><thead><tr><th class="track-wsm__th-topic">Topic</th>`;
-const _yearAbbr={'2020':'20','2021':'21','2021-Jun':"21·6",'2022':'22','2023-Jun':"23·6",'2023-Sep':"23·9",'2024-May':"24·5",'2024-Sep':"24·9",'2025-Jun':"25·6",'Hazzard':'Haz','Harrison':'Har','Exam':'Ex','Hazzard-suppl':'Sup','FM-Core':'FM','GRS8':'GRS','Harrison-suppl':'HSup'};
+const _yearAbbr={'2020':'20','2021':'21','2021-Dec':"21·12",'2022':'22','2023-Jun':"23·6",'2024-May':"24·5",'2024-Sep':"24·9",'2025-Jun':"25·6",'Hazzard':'Haz','Harrison':'Har','Exam':'Ex','Hazzard-suppl':'Sup','FM-Core':'FM','GRS8':'GRS','Harrison-suppl':'HSup'};
 years.forEach(y=>{h+=`<th class="track-wsm__th-year" title="${y}">${_yearAbbr[y]||y}</th>`;});
 h+=`</tr></thead><tbody>`;
 heatData.sort((a,b)=>{
@@ -7288,8 +7293,9 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.149';
+const APP_VERSION='10.64.150';
 const CHANGELOG={
+'10.64.150':['fix(data): retag the fabricated exam-sitting tags "2021-Jun" (103 Qs) and "2023-Sep" (22 Qs) to their TRUE sittings via authoritative booklet matching (same-corruption k-gram overlap against the real IMA exam PDFs). There was never a June-2021 or Sep-2023 IMA geriatrics sitting — the 2021 exam was Dec-2021, 2023 was Jun-2023. All 103 "2021-Jun" Qs matched the 2021-12-21 Advanced booklet (max conf 0.94, 101/103 ≥0.5, none matched 2020) → retagged 2021-Dec (vindicating the #316 idx-2419 finding). The 22 "2023-Sep" Qs were a garbage/orphan tag spread across 3 sittings (8→2020, 8→2021-Dec, 6→2023-Jun-Basic, all ≥0.5 conf) → retagged per-Q. Counts: 2020 100→108, 2021-Dec 104→215, 2023-Jun-Basic 141→147; "2021-Jun"/"2023-Sep" eliminated. 125 t-only changes (0 changes to q/o/c/e/ref; count unchanged 3823). Downstream in lockstep: EXAM_YEARS picker (13→11), _yearAbbr, OLD_EX, localStorage tag-migration MAP (יוני 21+2021-Jun→2021-Dec; 2023-ב/2023-Sep dropped — split across sittings), 8 test files (pastExamCoverage REQUIRED_TAGS, regressionGuards count-locks + lists, dataIntegrity/parserBleed/topicSrc/harrison-baseline allowlists, multiSelectFilters EXAM_YEARS len, tagMigration assertions). Within-session dup-stems 9 (≤10 ceiling). Evidence: .audit_logs/clinical_sweep_2026-06-01/retag_map.json. Trinity 10.64.149→10.64.150.'],
 '10.64.149':['fix(data): reference hygiene + new integrity guard (§1d/§1e of the 2026-05-31 audit). (A) Dropped the boilerplate-mistagged "Harrison Ch 14 — Pain: Pathophysiology and Management" citation half from 9 verifiably NON-pain questions (idx 362/2375/2376/2379/2380/2381/2385/3373/3396 — med-induced fall, chest-CT, CXR, facial BCC, bullous pemphigoid, disseminated zoster, blood-smear, uremic pruritus, DHIC urodynamics), leaving the correct Hazzard half. These were a systematic image-Q mis-tag (every "the finding shown" Q got "Ch 14 — Pain" appended regardless of topic). idx 1663 (pain assessment in non-communicative dementia, Hazzard Ch 68 PAIN MANAGEMENT) was EXCLUDED — its Harrison-Pain half is correct. Sanctioned by the authority-sources rule "rebuild only where current ref is verifiably worse, verifiable from the question content itself". (B) Canonicalized the glued ref "הריסון370" → "Harrison Ch 370 — Rheumatoid Arthritis" (idx 2959/3521; "370" was already the chapter number, title verbatim from harrison_22e_toc.json; stem = symmetric hand+knee joint disease matches RA). 11 refs changed, ref text ONLY — 0 changes to o[]/c/e/t, 0 answer-key changes, question count unchanged (3823). (C) New tests/referenceIntegrity.test.js (3 tests): asserts ZERO phantom chapters (every cited Hazzard 1-108 / Harrison 1-505 chapter exists — 0 violations across 5434 chapter-segments) + ratchets the two audited gaps (empty refs ≤75 SZMC-Rescue, Harrison unindexed-but-valid ≤219 copyright-blocked). Trinity 10.64.148→10.64.149.'],
 '10.64.148':['fix(content): reconstructed the final 10 quarantined intra-word spaced-Hebrew questions (idx 2419/2625/2632/2774/3272/3279/3379/3464/3492/3509) from their ORIGINAL exam PDFs. The corruption lives in the PDFs\' text layer (bad ToUnicode mapping), so each corrupted span was read VERBATIM off the rendered exam page (the visual layer is clean) and de-spaced — e.g. "מ מ .מאירות"→"ממאירות" (2625/3272), "ממ ו מ שך"→"ממושך" (2632/3279), "ל ת הש לת"→"להשתלת" + "ילי מ שני ות"→"מילישניות" (2774/3379), "ויפו י י כח"→"ויפויי כח" (3464), "ס י .סטמי"→"סיסטמי" + 6 more spans (3492), "סיכוי י ה תמותה"→"סיכויי התמותה" ×3 (3509), "מ ה מבחנים"→"מהמבחנים" (2419). 23 span-edits, 0 answer-key (c) changes, 0 option reorders, question count unchanged (3823); spacing/punctuation only, no word substitution (each span zoom-verified against source to avoid mis-transcription — 3 phantom "divergences" from low-res reads were caught and discarded). tests/spacedHebrewGuard.test.js ALLOWLIST emptied — the ratchet now asserts zero spaced-Hebrew dataset-wide. Note: idx 2419 t="2021-Jun" is mislabelled (its source booklet is 2021-Dec-Subspec / file 644197); tag left unchanged (out of scope). Trinity 10.64.147→10.64.148.'],
 '10.64.147':['fix(content): re-key idx 3474 (aphasia, 2024-Sep-Subspec) c:1→2 — Broca→Conduction. The stem describes intact comprehension + neologisms + impaired repetition; neologisms are a FLUENT-aphasia feature that Broca (non-fluent) does not produce, so the keyed Broca was contradicted by the stem. Source: Harrison 22e Ch 437 — "nonfluent (Broca) aphasia" vs "fluent (Wernicke\'s) aphasia ... Jargon speech". Triple-confirmed (Eias + advisor + stem). Coupled edits: distractors.json DIS[3474] empty slot 1→2 (+ added Broca wrong-because), explanations.json[3474] rewritten to Conduction with corrected rationale (the old explanation wrongly listed neologisms as a Broca feature). Only the single answer-key flip in the 2026-05-31 sweep.'],

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -1935,7 +1935,12 @@ const EXAM_YEARS=['2020','2021-Dec','2022-Jun-Basic','2022-Jun-Subspec','2023-Ju
 // Multi-select exam-year filter. Persisted across sessions (unlike Pnimit's runtime-only G.years).
 let selectedExamYears=(function(){
   try{const raw=localStorage.getItem('samega_exam_filter');if(!raw)return new Set();
-    const arr=JSON.parse(raw);return new Set(Array.isArray(arr)?arr.filter(y=>EXAM_YEARS.includes(y)):[]);
+    const arr=JSON.parse(raw);if(!Array.isArray(arr))return new Set();
+    // v10.64.150: migrate retired exam tags saved in older filter selections (samega_exam_filter
+    // is not covered by the migrateExamYearTags IIFE). '2021-Jun'→'2021-Dec' (same Dec-2021 sitting);
+    // '2023-Sep' is intentionally NOT remapped (it split across 3 sittings) → it drops via the EXAM_YEARS filter.
+    const RETAG={'2021-Jun':'2021-Dec'};
+    return new Set(arr.map(y=>RETAG[y]||y).filter(y=>EXAM_YEARS.includes(y)));
   }catch(e){return new Set();}
 })();
 function saveExamYears(){try{localStorage.setItem('samega_exam_filter',JSON.stringify([...selectedExamYears]));}catch(e){}}

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.149';
+const CACHE='shlav-a-v10.64.150';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 // CRITICAL_URLS = the bare-minimum app shell required for offline boot.
 // Anything else (data/*.json, fonts, icons) is best-effort in the install

--- a/tests/dataIntegrity.test.js
+++ b/tests/dataIntegrity.test.js
@@ -298,9 +298,9 @@ describe("cross-file referential integrity", () => {
   it("every q.t is in the known-tags allowlist", () => {
     const KNOWN_TAGS = new Set([
       // IMA exam sessions (must match shlav-a-mega.html EXAM_YEARS)
-      "2020", "2021-Jun", "2021-Dec",
+      "2020", "2021-Dec",
       "2022-Jun-Basic", "2022-Jun-Subspec",
-      "2023-Jun-Basic", "2023-Jun-Subspec", "2023-Sep",
+      "2023-Jun-Basic", "2023-Jun-Subspec",
       "2024-May-Basic", "2024-May-Subspec",
       "2024-Sep-Basic", "2024-Sep-Subspec",
       "2025-Jun-Basic",

--- a/tests/multiSelectFilters.test.js
+++ b/tests/multiSelectFilters.test.js
@@ -37,9 +37,9 @@ describe('v10.64.51-57 — multi-axis filter system', () => {
       expect(TOPICS.length).toBe(46);
     });
 
-    it('EXAM_YEARS array extracts to 13 entries', () => {
+    it('EXAM_YEARS array extracts to 11 entries', () => {
       expect(EXAM_YEARS).toBeTruthy();
-      expect(EXAM_YEARS.length).toBe(13);
+      expect(EXAM_YEARS.length).toBe(11); // v10.64.150: was 13; '2021-Jun'+'2023-Sep' removed (not real sittings, retagged)
     });
 
     it('every EXAM_YEARS tag exists in actual question data', () => {
@@ -295,7 +295,7 @@ describe('v10.64.51-57 — multi-axis filter system', () => {
       const counts = {};
       questions.forEach(q => { counts[q.t] = (counts[q.t] || 0) + 1; });
       const tooSmall = EXAM_YEARS.filter(y => (counts[y] || 0) < 20);
-      // 2023-Sep is currently 22 — borderline but passes.
+      // v10.64.150: smallest sitting is now well above 20 (the borderline 2023-Sep@22 was retagged away).
       expect(tooSmall, `EXAM_YEARS with <20 Qs: ${tooSmall.join(', ')}`).toEqual([]);
     });
 

--- a/tests/parserBleedGuard.test.js
+++ b/tests/parserBleedGuard.test.js
@@ -27,9 +27,9 @@ const ROOT = resolve(import.meta.dirname, '..');
 function loadJSON(rel) { return JSON.parse(readFileSync(resolve(ROOT, rel), 'utf-8')); }
 
 const PAST_EXAM_TAGS = new Set([
-  '2020', '2021-Dec', '2021-Jun',
+  '2020', '2021-Dec',
   '2022-Jun-Basic', '2022-Jun-Subspec', '2022-Jun-orphan',
-  '2023-Jun-Basic', '2023-Jun-Subspec', '2023-Jun-orphan', '2023-Sep',
+  '2023-Jun-Basic', '2023-Jun-Subspec', '2023-Jun-orphan',
   '2024-May-Basic', '2024-May-Subspec',
   '2024-Sep-Basic', '2024-Sep-Subspec', '2024-orphan',
   '2025-Jun-Basic',

--- a/tests/pastExamCoverage.test.js
+++ b/tests/pastExamCoverage.test.js
@@ -45,9 +45,9 @@ const EXAM_DIRS = [
 // Tag bucket → required tag list (any one of the alternatives is acceptable).
 const REQUIRED_TAGS = {
   '2020_al': ['2020'],
-  '2021_dec_al': ['2021-Dec', '2021-Jun'],
+  '2021_dec_al': ['2021-Dec'],
   '2022_jun_al': ['2022-Jun-Basic', '2022-Jun-Subspec', '2022-Jun-orphan'],
-  '2023_jun_al': ['2023-Jun-Basic', '2023-Jun-Subspec', '2023-Jun-orphan', '2023-Sep'],
+  '2023_jun_al': ['2023-Jun-Basic', '2023-Jun-Subspec', '2023-Jun-orphan'],
   '2024_may_al': ['2024-May-Basic', '2024-May-Subspec', '2024-orphan'],
   '2024_sep_al': ['2024-Sep-Basic', '2024-Sep-Subspec'],
   '2025_jun_al': ['2025-Jun-Basic'],

--- a/tests/regressionGuards.test.js
+++ b/tests/regressionGuards.test.js
@@ -84,7 +84,7 @@ describe('questions.json — formatting quality', () => {
   let questions;
   // Only past-exam sessions suffer PDF-extraction artifacts.
   // Hazzard/Harrison/Hazzard-suppl are AI-generated and immune.
-  const PAST_EXAM_TAGS = ['2020', '2021-Dec', '2021-Jun', '2022-Jun-Subspec', '2022-Jun-Basic', '2022-Jun-orphan', '2023-Jun-Subspec', '2023-Jun-Basic', '2023-Jun-orphan', '2023-Sep', '2024-May-Subspec', '2024-May-Basic', '2024-Sep-Subspec', '2024-Sep-Basic', '2024-orphan', '2025-Jun-Basic'];
+  const PAST_EXAM_TAGS = ['2020', '2021-Dec', '2022-Jun-Subspec', '2022-Jun-Basic', '2022-Jun-orphan', '2023-Jun-Subspec', '2023-Jun-Basic', '2023-Jun-orphan', '2024-May-Subspec', '2024-May-Basic', '2024-Sep-Subspec', '2024-Sep-Basic', '2024-orphan', '2025-Jun-Basic'];
   beforeAll(() => { questions = loadQuestions(); });
 
   // Catches "בן58" → should be "בן 58". Geriatrics has a legacy backlog
@@ -172,6 +172,7 @@ describe('questions.json — duplicates', () => {
     const byKey = new Map();
     const dupes = [];
     questions.forEach((q, i) => {
+      if (q.allow_dup) return; // honor the curator-sanctioned near-dup flag, consistent with the per-tag + cross-tag dup guards below (v10.64.150: the 2021-Jun→2021-Dec retag merged already-allow_dup'd paraphrase pairs into one tag)
       const key = `${q.t}||${normStem(q.q)}`;
       if (!key.endsWith('||')) {
         if (byKey.has(key)) {
@@ -281,7 +282,7 @@ describe('questions.json — structural invariants', () => {
       // Unresolved (TODO: determine month, currently kept as-is)
       '2020', '2022',
       // Canonical exam sessions
-      '2021-Dec', '2021-Jun', '2022-Jun-Subspec', '2022-Jun-Basic', '2022-Jun-orphan', '2023-Jun-Subspec', '2023-Jun-Basic', '2023-Jun-orphan', '2023-Sep', '2024-May-Subspec', '2024-May-Basic', '2024-Sep-Subspec', '2024-Sep-Basic', '2024-orphan',
+      '2021-Dec', '2022-Jun-Subspec', '2022-Jun-Basic', '2022-Jun-orphan', '2023-Jun-Subspec', '2023-Jun-Basic', '2023-Jun-orphan', '2024-May-Subspec', '2024-May-Basic', '2024-Sep-Subspec', '2024-Sep-Basic', '2024-orphan',
       // v10.11: real 2025-Jun Geri Stage A Basic (150 Qs) — per IMA post-appeal key 15314
       // v10.33: removed '2025-Jun' (219 condensed paraphrases — internal answer-key conflicts) and '2025-Jun-Subspec' (100 Qs that were 99 dupes of Basic + 1 misfiled real-Basic Q12). See CHANGELOG['10.33'].
       '2025-Jun-Basic',
@@ -333,17 +334,18 @@ describe('questions.json — per-session counts locked', () => {
   let questions;
   beforeAll(() => { questions = loadQuestions(); });
 
+  // v10.64.150: '2021-Jun'(103)+'2023-Sep'(22) were never real IMA sittings — retagged
+  // to their true booklet (all 103 '2021-Jun'→2021-Dec; '2023-Sep'→2020×8/2021-Dec×8/2023-Jun-Basic×6).
+  // So 2020 100→108, 2021-Dec 104→215, 2023-Jun-Basic 141→147; the two dead tags drop out.
   const EXPECTED = {
-    '2020': 100,
-    '2021-Dec': 104,
-    '2021-Jun': 103,
+    '2020': 108,
+    '2021-Dec': 215,
     '2022-Jun-Subspec': 95,
     '2022-Jun-Basic': 150,
     '2022-Jun-orphan': 0,
     '2023-Jun-Subspec': 100,
-    '2023-Jun-Basic': 141,
+    '2023-Jun-Basic': 147,
     '2023-Jun-orphan': 0,
-    '2023-Sep': 22,
     '2024-May-Subspec': 96,
     '2024-May-Basic': 150,
     '2024-Sep-Subspec': 98,
@@ -382,9 +384,9 @@ describe('questions.json — no within-tag stem duplicates (per past-exam tag)',
   // Past-exam tags only — Hazzard / Harrison / GRS8 / Exam are content
   // sources where the same conceptual Q can legitimately appear twice.
   const PAST_EXAM_TAGS = [
-    '2020', '2021-Dec', '2021-Jun',
+    '2020', '2021-Dec',
     '2022-Jun-Basic', '2022-Jun-Subspec', '2022-Jun-orphan',
-    '2023-Jun-Basic', '2023-Jun-Subspec', '2023-Jun-orphan', '2023-Sep',
+    '2023-Jun-Basic', '2023-Jun-Subspec', '2023-Jun-orphan',
     '2024-May-Basic', '2024-May-Subspec',
     '2024-Sep-Basic', '2024-Sep-Subspec', '2024-orphan',
     '2025-Jun-Basic',
@@ -479,7 +481,7 @@ describe('multi-select exam-year filter — Task 3 contract', () => {
   beforeAll(() => { questions = loadQuestions(); });
 
   // v10.64.11: orphan tags removed (all 48 deleted as fragment-dups)
-  const EXAM_YEARS = ['2020', '2021-Dec', '2021-Jun', '2022-Jun-Subspec', '2022-Jun-Basic', '2023-Jun-Subspec', '2023-Jun-Basic', '2023-Sep', '2024-May-Subspec', '2024-May-Basic', '2024-Sep-Subspec', '2024-Sep-Basic', '2025-Jun-Basic'];
+  const EXAM_YEARS = ['2020', '2021-Dec', '2022-Jun-Subspec', '2022-Jun-Basic', '2023-Jun-Subspec', '2023-Jun-Basic', '2024-May-Subspec', '2024-May-Basic', '2024-Sep-Subspec', '2024-Sep-Basic', '2025-Jun-Basic'];
 
   // Reproduces the pool-building logic inline so test doesn't depend on
   // running the monolith's runtime.
@@ -494,7 +496,7 @@ describe('multi-select exam-year filter — Task 3 contract', () => {
   });
 
   test('two-tag selection is exact union of those tags', () => {
-    const sel = ['2021-Jun', '2025-Jun-Basic'];
+    const sel = ['2021-Dec', '2025-Jun-Basic'];
     const expected = questions.filter(q => sel.includes(q.t)).length;
     expect(buildYearPool(sel).length).toBe(expected);
   });
@@ -517,9 +519,9 @@ describe('multi-select exam-year filter — Task 3 contract', () => {
     //   const raw = localStorage.getItem('samega_exam_filter');
     //   const arr = JSON.parse(raw);
     //   new Set(arr.filter(y => EXAM_YEARS.includes(y)));
-    const stored = ['2021-Jun', 'לא-קיים', 'Jun25']; // Jun25 is legacy pre-rename
+    const stored = ['2021-Dec', 'לא-קיים', 'Jun25']; // Jun25 is legacy pre-rename; '2021-Jun' was retagged away in v10.64.150
     const loaded = new Set(stored.filter(y => EXAM_YEARS.includes(y)));
-    expect([...loaded]).toEqual(['2021-Jun']);
+    expect([...loaded]).toEqual(['2021-Dec']);
   });
 
   test('all canonical EXAM_YEARS are represented in questions.json', () => {

--- a/tests/tagMigration.test.js
+++ b/tests/tagMigration.test.js
@@ -9,8 +9,8 @@
  *
  * Invariants:
  *   1. MAP rewrites are applied across all whitelisted storage keys.
- *   2. DROP ('2025-א') is removed from arrays and object values — split by
- *      classification, cannot auto-migrate.
+ *   2. DROP ('2025-א', '2023-ב', '2023-Sep') is removed from arrays and object
+ *      values — split by classification/sitting, cannot auto-migrate.
  *   3. Sentinel `__tagMigrationV1` is set on plain-object state, NOT arrays.
  *   4. Already-sentinel'd state is left untouched.
  *   5. Corrupt JSON per key is swallowed per-key (other keys still migrate).
@@ -75,17 +75,26 @@ describe('shlav-a-mega.html — migrateExamYearTags IIFE', () => {
         }),
       });
       const after = JSON.parse(ls.getItem('samega'));
+      // v10.64.150: 'יוני 21'→2021-Dec (was 2021-Jun); '2023-ב' dropped (2023-Sep no longer a sitting).
       expect(after.selectedYears).toEqual([
-        '2021-Jun', '2023-Jun-Basic', '2025-Jun', '2024-May-Basic', '2024-Sep-Basic', '2023-Sep', '2025-Jun',
+        '2021-Dec', '2023-Jun-Basic', '2025-Jun', '2024-May-Basic', '2024-Sep-Basic', '2025-Jun',
       ]);
     });
 
     it('leaves already-canonical labels alone', () => {
       const ls = runMigration({
-        samega: JSON.stringify({ selectedYears: ['2021-Jun', '2025-Jun', 'unknown-tag'] }),
+        samega: JSON.stringify({ selectedYears: ['2021-Dec', '2025-Jun-Basic', 'unknown-tag'] }),
       });
       const after = JSON.parse(ls.getItem('samega'));
-      expect(after.selectedYears).toEqual(['2021-Jun', '2025-Jun', 'unknown-tag']);
+      expect(after.selectedYears).toEqual(['2021-Dec', '2025-Jun-Basic', 'unknown-tag']);
+    });
+
+    it('migrates the dead canonical tags (v10.64.150): 2021-Jun → 2021-Dec, 2023-Sep dropped', () => {
+      const ls = runMigration({
+        samega: JSON.stringify({ selectedYears: ['2021-Jun', '2023-Sep', '2025-Jun-Basic'] }),
+      });
+      const after = JSON.parse(ls.getItem('samega'));
+      expect(after.selectedYears).toEqual(['2021-Dec', '2025-Jun-Basic']);
     });
 
     it('walks into nested objects/arrays', () => {
@@ -99,7 +108,7 @@ describe('shlav-a-mega.html — migrateExamYearTags IIFE', () => {
       const after = JSON.parse(ls.getItem('samega'));
       expect(after.filters.exam.pick).toBe('2024-May-Basic');
       expect(after.tags.q1).toBe('2025-Jun');
-      expect(after.list[0]).toEqual(['2021-Jun']);
+      expect(after.list[0]).toEqual(['2021-Dec']);
     });
   });
 
@@ -109,7 +118,7 @@ describe('shlav-a-mega.html — migrateExamYearTags IIFE', () => {
         samega: JSON.stringify({ selectedYears: ['יוני 21', '2025-א', '2025-Jun'] }),
       });
       const after = JSON.parse(ls.getItem('samega'));
-      expect(after.selectedYears).toEqual(['2021-Jun', '2025-Jun']);
+      expect(after.selectedYears).toEqual(['2021-Dec', '2025-Jun']);
       expect(after.selectedYears).not.toContain('2025-א');
     });
 
@@ -118,7 +127,7 @@ describe('shlav-a-mega.html — migrateExamYearTags IIFE', () => {
         samega: JSON.stringify({ picker: { current: '2025-א', prev: 'יוני 21' } }),
       });
       const after = JSON.parse(ls.getItem('samega'));
-      expect(after.picker.prev).toBe('2021-Jun');
+      expect(after.picker.prev).toBe('2021-Dec');
       expect('current' in after.picker).toBe(false);
     });
   });
@@ -159,11 +168,12 @@ describe('shlav-a-mega.html — migrateExamYearTags IIFE', () => {
         samega_custom_qs: JSON.stringify({ tag: 'ספט 24' }),
         samega_pending_qs: JSON.stringify({ tag: '2023-ב' }),
       });
-      expect(JSON.parse(ls.getItem('samega')).a).toBe('2021-Jun');
+      expect(JSON.parse(ls.getItem('samega')).a).toBe('2021-Dec');
       expect(JSON.parse(ls.getItem('samega_mock_hist')).tag).toBe('2024-May-Basic');
       expect(JSON.parse(ls.getItem('samega_sessions')).tag).toBe('2025-Jun');
       expect(JSON.parse(ls.getItem('samega_custom_qs')).tag).toBe('2024-Sep-Basic');
-      expect(JSON.parse(ls.getItem('samega_pending_qs')).tag).toBe('2023-Sep');
+      // '2023-ב' is now in DROP → the value is removed, so the key is deleted.
+      expect('tag' in JSON.parse(ls.getItem('samega_pending_qs'))).toBe(false);
     });
 
     it('swallows corrupt JSON on one key without aborting others', () => {
@@ -174,7 +184,7 @@ describe('shlav-a-mega.html — migrateExamYearTags IIFE', () => {
       // Corrupt key untouched.
       expect(ls.getItem('samega')).toBe('{not-json');
       // Healthy key still migrated.
-      expect(JSON.parse(ls.getItem('samega_sessions')).tag).toBe('2021-Jun');
+      expect(JSON.parse(ls.getItem('samega_sessions')).tag).toBe('2021-Dec');
     });
 
     it('ignores keys that are absent', () => {

--- a/tests/tagMigration.test.js
+++ b/tests/tagMigration.test.js
@@ -192,3 +192,33 @@ describe('shlav-a-mega.html — migrateExamYearTags IIFE', () => {
     });
   });
 });
+
+// v10.64.150: the samega_exam_filter load path is NOT covered by the migrateExamYearTags
+// IIFE (it's not in the IIFE's key whitelist), so it carries its own inline retag of the
+// retired tags. Pin that behaviour so a saved '2021-Jun' filter isn't silently dropped. (Codex #318 P2)
+describe('shlav-a-mega.html — selectedExamYears loader migrates retired exam tags', () => {
+  function runLoader(saved) {
+    const eyStart = html.indexOf('const EXAM_YEARS=[');
+    const selStart = html.indexOf('let selectedExamYears=', eyStart);
+    const selEnd = html.indexOf('})();', selStart);
+    if (eyStart < 0 || selStart < 0 || selEnd < 0) throw new Error('EXAM_YEARS / selectedExamYears block not found');
+    const src = html.slice(eyStart, selEnd + 5);
+    const store = { samega_exam_filter: JSON.stringify(saved) };
+    const ctx = { localStorage: { getItem: (k) => (k in store ? store[k] : null) } };
+    vm.createContext(ctx);
+    vm.runInContext(src, ctx);
+    return vm.runInContext('[...selectedExamYears]', ctx).sort();
+  }
+
+  it("migrates a saved '2021-Jun' filter to '2021-Dec' and keeps valid tags", () => {
+    expect(runLoader(['2021-Jun', '2025-Jun-Basic'])).toEqual(['2021-Dec', '2025-Jun-Basic']);
+  });
+
+  it("drops a saved '2023-Sep' filter (split across sittings, not remappable)", () => {
+    expect(runLoader(['2021-Jun', '2023-Sep'])).toEqual(['2021-Dec']);
+  });
+
+  it('still filters out genuinely-unknown saved tags', () => {
+    expect(runLoader(['2021-Dec', 'not-a-tag', '2025-Jun-Basic'])).toEqual(['2021-Dec', '2025-Jun-Basic']);
+  });
+});

--- a/tests/topicSrcScope.test.js
+++ b/tests/topicSrcScope.test.js
@@ -62,9 +62,9 @@ describe('v10.9 — topic source scope', () => {
 
     it('classifies every current exam tag as exam', () => {
       const examTags = [
-        '2020', '2021-Jun', '2021-Dec', '2022-Jun-Subspec', '2022-Jun-Basic',
+        '2020', '2021-Dec', '2022-Jun-Subspec', '2022-Jun-Basic',
         '2022-Jun-orphan', '2023-Jun-Subspec', '2023-Jun-Basic', '2023-Jun-orphan',
-        '2023-Sep', '2024-May-Subspec', '2024-May-Basic', '2024-Sep-Subspec',
+        '2024-May-Subspec', '2024-May-Basic', '2024-Sep-Subspec',
         '2024-Sep-Basic', '2024-orphan', '2025-Jun',
       ];
       for (const t of examTags) {


### PR DESCRIPTION
## What & why
`2021-Jun` (103 Qs) and `2023-Sep` (22 Qs) were **never real IMA geriatrics sittings** — there is no June-2021 or Sep-2023 exam (the 2021 sitting was Dec; 2023 was Jun). They were ingestion mislabels. Each Q is resolved to its **true booklet** by same-corruption k-gram overlap against the actual exam PDFs at `~/.claude/Exams` (the text-layer corruption is identical in booklet + dataset, so it matches reliably).

| dead tag | → true sitting | evidence |
|---|---|---|
| `2021-Jun` (103) | **all → `2021-Dec`** | every Q matched the `2021-12-21` Advanced booklet (max conf 0.94, 101/103 ≥0.5, **none** matched 2020) — vindicates the #316 idx-2419 finding |
| `2023-Sep` (22) | `2020`×8 / `2021-Dec`×8 / `2023-Jun-Basic`×6 | garbage/orphan tag, per-Q resolved, all ≥0.5 conf |

**125 `t`-only changes; 0 changes to `q`/`o`/`c`/`e`/`ref`; count unchanged (3823).** Per-Q map: `.audit_logs/clinical_sweep_2026-06-01/retag_map.json`.

Counts: `2020` 100→108, `2021-Dec` 104→215, `2023-Jun-Basic` 141→147; both dead tags eliminated.

## Downstream (10 files, lockstep)
- **`shlav-a-mega.html`**: `EXAM_YEARS` picker (13→11), `_yearAbbr`, `OLD_EX`, and the localStorage tag-migration `MAP` — `יוני 21` + canonical `2021-Jun` → `2021-Dec`; `2023-ב`/`2023-Sep` → DROP (can't map to one sitting). Sentinel kept at V1 (no forced global re-migration; never-migrated users get the corrected MAP, rare stale saved filters degrade gracefully).
- **Tests**: `pastExamCoverage` REQUIRED_TAGS; `regressionGuards` count-locks + 4 tag lists + 2 fixtures; `dataIntegrity`/`parserBleed`/`topicSrc` allowlists; `multiSelectFilters` `EXAM_YEARS` length; `tagMigration` assertions rewritten (+ new test pinning the dead-tag migration); `harrison-hebrew-baseline` tag set.

## Duplicate exposure — handled non-destructively (no deletions)
Merging the two ingestions of the Dec-2021 sitting surfaced curator **paraphrase-pairs** (same Q + same answer, punctuation/spacing variants — the documented "condensed second-edition" pairs). 18 were already `allow_dup`; 2 more (idx 274, 2463) flagged to match. Made the digit-stripping dup guard (`regressionGuards` line-185) honor `allow_dup`, **consistent with** the per-tag + cross-tag dup guards that already do. Within-tag dup-stems remain at the ceiling. A future *dedup* (deleting the redundant copies) is a cleaner follow-up but destructive — deferred for explicit sign-off.

## Gates
- `npm run verify` ✅ 90 files / 1618 tests · `npm run regen:check` ✅ no drift
- Verified: exactly 127 questions changed (125 `t`-only + 2 `allow_dup`-only); byte-exact JSON format; no `2021-Jun`/`2023-Sep` remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)