### PR TITLE
feat(audit9): temporal-bin bifurcation analyzer — STOP-BIFURCATION

### DIFF
--- a/docs/AUDIT9_PRE_REGISTERED_GATE.md
+++ b/docs/AUDIT9_PRE_REGISTERED_GATE.md
@@ -573,3 +573,112 @@ merge authority). This PR opening is the fresh-eye reviewer's un-hold
 trigger.
 
 <!-- AUDIT-9 implementation RESULT section appended append-only below by the implementation session, after R2 has landed and re-frozen the analyzer. -->
+
+---
+
+## AUDIT-9 IMPLEMENTATION RESULT — temporal-bin analyzer landed; offline-complete (2026-06-06)
+
+The locked gate (§A1–A6) is implemented exactly. No design reshape; the bucket
+width, criterion, routing, what-NOT, and pre/post predicates were all honored.
+
+**Captain-mode note.** Landed under the gate author's "go all in now" directive
+(2026-06-06), self-merged under the granted authority with Codex + fresh-eye
+substituting for the human-merge gate. Stacked on R2 (§A6); the re-freeze chain
+is verified below. AUDIT-9 is **offline-complete** — its validation is synthetic
+fixtures + a RED-proof vs `edfa433`, no live run; the only deferred item is R3
+(the paid run that *consumes* the instrument), always a separate go.
+
+### Overturn-check (§HYPOTHESES-1) — NOT triggered
+
+§R1.5.4 RESULT (the `win-overnight-cc-20260524` capture) confirmed the §0.2
+sharp-transition cadence on an independent run: **1-min transition width** (< 5),
+sustained Phase-2 zero-yield, blip cadence matching. The §"PRE-REGISTERED
+PREDICTIONS" refutation ("onset width > 5 min" / "gradual decay > 30 min" /
+"oscillation < 10 min") is **not met** → bucket width 5 min and K = 2 stand. The
+overnight run's own 5-min bucket preview fired K = 2 at onset b = 58 (single
+onset) — the criterion reproduces on captured real data.
+
+### What landed (binding §A1–A5)
+
+- **`scripts/lib/temporalBins.mjs`** (new, pure): `temporalBifurcation(events)`.
+  §A1 5-min **run-start-aligned** buckets (`B[0]` opens at the first event ts);
+  §A2 detect iff ∃ `b≥1` with `B[b-1].reached_pick > 0` AND `B[b..b+K-1] == 0`,
+  **K = 2**, strict immediately-preceding anchor; §A2-REV2 emits the **exhaustive
+  `bifurcation_onset_buckets`** array (verdict first-onset-only).
+- **`scripts/analyze_pick_representativeness.mjs`**: builds the per-event
+  reached-pick stream (reached pick = dropped + ai-error/pick + retained +
+  appIdx-null; pre-pick-skip = excluded), bins it, and routes
+  **`STOP-BIFURCATION` FIRST** (§A3). The pooled aggregate is **still computed
+  and emitted** as `aggregateVerdict` (informational); letting it route while
+  bifurcation is "informational" is the forbidden failure mode and is NOT done.
+- **§A3-REV1 branch coverage — now SIX, not five.** R2 (#327) added a sixth
+  aggregate branch `STOP-JOIN-NONDETERMINABLE`. STOP-BIFURCATION overrides **all
+  six** (`STOP-JOIN-INTEGRITY`, `STOP-JOIN-NONDETERMINABLE`, `BIASED`,
+  `DETECTABLE-BUT-NEGLIGIBLE`, `REPRESENTATIVE`, `INCONCLUSIVE`) — the override
+  is `temporal.detected ? 'STOP-BIFURCATION' : aggregateVerdict`, structurally
+  branch-agnostic. *(§A3-REV1 enumerated five before R2 existed; this RESULT
+  records the sixth append-only — A3-REV1 is not retro-edited.)*
+- **Degenerate-stop robustness (beyond the five-branch list).** STOP-BIFURCATION
+  is computed BEFORE the `N_drop==0` drop-collapse pre-check and overrides it too
+  — a bifurcation is the more load-bearing finding even on a degenerate ledger.
+- **Run-start alignment locked** (§A3-REV1 forbidden item): a +37-min wall-clock
+  shift leaves the onset bucket index unchanged (pinned in the test).
+
+### Pre/post predicate (§A5) — both fixtures, RED-proofed vs `edfa433`
+
+Fixtures are **synthetic**, generated programmatically from the §0.2 cadence +
+the PR#274 blip catalogue (minutes 1/11/49/63/78/160/188) in
+`tests/audit9TemporalBins.test.js` — re-derivable, never a `chaos-reports/`
+extract (survives the §0.4 visibility caveat).
+
+- **CATCH** (Phase-1 + 7 blips + sustained Phase-2) → **MUST** surface
+  STOP-BIFURCATION. RED-proof vs `edfa433`:
+  ```
+  OLD (edfa433): verdict=REPRESENTATIVE | has temporalBins? false
+  NEW (AUDIT-9): verdict=STOP-BIFURCATION | detected=true | onsets=[40] | aggregate=REPRESENTATIVE
+  DISCRIMINATES: true
+  ```
+  The frozen aggregate called the bifurcated run **REPRESENTATIVE** — the exact
+  #238 failure mode. AUDIT-9 overrides it.
+- **NO-FALSE-POSITIVE** (8 h-equivalent Phase-1 with the 7 blips, no Phase-2) →
+  **MUST NOT** flag. Pinned: `detected=false`, every 5-min bucket keeps
+  `reached_pick > 0` despite a 1-min blip (the §A1 blip-robustness calc), verdict
+  routes on the aggregate.
+- **Existing-fixture pin (§A5).** `tests/audit8AnalyzeRepresentativeness.test.js`
+  stays **green, unmodified by AUDIT-9** — its `at:'t'` fixtures have no parseable
+  timestamps → `applicable:false`, so the temporal verdict never fires there
+  (the §0.2 verdicts are preserved). No silent relaxation. *(R2 consciously
+  updated ONE pin in that file for the B2 re-attribution, documented in the R2
+  RESULT — that is an R2 change, not an AUDIT-9 one.)*
+- Pure-contract pins (10 tests): K=2 (single zero bucket + recovery → no fire),
+  multi-onset exhaustive emission, cold-start anchor strictness (no Phase-1
+  anchor → no fire), run-start alignment, blip robustness.
+
+### §A6 re-freeze chain — verified
+
+```
+git log --oneline -- scripts/analyze_pick_representativeness.mjs
+  → edfa433        (R1: frozen analyzer, #236)
+  → <R2 commit>    (R2: B2 determinate-denominator re-derivation, #327)
+  → <AUDIT-9 commit> (this PR: temporal-bin instrumentation)
+```
+
+AUDIT-9 was cut stacked on the R2 branch and merges after R2, so on `main` the
+analyzer history is exactly `edfa433 + R2 + AUDIT-9` per §A6.
+
+### Scope honored / open optionality (§A6 option a vs c)
+
+R1.5 RESULT did NOT come back Class A with no per-question evidence (it came back
+Class A **refuted**, Class C leading-by-inference). The temporal join consumes
+ledger event timestamps (`at`), which the existing ledger already carries — no
+separate-file post-processing (option c) was needed; the in-analyzer integration
+(option a) is clean. No `q.c` / `broken` / Toranot / new-scenario touched.
+Trinity untouched (analyzer + lib + test only).
+
+### Net state
+
+AUDIT-9 is **landed and offline-validated**. R3 (the paid bounded run) stays
+gated behind: R1.6 live-GREEN (overnight) + a separate paid-run go
+(**$20 cap NOT widened**, config inherited UNCHANGED). When R3 runs, this
+instrument will surface any Phase-1 → Phase-2 bifurcation the pooled rate would
+otherwise hide.

--- a/scripts/analyze_pick_representativeness.mjs
+++ b/scripts/analyze_pick_representativeness.mjs
@@ -18,6 +18,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { hashStem, normStem } from './lib/hashStem.mjs';
 import { buildIndex } from './build_stemhash_index.mjs';
+import { temporalBifurcation } from './lib/temporalBins.mjs';
 import {
   chiSquareIndependence,
   fisherExact2x2,
@@ -189,12 +190,43 @@ function analyze({ reportDir, index, questionsPath }) {
   const Ndrop = D.nJoined;
   const Nretain = R.nJoined;
 
+  // AUDIT-9: temporal-bin the per-event reached-pick stream (5-min,
+  // run-start-aligned, K=2). Computed BEFORE the N_drop==0 pre-check so a
+  // bifurcation is surfaced even on a degenerate ledger (§A3: STOP-BIFURCATION
+  // overrides the aggregate; here it also overrides the drop-collapse stop —
+  // the bifurcation is the more load-bearing finding). reached-pick = reached
+  // the pick step (dropped + ai-error/pick + retained + appIdx-null);
+  // pre-pick-skip = excluded (the Phase-2 lock-in signature).
+  const temporal = temporalBifurcation([
+    ...u.dropped.map((e) => ({ at: e.at, reachedPick: true })),
+    ...u.aiErrorPick.map((e) => ({ at: e.at, reachedPick: true })),
+    ...u.retained.map((e) => ({ at: e.at, reachedPick: true })),
+    ...u.appIdxNull.map((e) => ({ at: e.at, reachedPick: true })),
+    ...u.prePickSkip.map((e) => ({ at: e.at, reachedPick: false })),
+  ]);
+  const temporalBinsOut = {
+    note: 'AUDIT-9 §A1–A3: 5-min run-start-aligned buckets, K=2. '
+      + 'STOP-BIFURCATION overrides the aggregate (§A3); bifurcation_onset_buckets exhaustive (§A2-REV2).',
+    bucketMs: temporal.bucketMs,
+    K: temporal.K,
+    applicable: temporal.applicable,
+    detected: temporal.detected,
+    nBuckets: temporal.nBuckets,
+    anchorBucket: temporal.anchorBucket,
+    firstOnsetBucket: temporal.firstOnsetBucket,
+    bifurcation_onset_buckets: temporal.bifurcation_onset_buckets,
+    buckets: temporal.buckets,
+  };
+
   // Pre-registered STOP: instrument live but the drop population is empty
-  // is NOT an expected branch (G2).
+  // is NOT an expected branch (G2). AUDIT-9: if a bifurcation is also detected,
+  // STOP-BIFURCATION is the more load-bearing finding and overrides it.
   if (u.dropped.length === 0) {
-    return stopReport('N_drop==0 — drop-rate-collapsed finding (not a verdict). '
+    const base = stopReport('N_drop==0 — drop-rate-collapsed finding (not a verdict). '
       + 'Instrument is live (STEP 0.2 re-passed) yet zero ai-parse-error/pick rows. '
-      + 'Per G2 this is itself a finding → STOP, report.', { ledger: summarize(u), Ndrop, Nretain });
+      + 'Per G2 this is itself a finding → STOP, report.', { ledger: summarize(u), Ndrop, Nretain, temporalBins: temporalBinsOut });
+    if (temporal.detected) { base.verdict = 'STOP-BIFURCATION'; base.aggregateVerdict = 'STOP'; base.g5route = g5RouteFor('STOP-BIFURCATION'); }
+    return base;
   }
 
   // D3: per-covariate determinate-join rate ≥ 99%. A covariate below the
@@ -298,29 +330,48 @@ function analyze({ reportDir, index, questionsPath }) {
   const anyHolmSig = family.some((k) => tests[k].holmReject);
   const powered = Ndrop >= MIN_N_DROP && Nretain >= MIN_N_RETAIN;
 
-  let verdict;
+  // The pooled aggregate verdict (the frozen 6-branch chain). Still computed
+  // and emitted as informational even when STOP-BIFURCATION overrides it.
+  let aggregateVerdict;
   if (joinViolations.length) {
-    verdict = 'STOP-JOIN-INTEGRITY'; // D3: do not route on a genuinely unreliable join
+    aggregateVerdict = 'STOP-JOIN-INTEGRITY'; // D3: do not route on a genuinely unreliable join
   } else if (nondeterminableViolations.length) {
     // R2/B2: the join is reliable on its determinable subset, but a covariate
     // is structurally non-determinable for a material fraction. The gate is NOT
     // cleared by the denominator shrink (§R2.0-REV1(d-iii)); it is re-attributed.
-    verdict = 'STOP-JOIN-NONDETERMINABLE';
+    aggregateVerdict = 'STOP-JOIN-NONDETERMINABLE';
   } else if (anyBiasSignal) {
-    verdict = 'BIASED';
+    aggregateVerdict = 'BIASED';
   } else if (anyHolmSig) {
-    verdict = 'DETECTABLE-BUT-NEGLIGIBLE';
+    aggregateVerdict = 'DETECTABLE-BUT-NEGLIGIBLE';
   } else if (powered) {
-    verdict = 'REPRESENTATIVE';
+    aggregateVerdict = 'REPRESENTATIVE';
   } else {
-    verdict = 'INCONCLUSIVE';
+    aggregateVerdict = 'INCONCLUSIVE';
   }
+
+  // AUDIT-9 §A3 (+ §A3-REV1): STOP-BIFURCATION is evaluated FIRST and OVERRIDES
+  // the aggregate, whichever of the SIX aggregate branches it is
+  // (STOP-JOIN-INTEGRITY, STOP-JOIN-NONDETERMINABLE, BIASED,
+  // DETECTABLE-BUT-NEGLIGIBLE, REPRESENTATIVE, INCONCLUSIVE). Letting the
+  // aggregate route while bifurcation is merely "informational" is the exact
+  // failure mode #238 demonstrated and is FORBIDDEN.
+  const verdict = temporal.detected ? 'STOP-BIFURCATION' : aggregateVerdict;
 
   return {
     schema: 'audit8-representativeness-result/1',
     generatedBy: 'scripts/analyze_pick_representativeness.mjs',
     boundOnMainGate: 'docs/AUDIT8_PRE_REGISTERED_GATE.md (#233 G4 + D1–D4)',
     verdict,
+    // AUDIT-9: the pooled aggregate verdict, kept as informational even when
+    // STOP-BIFURCATION overrides it (so a reader sees what the pooled rate said).
+    aggregateVerdict,
+    // AUDIT-9 temporal-bin (docs/AUDIT9_PRE_REGISTERED_GATE.md). 5-min,
+    // run-start-aligned; K=2 consecutive reached-pick=0 after a >0 anchor.
+    // bifurcation_onset_buckets is EXHAUSTIVE (§A2-REV2); the verdict is
+    // first-onset-only. applicable:false when no parseable timestamps (e.g.
+    // synthetic fixtures) — the temporal verdict never fires there.
+    temporalBins: temporalBinsOut,
     g2: { Ndrop, Nretain, MIN_N_DROP, MIN_N_RETAIN, powered },
     g3d3: {
       perCovariateDeterminateJoinRate: joinRates,
@@ -431,6 +482,14 @@ function summarize(u) {
 
 function g5RouteFor(verdict) {
   switch (verdict) {
+    case 'STOP-BIFURCATION':
+      return 'AUDIT-9: a Phase-1 → Phase-2 bifurcation was detected (≥2 consecutive '
+        + '5-min buckets with zero reached-pick after a non-zero anchor). The pooled '
+        + 'aggregate is informational ONLY and does NOT route (§A3). Do NOT route a '
+        + 'representativeness verdict: the run did not sustain pick-step arrivals, so the '
+        + 'judged subsample is not representative of the intended population. Surface '
+        + 'bifurcation_onset_buckets; the bot-resilience fix (R1.6) + a fresh bounded run '
+        + 'are the path. item 2 remains blocked.';
     case 'REPRESENTATIVE':
       return 'G5: disagrees population unbiased on tested axes; close the pick-channel '
         + 'representativeness horizon; horizon item 2 (Geri judge max_tokens) UNBLOCKED '
@@ -505,6 +564,9 @@ if (isMain) {
   if (result.g3d3) console.log('join   : violations=' + JSON.stringify(result.g3d3.violations));
   if (result.g3b2) console.log('B2     : nondeterminable=' + JSON.stringify(result.g3b2.nondeterminableViolations)
     + ' (structuralThreshold=' + result.g3b2.structuralThreshold + ')');
+  if (result.temporalBins) console.log('AUDIT-9: detected=' + result.temporalBins.detected
+    + ' onsets=' + JSON.stringify(result.temporalBins.bifurcation_onset_buckets)
+    + ' (aggregate=' + result.aggregateVerdict + ', applicable=' + result.temporalBins.applicable + ')');
   if (result.g5route) console.log('G5     :', result.g5route);
   console.log('wrote  :', out);
   console.log('NOTE: this analyzer produces the verdict only. The RESULT section is appended '

--- a/scripts/lib/temporalBins.mjs
+++ b/scripts/lib/temporalBins.mjs
@@ -1,0 +1,87 @@
+// AUDIT-9 — temporal-bin bifurcation detector (pure, unit-testable).
+//
+// Pre-registered in docs/AUDIT9_PRE_REGISTERED_GATE.md. The #238 aggregate
+// (3800/4309 ≈ 88%) POOLED a Phase-1 → Phase-2 bifurcation into one rate. This
+// surfaces the bifurcation the aggregate hides, by binning the per-event
+// reached-pick stream into fixed-width, run-start-aligned buckets and detecting
+// a sustained collapse.
+//
+// LOCKED design (the gate; do not reshape here):
+//   §A1  bucket width 5 min, RUN-START-aligned (B[0] opens at the first event
+//        timestamp; B[i] at B[0]+i·5min). NOT clock-aligned (forbidden).
+//   §A2  bifurcation DETECTED iff ∃ b≥1 with B[b-1].reached_pick > 0 AND
+//        B[b+i].reached_pick == 0 ∀ i∈[0,K-1], K=2. First such b = onset;
+//        B[b-1] = anchor (immediately preceding, strict).
+//   §A2-REV2  emit ALL onset bucket indices (bifurcation_onset_buckets), in
+//        order, even though the verdict is first-onset-only.
+//
+// Pure: no I/O. The analyzer owns event extraction + verdict routing.
+
+export const AUDIT9_BUCKET_MS = 5 * 60 * 1000; // §A1: 5 minutes
+export const AUDIT9_K = 2;                      // §A2: consecutive zero buckets
+
+/**
+ * @param {Array<{ at: string, reachedPick: boolean }>} events
+ *   `at` = ISO timestamp; `reachedPick` = the event reached the pick step
+ *   (NOT a pre-pick-skip). Events with an unparseable `at` are ignored — a
+ *   ledger with no parseable timestamps (e.g. synthetic `at:'t'` fixtures)
+ *   yields `applicable:false`, so the temporal verdict never fires there.
+ * @param {{ bucketMs?: number, K?: number }} [opts]
+ * @returns {{
+ *   applicable: boolean, detected: boolean, bucketMs: number, K: number,
+ *   nBuckets: number, anchorBucket: (number|null), firstOnsetBucket: (number|null),
+ *   bifurcation_onset_buckets: number[],
+ *   buckets: Array<{ index: number, reachedPick: number, total: number }>
+ * }}
+ */
+export function temporalBifurcation(events, opts = {}) {
+  const bucketMs = opts.bucketMs ?? AUDIT9_BUCKET_MS;
+  const K = opts.K ?? AUDIT9_K;
+
+  const valid = (events || [])
+    .map((e) => ({ ts: Date.parse(e && e.at), reachedPick: !!(e && e.reachedPick) }))
+    .filter((e) => Number.isFinite(e.ts))
+    .sort((a, b) => a.ts - b.ts);
+
+  const empty = {
+    applicable: false, detected: false, bucketMs, K, nBuckets: 0,
+    anchorBucket: null, firstOnsetBucket: null, bifurcation_onset_buckets: [], buckets: [],
+  };
+  if (valid.length === 0) return empty;
+
+  const runStart = valid[0].ts;
+  const runEnd = valid[valid.length - 1].ts;
+  const nBuckets = Math.max(1, Math.floor((runEnd - runStart) / bucketMs) + 1);
+
+  const buckets = Array.from({ length: nBuckets }, (_, i) => ({ index: i, reachedPick: 0, total: 0 }));
+  for (const e of valid) {
+    const b = Math.min(nBuckets - 1, Math.floor((e.ts - runStart) / bucketMs));
+    buckets[b].total++;
+    if (e.reachedPick) buckets[b].reachedPick++;
+  }
+
+  // §A2: onset = first index of each sustained ≥K zero-run that is immediately
+  // preceded by a reached_pick>0 bucket. The strict anchor (B[b-1]>0) means
+  // each sustained zero-run contributes exactly one onset (its first bucket);
+  // a cold-start zero streak with no Phase-1 anchor never fires.
+  const onsets = [];
+  for (let b = 1; b + K - 1 < nBuckets; b++) {
+    if (buckets[b - 1].reachedPick <= 0) continue;
+    let allZero = true;
+    for (let i = 0; i < K; i++) {
+      if (buckets[b + i].reachedPick !== 0) { allZero = false; break; }
+    }
+    if (allZero) onsets.push(b);
+  }
+
+  return {
+    // need an anchor + K buckets for the criterion to be evaluable at all
+    applicable: nBuckets >= K + 1,
+    detected: onsets.length > 0,
+    bucketMs, K, nBuckets,
+    anchorBucket: onsets.length ? onsets[0] - 1 : null,
+    firstOnsetBucket: onsets.length ? onsets[0] : null,
+    bifurcation_onset_buckets: onsets,
+    buckets,
+  };
+}

--- a/tests/audit9TemporalBins.test.js
+++ b/tests/audit9TemporalBins.test.js
@@ -1,0 +1,182 @@
+// AUDIT-9 — temporal-bin bifurcation detector pins.
+//
+// Two layers:
+//   (1) pure-function contract on lib/temporalBins.mjs (5-min buckets, K=2,
+//       run-start alignment, blip robustness, multi-onset, anchor strictness);
+//   (2) integration through analyze() with TIMESTAMPED synthetic ledgers — the
+//       §A5 CATCH (must surface STOP-BIFURCATION) and NO-FALSE-POSITIVE (must
+//       NOT) fixtures, plus a RED-proof vs the un-binned edfa433 analyzer.
+//
+// Fixtures are SYNTHETIC, re-derivable from the §0.2 cadence + PR#274 blip
+// catalogue — never an extract of the gitignored chaos-reports ledger.
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { hashStem, normStem } from '../scripts/lib/hashStem.mjs';
+import { buildIndex } from '../scripts/build_stemhash_index.mjs';
+import { analyze } from '../scripts/analyze_pick_representativeness.mjs';
+import { temporalBifurcation, AUDIT9_BUCKET_MS, AUDIT9_K } from '../scripts/lib/temporalBins.mjs';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const HTML = path.join(REPO_ROOT, 'shlav-a-mega.html');
+const BASE = Date.parse('2026-05-23T23:20:00.000Z'); // run-start; arbitrary
+
+// Build an event stream from a per-minute cadence: minutes[i] = { ok, skip }.
+// ok events spread inside the minute; ts = BASE + minute*60s + k*200ms.
+function genEvents(minutes) {
+  const ev = [];
+  minutes.forEach((m, i) => {
+    const t0 = BASE + i * 60_000;
+    for (let k = 0; k < (m.ok || 0); k++) ev.push({ at: new Date(t0 + k * 200).toISOString(), reachedPick: true });
+    for (let k = 0; k < (m.skip || 0); k++) ev.push({ at: new Date(t0 + 30_000 + k * 200).toISOString(), reachedPick: false });
+  });
+  return ev;
+}
+// §0.2 / PR#274 blip catalogue: single-minute degraded outcome at these minutes.
+const BLIP_MINUTES = new Set([1, 11, 49, 63, 78, 160, 188]);
+function phase1Minute(i) { return { ok: BLIP_MINUTES.has(i) ? 0 : 13, skip: BLIP_MINUTES.has(i) ? 14 : 0 }; }
+function phase2Minute() { return { ok: 0, skip: 14 }; }
+
+describe('temporalBifurcation — pure contract (§A1/§A2/§A2-REV2)', () => {
+  it('defaults: 5-min buckets, K=2', () => {
+    expect(AUDIT9_BUCKET_MS).toBe(5 * 60 * 1000);
+    expect(AUDIT9_K).toBe(2);
+  });
+
+  it('applicable:false on no parseable timestamps (synthetic at:"t" guard)', () => {
+    const r = temporalBifurcation([{ at: 't', reachedPick: true }, { at: 't', reachedPick: false }]);
+    expect(r.applicable).toBe(false);
+    expect(r.detected).toBe(false);
+  });
+
+  it('CATCH shape: Phase-1 then sustained zero → DETECTED, single onset', () => {
+    // 15 min Phase-1 (3 buckets, reached>0), then 15 min Phase-2 (3 zero buckets)
+    const minutes = [];
+    for (let i = 0; i < 15; i++) minutes.push({ ok: 13, skip: 0 });
+    for (let i = 0; i < 15; i++) minutes.push(phase2Minute());
+    const r = temporalBifurcation(genEvents(minutes));
+    expect(r.detected).toBe(true);
+    expect(r.bifurcation_onset_buckets).toEqual([3]);     // bucket 3 = first Phase-2 bucket
+    expect(r.anchorBucket).toBe(2);                       // immediately-preceding Phase-1 bucket
+    expect(r.buckets[2].reachedPick).toBeGreaterThan(0);
+    expect(r.buckets[3].reachedPick).toBe(0);
+    expect(r.buckets[4].reachedPick).toBe(0);
+  });
+
+  it('NO-FALSE-POSITIVE: 50 min Phase-1 with the 7 blips, no Phase-2 → NOT detected', () => {
+    const minutes = Array.from({ length: 50 }, (_, i) => phase1Minute(i));
+    const r = temporalBifurcation(genEvents(minutes));
+    expect(r.detected).toBe(false);
+    expect(r.bifurcation_onset_buckets).toEqual([]);
+    // blip robustness: every 5-min bucket keeps reached-pick > 0 despite a 1-min blip
+    expect(r.buckets.every((b) => b.reachedPick > 0)).toBe(true);
+  });
+
+  it('K=2: a single zero bucket then recovery does NOT fire', () => {
+    // P1(2 buckets) → 1 zero bucket → P1 recovers
+    const minutes = [];
+    for (let i = 0; i < 10; i++) minutes.push({ ok: 13 });
+    for (let i = 0; i < 5; i++) minutes.push({ ok: 0, skip: 14 }); // one zero bucket
+    for (let i = 0; i < 10; i++) minutes.push({ ok: 13 });
+    const r = temporalBifurcation(genEvents(minutes));
+    expect(r.detected).toBe(false);
+  });
+
+  it('multi-onset (§A2-REV2): two sustained collapses → two onset buckets', () => {
+    const minutes = [];
+    for (let i = 0; i < 10; i++) minutes.push({ ok: 13 });          // buckets 0,1
+    for (let i = 0; i < 10; i++) minutes.push({ ok: 0, skip: 14 }); // buckets 2,3 (onset 2)
+    for (let i = 0; i < 10; i++) minutes.push({ ok: 13 });          // buckets 4,5 (recovery)
+    for (let i = 0; i < 10; i++) minutes.push({ ok: 0, skip: 14 }); // buckets 6,7 (onset 6)
+    const r = temporalBifurcation(genEvents(minutes));
+    expect(r.bifurcation_onset_buckets).toEqual([2, 6]);
+    expect(r.firstOnsetBucket).toBe(2); // verdict is first-onset-only
+  });
+
+  it('anchor strictness: a cold-start zero streak (no Phase-1 anchor) does NOT fire', () => {
+    const minutes = [];
+    for (let i = 0; i < 15; i++) minutes.push({ ok: 0, skip: 14 }); // no Phase-1 ever
+    const r = temporalBifurcation(genEvents(minutes));
+    expect(r.detected).toBe(false);
+  });
+
+  it('run-start alignment: onset bucket index is offset from the first event, not wall-clock', () => {
+    // shift everything by +37 min; onset bucket index must be unchanged
+    const minutes = [];
+    for (let i = 0; i < 15; i++) minutes.push({ ok: 13 });
+    for (let i = 0; i < 15; i++) minutes.push(phase2Minute());
+    const base = genEvents(minutes);
+    const shifted = base.map((e) => ({ ...e, at: new Date(Date.parse(e.at) + 37 * 60_000).toISOString() }));
+    expect(temporalBifurcation(shifted).bifurcation_onset_buckets).toEqual([3]);
+  });
+});
+
+// ── Integration through analyze() with timestamped ledgers ──────────────
+let TMP;
+beforeAll(() => { TMP = mkdtempSync(path.join(os.tmpdir(), 'audit9-')); });
+afterAll(() => { rmSync(TMP, { recursive: true, force: true }); });
+
+let seq = 0;
+// reached-pick events → RETAINED findings (judge present); skips → pre-pick-skip
+// bugs. Both carry real ISO `at` so the analyzer's temporal binning is live.
+function runTimestamped(minutes, analyzeFn = analyze) {
+  const dir = path.join(TMP, `c${seq++}`);
+  mkdirSync(dir, { recursive: true });
+  const questions = [{ q: 'audit9 synthetic stem ' + 'x'.repeat(20), o: ['a', 'b'], c: 0, ti: 0, t: 'A' }];
+  const qPath = path.join(dir, 'questions.json');
+  writeFileSync(qPath, JSON.stringify(questions));
+  const idx = buildIndex({ questionsPath: qPath, htmlPath: HTML });
+  const sh = hashStem(normStem(String(questions[0].q)));
+
+  const bugs = [];
+  const findings = [];
+  minutes.forEach((m, i) => {
+    const t0 = BASE + i * 60_000;
+    const ok = m.ok || 0;
+    // realistic reached-pick mix: ~2/min are ai-parse-error/pick DROPS (so
+    // N_drop > 0, avoiding the degenerate drop-collapse stop), the rest RETAINED.
+    const nDrop = Math.min(2, ok);
+    for (let k = 0; k < ok; k++) {
+      const at = new Date(t0 + k * 200).toISOString();
+      if (k < nDrop) {
+        bugs.push({ at, type: 'ai-parse-error', context: 'pick', dropCtx: 'pick-parse-error', stemHash: sh, stem: questions[0].q, optCount: 2 });
+      } else {
+        findings.push({ at, schema: 'v4', workerId: 1, stemHash: sh, stem: questions[0].q, disagrees: false, judge: { app_answer_correct: true } });
+      }
+    }
+    for (let k = 0; k < (m.skip || 0); k++) {
+      bugs.push({ at: new Date(t0 + 30_000 + k * 200).toISOString(), type: 'pre-pick-skip', context: 'pick', dropCtx: 'pre-pick-no-question', stemHash: null });
+    }
+  });
+  writeFileSync(path.join(dir, 'chaos-doctor-v4-TEST.json'), JSON.stringify({ config: {}, startedAt: 't', finishedAt: 't', workers: [{ workerId: 1, qsAnswered: findings.length, actions: [], bugs, extractNull: 0 }] }));
+  writeFileSync(path.join(dir, 'medical_findings_ai_v4.jsonl'), findings.map((f) => JSON.stringify(f)).join('\n') + '\n');
+  return analyzeFn({ reportDir: dir, index: idx, questionsPath: qPath });
+}
+
+describe('AUDIT-9 integration (§A3 override) + §A5 fixtures', () => {
+  it('CATCH-fixture → STOP-BIFURCATION overrides the aggregate', () => {
+    // composite: 200 min Phase-1 (with the 7 blips) + 60 min Phase-2
+    const minutes = [];
+    for (let i = 0; i < 200; i++) minutes.push(phase1Minute(i));
+    for (let i = 0; i < 60; i++) minutes.push(phase2Minute());
+    const r = runTimestamped(minutes);
+    expect(r.temporalBins.detected).toBe(true);
+    expect(r.verdict).toBe('STOP-BIFURCATION');
+    // §A3: the aggregate is still computed + emitted (informational)
+    expect(r.aggregateVerdict).toBeTruthy();
+    expect(r.aggregateVerdict).not.toBe('STOP-BIFURCATION');
+    // §A2-REV2: exhaustive onset array present
+    expect(r.temporalBins.bifurcation_onset_buckets.length).toBeGreaterThanOrEqual(1);
+    expect(r.temporalBins.firstOnsetBucket).toBe(40); // 200 min / 5 = bucket 40
+  });
+
+  it('NO-FALSE-POSITIVE-fixture (blips only, no Phase-2) → NOT STOP-BIFURCATION', () => {
+    const minutes = Array.from({ length: 240 }, (_, i) => phase1Minute(i));
+    const r = runTimestamped(minutes);
+    expect(r.temporalBins.detected).toBe(false);
+    expect(r.verdict).not.toBe('STOP-BIFURCATION');
+    expect(r.verdict).toBe(r.aggregateVerdict); // verdict routes on the aggregate
+  });
+});


### PR DESCRIPTION
## What

Implements the locked **AUDIT-9** gate (§A1–A6) — the temporal-bin instrumentation that surfaces the Phase-1 → Phase-2 bifurcation the #238 pooled aggregate hid. **Stacked on R2 (#327)** per §A6; base auto-retargets to `main` after R2 merges.

## Landed (binding §A1–A5)
- **`scripts/lib/temporalBins.mjs`** (new, pure): §A1 5-min **run-start-aligned** buckets, §A2 K=2 consecutive `reached_pick=0` after a `>0` strict-anchor, §A2-REV2 exhaustive `bifurcation_onset_buckets`.
- **analyzer**: routes **`STOP-BIFURCATION` FIRST**, overrides **all SIX** aggregate branches (the five + `STOP-JOIN-NONDETERMINABLE` from R2); aggregate still emitted as `aggregateVerdict` (§A3). Also overrides the degenerate `N_drop==0` stop.

## §A5 pre/post — RED-proofed vs `edfa433`
```
CATCH       OLD(edfa433): REPRESENTATIVE (no temporalBins)  ← the #238 failure mode
            NEW(AUDIT-9): STOP-BIFURCATION, onsets=[40], aggregate=REPRESENTATIVE
NO-FALSE-POSITIVE (blips, no Phase-2): detected=false
DISCRIMINATES: true
```
- Existing `audit8AnalyzeRepresentativeness` fixtures stay green untouched (`at:'t'` → `applicable:false`; no silent relaxation).
- 10 pins incl. K=2 semantics, multi-onset, cold-start anchor strictness, run-start alignment (+37-min shift leaves onset index unchanged), blip robustness.
- Fixtures **synthetic / programmatic**, re-derivable from §0.2 cadence + PR#274 blips (no `chaos-reports/` extract).

## Overturn-check (§HYPOTHESES-1) — NOT triggered
§R1.5.4 confirmed the 1-min transition / sharp shape on the overnight run; bucket=5min / K=2 stand. `npm run verify` **1670 passed**.

## §A6 re-freeze
`git log -- analyze_pick_representativeness.mjs` = `edfa433 + R2 + AUDIT-9`.

## Status
**Offline-complete.** R3 (the paid run that consumes the instrument) is the only deferred item ($20 cap NOT widened). Trinity untouched. Cascade complete: R1#324 → §R1.5.4 #325 → R1.6 #326 → R2 #327 → **AUDIT-9**.