### PR TITLE
fix(audit8): analyzer RESULT pointer → REPAIR gate (#338)

### DIFF
--- a/scripts/analyze_pick_representativeness.mjs
+++ b/scripts/analyze_pick_representativeness.mjs
@@ -59,6 +59,15 @@ const STRUCTURAL_FRACTION_EPS = 1e-9;
 const CATEGORICAL = ['topic_group', 't', 'bilingual', 'c_accept', 'broken'];
 const ALL_COVS = ['stem_len', ...CATEGORICAL];
 
+// Home-of-record gate for the bounded-run RESULT append (issue #338). The
+// repair-gate cascade (R1.x → R3) appends its RESULT to the REPAIR gate — the
+// gate that authors the bounded run — NOT the original representativeness
+// pre-registration. (The verdict LOGIC this analyzer is bound to is still the
+// original gate's G2–G5; see the "Binding spec" header — that provenance is
+// unchanged.) Single source of truth so the pointer can't silently re-drift.
+// Was a hardcoded mis-pointer at docs/AUDIT8_PRE_REGISTERED_GATE.md.
+const RESULT_HOME_OF_RECORD_GATE = 'docs/AUDIT8_G5_REPAIR_GATE.md';
+
 // ---- ledger ingestion ------------------------------------------------
 
 function loadLedger(reportDir) {
@@ -368,7 +377,7 @@ function analyze({ reportDir, index, questionsPath }) {
   return {
     schema: 'audit8-representativeness-result/1',
     generatedBy: 'scripts/analyze_pick_representativeness.mjs',
-    boundOnMainGate: 'docs/AUDIT8_PRE_REGISTERED_GATE.md (#233 G4 + D1–D4)',
+    boundOnMainGate: RESULT_HOME_OF_RECORD_GATE,
     verdict,
     // AUDIT-9: the pooled aggregate verdict, kept as informational even when
     // STOP-BIFURCATION overrides it (so a reader sees what the pooled rate said).
@@ -577,6 +586,6 @@ if (isMain) {
   if (result.g5route) console.log('G5     :', result.g5route);
   console.log('wrote  :', out);
   console.log('NOTE: this analyzer produces the verdict only. The RESULT section is appended '
-    + 'to docs/AUDIT8_PRE_REGISTERED_GATE.md by the bounded-run session (gate SHIP clause), '
-    + 'after web-lane fresh-eye review.');
+    + 'to ' + RESULT_HOME_OF_RECORD_GATE + ' by the bounded-run session (gate SHIP clause), '
+    + 'after fresh-eye / Codex review.');
 }

--- a/tests/analyzerResultPointer.test.js
+++ b/tests/analyzerResultPointer.test.js
@@ -1,0 +1,37 @@
+// Regression guard for issue #338 — the analyzer's bounded-run RESULT home-of-record
+// pointer drifted (it hardcoded the original representativeness gate
+// AUDIT8_PRE_REGISTERED_GATE.md instead of the REPAIR gate that authors the
+// bounded run). A mis-pointer silently re-routes the next cascade's RESULT to the
+// wrong doc. This pins the home-of-record at the REPAIR gate while preserving the
+// verdict-logic provenance (which legitimately IS the original gate).
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SRC = fs.readFileSync(path.join(ROOT, 'scripts', 'analyze_pick_representativeness.mjs'), 'utf8');
+
+describe('analyzer RESULT home-of-record pointer (#338)', () => {
+  it('defines the home-of-record as the REPAIR gate (single source of truth)', () => {
+    expect(SRC).toContain("const RESULT_HOME_OF_RECORD_GATE = 'docs/AUDIT8_G5_REPAIR_GATE.md'");
+  });
+
+  it('boundOnMainGate + the stdout NOTE use the constant, not a hardcoded gate path', () => {
+    expect(SRC).toMatch(/boundOnMainGate:\s*RESULT_HOME_OF_RECORD_GATE/);
+    // the NOTE interpolates the constant rather than naming a gate literally
+    expect(SRC).toMatch(/RESULT section is appended[\s\S]{0,60}RESULT_HOME_OF_RECORD_GATE/);
+  });
+
+  it('does NOT mis-point boundOnMainGate or the append NOTE at the pre-registration gate', () => {
+    // The only legitimate AUDIT8_PRE_REGISTERED references are provenance comments
+    // (the "Binding spec" header + the #338 fix note). Neither boundOnMainGate's
+    // value nor the appended-to NOTE may name it.
+    expect(SRC).not.toMatch(/boundOnMainGate:\s*'[^']*AUDIT8_PRE_REGISTERED/);
+    expect(SRC).not.toMatch(/RESULT section is appended[\s\S]{0,80}AUDIT8_PRE_REGISTERED/);
+  });
+
+  it('preserves the verdict-logic provenance (binding spec header still cites the original gate)', () => {
+    expect(SRC).toMatch(/Binding spec:\s*docs\/AUDIT8_PRE_REGISTERED_GATE\.md/);
+  });
+});


### PR DESCRIPTION
Closes #338.

The analyzer hardcoded `docs/AUDIT8_PRE_REGISTERED_GATE.md` as the bounded-run RESULT home-of-record in two places (`boundOnMainGate` field + stdout NOTE). For the repair-gate cascade (R1.x→R3) the RESULT lives in the **REPAIR gate** — the mis-pointer would re-route the next cascade's RESULT to the wrong doc.

**Fix:** single `RESULT_HOME_OF_RECORD_GATE = 'docs/AUDIT8_G5_REPAIR_GATE.md'` constant used by both sites (parameterized → anti-drift, per #338). **Verdict-logic provenance unchanged** — the "Binding spec" header still cites AUDIT8_PRE_REGISTERED #233 (legitimately where G2–G5 came from); only the RESULT home-of-record moved.

**Verified:** functional re-run on the R3 dir → NOTE + `boundOnMainGate` now emit the REPAIR gate; verdict unchanged (`STOP-JOIN-NONDETERMINABLE`). Guard `tests/analyzerResultPointer.test.js` (4 tests) + `npm run verify` 1707 passed.

Scripts/tests only — no trinity bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)