### PR TITLE
chore: gitignore orphan *.generated.json scratch stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,10 @@ scripts/fm-state-probe.mjs
 source_completeness_audit_*.json
 data/ai_hard_seed.geri.generated.json
 
+# Orphan AI-generation scratch stubs (no in-repo producer) — prevent git add -A commits
+data/gapfill.generated.json
+data/highyield.generated.json
+
 # 2026-05-10: chaos-bot output + test coverage (prevent git add -A near-misses)
 chaos-reports/
 coverage/


### PR DESCRIPTION
Untracked placeholder `*.generated.json` stub file(s) appeared in the working tree (created 2026-06-06, no in-repo producer or consumer). Adds a targeted `.gitignore` entry so a future `git add -A` can't accidentally commit the junk. No app/version/behaviour change — config-only.

Surfaced by the cross-repo `/audit-fix-deploy` read-only audit. The stub files themselves were deleted locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)