### PR TITLE
fix(audit8/9): resolve 3 Codex P2 findings from the AUDIT-9 cascade

### DIFF
--- a/docs/AUDIT9_PRE_REGISTERED_GATE.md
+++ b/docs/AUDIT9_PRE_REGISTERED_GATE.md
@@ -682,3 +682,50 @@ gated behind: R1.6 live-GREEN (overnight) + a separate paid-run go
 (**$20 cap NOT widened**, config inherited UNCHANGED). When R3 runs, this
 instrument will surface any Phase-1 → Phase-2 bifurcation the pooled rate would
 otherwise hide.
+
+---
+
+## §A2-REV3 — Observed-zero-yield refinement (post-merge Codex review, 2026-06-06)
+
+Codex P2 on the AUDIT-9 implementation PR (#328,
+`scripts/lib/temporalBins.mjs`) flagged that the §A2 zero-run check tested only
+`reached_pick === 0`, so a **synthesized empty bucket** (`total === 0`) — a
+≥ `bucketMs` window with **no** AUDIT-9 input events at all (e.g. the worker
+reloads/sleeps off the quiz surface without emitting a dropped / retained /
+pre-pick-skip row) — was counted as a consecutive zero-yield bucket. A later
+event extending `runEnd` could then route `STOP-BIFURCATION` on an **idle /
+telemetry gap** rather than on the Phase-2 pre-pick-skip collapse the criterion
+targets.
+
+This is a refinement registered **before any R3 data is consumed** (R3 is still
+deferred — `$20 cap NOT widened`), so no verdict that has been seen is being
+re-routed (`feedback_prewritten_predictions`: the overturn condition is named
+before the data). The original §A2 / §A2-REV1 / §A2-REV2 text is **not
+retro-edited** (`feedback_spec_provenance_append_only`); this REV binds the
+clarification.
+
+**Binding clarification.** A bucket counts as a **zero-yield** bucket for the
+§A2 criterion only if it is **observed** — i.e. `total > 0 AND reached_pick == 0`
+(events present in the bucket, none reaching the pick step). An **empty** bucket
+(`total === 0`) is an *absence of observation*, not a Phase-2 collapse, and
+**breaks** the consecutive-zero run (it cannot be one of the K zero buckets, nor
+can it be the anchor). This matches §0.2's disk-grounded Phase-2 signature
+(13–14 `pre-pick-skip` **events** per minute — dense, not empty).
+
+**Why this does not touch the locked design.** Bucket width stays 5 min, K stays
+2, the strict immediately-preceding anchor stays, run-start alignment stays,
+`STOP-BIFURCATION` still overrides all aggregate branches. The forbidden list
+(K shrink, anchor relax, bucket resize, alignment change, aggregate-overrides-
+bifurcation, branch under-coverage) is untouched — REV3 *tightens* the
+zero-yield definition (fewer false positives), it does not relax any lock.
+
+**Pre/post (§A5 mirror).** The implementation PR adds an **idle-gap fixture**
+(anchor bucket > 0 → ≥ 2 empty buckets from an event gap → a later event):
+the criterion **MUST NOT** fire (`detected=false`). The canonical CATCH fixture
+(dense Phase-2: events present, all `pre-pick-skip`) **MUST still** fire
+`STOP-BIFURCATION` — the dense-Phase-2 path is unchanged because those buckets
+have `total > 0`. Both pinned in `tests/audit9TemporalBins.test.js`.
+
+**Review.** Criterion-semantics change to the locked instrument → **Codex
+re-review requested** (`@codex review`); not self-merged unreviewed, per the
+gate's cross-model independence rule.

--- a/scripts/analyze_pick_representativeness.mjs
+++ b/scripts/analyze_pick_representativeness.mjs
@@ -47,7 +47,14 @@ const JOIN_DETERMINATE_MIN = 0.99; // D3: per-covariate determinate-join rate
 // STRUCTURAL FRACTION. Per §R2.0-REV1(d-iii) the denominator shrink may NOT, by
 // itself, clear the gate: a structural fraction at/above this ceiling is a
 // reportable limitation → STOP-JOIN-NONDETERMINABLE (gate NOT cleared).
-const STRUCTURAL_NONDETERMINABLE_MAX = 1 - JOIN_DETERMINATE_MIN; // 0.01
+const STRUCTURAL_NONDETERMINABLE_MAX = 1 - JOIN_DETERMINATE_MIN; // 0.01 (ceiling)
+// Codex P2 (#327): `1 - 0.99` is 0.0100000000000000089 in IEEE-754, while an
+// exact 1-in-100 structural fraction is 0.0100000000000000002, so a bare
+// `structuralFraction >= STRUCTURAL_NONDETERMINABLE_MAX` does NOT fire at the
+// documented "at/above 1%" knife-edge. Compare with a tolerance far below any
+// meaningful step (0.5%) and far above float error (~1e-17) so the exact-1%
+// ceiling routes to STOP-JOIN-NONDETERMINABLE as specified.
+const STRUCTURAL_FRACTION_EPS = 1e-9;
 
 const CATEGORICAL = ['topic_group', 't', 'bilingual', 'c_accept', 'broken'];
 const ALL_COVS = ['stem_len', ...CATEGORICAL];
@@ -256,7 +263,7 @@ function analyze({ reportDir, index, questionsPath }) {
     const rate = t.attempted ? t.determinate / t.attempted : 0; // legacy D3 rate (reported, not routed)
     joinRates[c] = { rate, determinableRate, structuralFraction, ...t };
     if (determinableRate < JOIN_DETERMINATE_MIN) joinViolations.push(c);
-    else if (structuralFraction >= STRUCTURAL_NONDETERMINABLE_MAX) nondeterminableViolations.push(c);
+    else if (structuralFraction >= STRUCTURAL_NONDETERMINABLE_MAX - STRUCTURAL_FRACTION_EPS) nondeterminableViolations.push(c);
   }
   // Union of covariates that cannot enter the analysis family (either reason).
   const unusableCovs = [...joinViolations, ...nondeterminableViolations];

--- a/scripts/chaos-doctor-bot-v4.mjs
+++ b/scripts/chaos-doctor-bot-v4.mjs
@@ -977,12 +977,22 @@ async function runWorker(browser, workerId, stopAt, report) {
         // no-quiz lock-in escalates past reload, then recover.
         const decision = nextRecovery(recovery, { advanced: false, stemHash: null }, recoveryCfg);
         recovery = decision.state;
+        // Codex P2 (#326): only act on the escalation decision. Previously this
+        // branch reloaded on BOTH 'reload' AND 'none', but reloadsSinceProgress
+        // only advances inside nextRecovery once the null streak crosses
+        // nullStreakThreshold — so reloading on 'none' thrashed the page without
+        // counting toward escalation, needing ~15 reloads (5×3) to reach
+        // 'recreate' instead of the documented 3. Mirror the on-quiz path: act
+        // only on 'reload'/'recreate'; on 'none' just wait for the next turn.
         if (decision.action === 'recreate') {
           log.bugs.push({ at: nowIso(), type: 'stuck-refresh', tier: 'recreate', context: 'no-quiz', recovery });
           await context.close().catch(() => {});
           ({ context, page } = await freshContext());
-        } else {
+        } else if (decision.action === 'reload') {
+          log.bugs.push({ at: nowIso(), type: 'stuck-refresh', tier: 'reload', context: 'no-quiz', recovery });
           try { await page.reload({ waitUntil: 'domcontentloaded', timeout: 15_000 }); } catch (_) { /* ok */ }
+          await sleep(rand(2000, 4000));
+        } else {
           await sleep(rand(2000, 4000));
         }
         continue;

--- a/scripts/lib/temporalBins.mjs
+++ b/scripts/lib/temporalBins.mjs
@@ -10,8 +10,10 @@
 //   §A1  bucket width 5 min, RUN-START-aligned (B[0] opens at the first event
 //        timestamp; B[i] at B[0]+i·5min). NOT clock-aligned (forbidden).
 //   §A2  bifurcation DETECTED iff ∃ b≥1 with B[b-1].reached_pick > 0 AND
-//        B[b+i].reached_pick == 0 ∀ i∈[0,K-1], K=2. First such b = onset;
-//        B[b-1] = anchor (immediately preceding, strict).
+//        B[b+i] is an OBSERVED zero-yield bucket (total>0, reached_pick==0)
+//        ∀ i∈[0,K-1], K=2. First such b = onset; B[b-1] = anchor (strict).
+//   §A2-REV3 an EMPTY bucket (total==0, idle/telemetry gap) is NOT zero-yield
+//        and breaks the zero-run — it is absence of observation, not collapse.
 //   §A2-REV2  emit ALL onset bucket indices (bifurcation_onset_buckets), in
 //        order, even though the verdict is first-onset-only.
 //
@@ -69,7 +71,14 @@ export function temporalBifurcation(events, opts = {}) {
     if (buckets[b - 1].reachedPick <= 0) continue;
     let allZero = true;
     for (let i = 0; i < K; i++) {
-      if (buckets[b + i].reachedPick !== 0) { allZero = false; break; }
+      const bk = buckets[b + i];
+      // §A2-REV3 (Codex P2, #328): a zero-yield bucket must be OBSERVED — events
+      // present, none reaching pick (`total > 0 && reachedPick === 0`). An EMPTY
+      // bucket (`total === 0`, e.g. a ≥bucketMs idle/telemetry gap with no events)
+      // is an *absence of observation*, not the Phase-2 pre-pick-skip collapse
+      // (§0.2: Phase-2 emits ~13–14 pre-pick-skip events/min). Treating an empty
+      // bucket as zero-yield would false-fire STOP-BIFURCATION on an idle gap.
+      if (bk.reachedPick !== 0 || bk.total === 0) { allZero = false; break; }
     }
     if (allZero) onsets.push(b);
   }

--- a/tests/audit8AnalyzeRepresentativeness.test.js
+++ b/tests/audit8AnalyzeRepresentativeness.test.js
@@ -251,6 +251,26 @@ describe('G4.5 verdict branches (synthetic)', () => {
     expect(r.g3b2.perCovariate.broken.structuralFraction).toBeLessThan(r.g3b2.structuralThreshold);
     expect(r.verdict).not.toBe('STOP-JOIN-NONDETERMINABLE');
   });
+
+  it('B2 fires at EXACTLY the 1% ceiling — Codex P2 (#327) float-boundary regression', () => {
+    // 200 distinct questions; idx0/idx1 share a stem and disagree ONLY on
+    // `broken` (t/ti forced equal). Served uniformly, the dup pair is exactly
+    // 1% of routed rows → structuralFraction === 0.01. In IEEE-754 the literal
+    // 0.01 (0.0100000000000000002) is STRICTLY BELOW the ceiling `1 - 0.99`
+    // (0.0100000000000000089), so the pre-fix bare `>= STRUCTURAL_NONDETERMINABLE_MAX`
+    // MISSED this case. With the epsilon tolerance it must STOP at "at/above 1%".
+    const q = pool(200, (o, i) => (i === 0
+      ? { ...o, q: 'dupExact', t: 'S0', ti: 0, broken: true }
+      : i === 1 ? { ...o, q: 'dupExact', t: 'S0', ti: 0, broken: false } : o));
+    const drop = Array.from({ length: 200 }, (_, i) => i % 200); // 1× each
+    const ret = Array.from({ length: 600 }, (_, i) => i % 200);  // 3× each → uniform
+    const r = runCase({ questions: q, dropSpecs: drop, retainSpecs: ret });
+    const sf = r.g3b2.perCovariate.broken.structuralFraction;
+    expect(sf).toBeCloseTo(0.01, 12);                 // exactly the 1% ceiling
+    expect(sf).toBeLessThan(r.g3b2.structuralThreshold); // below the raw float ceiling → old code missed it
+    expect(r.g3b2.nondeterminableViolations).toContain('broken'); // epsilon fix catches it
+    expect(r.verdict).toBe('STOP-JOIN-NONDETERMINABLE');          // gate NOT cleared at exactly 1%
+  });
 });
 
 describe('logistic sensitivity is verdict-neutral', () => {

--- a/tests/audit8WorkerRecovery.test.js
+++ b/tests/audit8WorkerRecovery.test.js
@@ -128,3 +128,38 @@ describe('R1.6 default config is sane', () => {
     expect(actions[4]).toBe('reload');
   });
 });
+
+// ── Codex P2 (#326): no-quiz escalation must not thrash ──────────────────
+// The bot's no-quiz branch previously reloaded on BOTH 'reload' AND 'none'.
+// reloadsSinceProgress only advances inside nextRecovery when the null streak
+// crosses nullStreakThreshold, so reloading on 'none' did not count toward
+// escalation → ~15 reloads (5×3) to reach 'recreate' instead of 3.
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+const BOT_SRC = readFileSync(
+  path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'scripts', 'chaos-doctor-bot-v4.mjs'),
+  'utf8',
+);
+
+describe('no-quiz escalation reaches recreate in exactly reloadEscalateThreshold acted reloads', () => {
+  it('a sustained null streak yields 2 reloads then recreate (not 15)', () => {
+    // Drive enough null turns to reach the first recreate.
+    const { actions } = drive(Array(15).fill(NULL_FAIL));
+    const acted = actions.filter((a) => a !== 'none'); // the FIXED bot acts ONLY on these
+    expect(acted).toEqual(['reload', 'reload', 'recreate']);
+    // recreate arrives at the 15th null turn — but via 3 ACTED decisions, not 15 reloads
+    expect(actions[14]).toBe('recreate');
+    expect(actions.filter((a) => a === 'reload').length).toBe(2);
+  });
+
+  it('bot no-quiz branch GATES its reload on action===reload (source guard)', () => {
+    const block = BOT_SRC.slice(BOT_SRC.indexOf('if (!onQuiz) {'));
+    const noQuiz = block.slice(0, block.indexOf('continue;'));
+    // the discriminating fix: reload is guarded by the escalation decision
+    expect(noQuiz).toContain("decision.action === 'reload'");
+    // and exactly one reload site in the block (the gated one) — no unconditional reload
+    expect((noQuiz.match(/page\.reload/g) || []).length).toBe(1);
+    expect(noQuiz).toContain("tier: 'reload', context: 'no-quiz'");
+  });
+});

--- a/tests/audit9TemporalBins.test.js
+++ b/tests/audit9TemporalBins.test.js
@@ -111,6 +111,29 @@ describe('temporalBifurcation — pure contract (§A1/§A2/§A2-REV2)', () => {
     const shifted = base.map((e) => ({ ...e, at: new Date(Date.parse(e.at) + 37 * 60_000).toISOString() }));
     expect(temporalBifurcation(shifted).bifurcation_onset_buckets).toEqual([3]);
   });
+
+  it('§A2-REV3: an idle gap (empty buckets, no events) does NOT fire — only OBSERVED zero-yield does', () => {
+    // Phase-1 anchor (15 min, 3 buckets reached>0), then a ≥10-min event gap
+    // (empty minutes → total:0 buckets), then a later event extending runEnd.
+    const idle = [];
+    for (let i = 0; i < 15; i++) idle.push({ ok: 13 });   // minutes 0–14: Phase-1
+    for (let i = 0; i < 15; i++) idle.push({});           // minutes 15–29: NO events (idle gap)
+    idle.push({ ok: 5 });                                  // minute 30: a later event
+    const rIdle = temporalBifurcation(genEvents(idle));
+    // the gap buckets exist and are empty (total:0) — they must NOT be onsets
+    expect(rIdle.buckets.some((b) => b.total === 0)).toBe(true);
+    expect(rIdle.detected).toBe(false);
+    expect(rIdle.bifurcation_onset_buckets).toEqual([]);
+
+    // CONTRAST: same shape but the gap carries pre-pick-skip EVENTS (observed
+    // zero-yield = dense Phase-2) → the criterion MUST fire. Proves REV3
+    // excludes only EMPTY buckets, not observed zero-yield ones.
+    const dense = [];
+    for (let i = 0; i < 15; i++) dense.push({ ok: 13 });
+    for (let i = 0; i < 15; i++) dense.push({ skip: 14 }); // observed zero-yield
+    dense.push({ ok: 5 });
+    expect(temporalBifurcation(genEvents(dense)).detected).toBe(true);
+  });
 });
 
 // ── Integration through analyze() with timestamped ledgers ──────────────


### PR DESCRIPTION
Follow-up to the AUDIT-9 cascade (#324/#325/#326/#327/#328, all merged). Fixes the three **real** Codex P2 findings that were routed here (with in-thread replies on each cascade PR) rather than self-merged into the cascade — none was an active defect, and #328 touches the **locked** AUDIT-9 criterion so it must get independent review first.

## Findings fixed (each RED-proofed)

| PR | File | Bug | Active? |
|----|------|-----|---------|
| #327 | `analyze_pick_representativeness.mjs` | `1-0.99`=`0.0100000000000000089`; exact-1% structural fraction skipped `STOP-JOIN-NONDETERMINABLE` | Latent — audit-8 `t` fraction is 1.0, far from the knife-edge |
| #328 | `scripts/lib/temporalBins.mjs` | empty buckets (`total:0` idle gaps) counted as zero-yield → false `STOP-BIFURCATION` | Dormant — R3 (only consumer) deferred; fixtures are dense |
| #326 | `chaos-doctor-bot-v4.mjs` | no-quiz branch reloaded on `'none'`; only `'reload'`/`'recreate'` escalate → ~15 reloads to `recreate`, not 3 | Offline bot; live GREEN deferred to overnight |

## What changed
- **#327** — epsilon-tolerant compare (`>= MAX - 1e-9`). Test: exact 2/200 = 1% fires `STOP-JOIN-NONDETERMINABLE`.
- **#328** — zero-yield must be **observed** (`total>0 && reachedPick===0`); empty bucket breaks the run. Registered append-only as **§A2-REV3** in `docs/AUDIT9_PRE_REGISTERED_GATE.md` **before any R3 data is consumed** — a *tightening* of the locked criterion (no lock relaxed: width 5min / K=2 / strict anchor / run-start alignment / override-all-branches all intact). Tests: idle-gap must NOT fire; dense Phase-2 still must.
- **#326** — gate the no-quiz reload on `action==='reload'` (mirror the on-quiz path). Tests: escalation contract (`['reload','reload','recreate']`) + source guard.

## Gate compliance
- `npm run verify` green (**1687 passed**, 7 skipped). Trinity untouched (docs + scripts + tests).
- §A2-REV3 follows `feedback_spec_provenance_append_only` (append-only, original §A2 text preserved) and `feedback_prewritten_predictions` (overturn condition registered before data).
- **NOT self-merged** — locked-criterion change → `@codex review` requested; Codex green + CI green before merge per the repo's cross-model independence rule.

@codex review