### PR TITLE
fix(audit8): boundOnMainGate is provenance (pre-reg), not home-of-record — #339 follow-up

### DIFF
--- a/scripts/analyze_pick_representativeness.mjs
+++ b/scripts/analyze_pick_representativeness.mjs
@@ -68,6 +68,16 @@ const ALL_COVS = ['stem_len', ...CATEGORICAL];
 // Was a hardcoded mis-pointer at docs/AUDIT8_PRE_REGISTERED_GATE.md.
 const RESULT_HOME_OF_RECORD_GATE = 'docs/AUDIT8_G5_REPAIR_GATE.md';
 
+// Binding provenance — the gate whose verdict LOGIC (G2–G5 + D1–D4) this
+// analyzer is bound to. That is the ORIGINAL representativeness
+// pre-registration (see the "Binding spec" header), NOT the repair gate.
+// Distinct concept from RESULT_HOME_OF_RECORD_GATE above: provenance answers
+// "which gate defines the verdict semantics" (pre-reg); home-of-record answers
+// "which gate the RESULT is appended to" (repair, SHIP clause). The
+// `boundOnMainGate` result field reports THIS. (#339 follow-up: #339
+// conflated the two and pointed this field at the home-of-record gate.)
+const BOUND_ON_MAIN_GATE = 'docs/AUDIT8_PRE_REGISTERED_GATE.md';
+
 // ---- ledger ingestion ------------------------------------------------
 
 function loadLedger(reportDir) {
@@ -377,7 +387,9 @@ function analyze({ reportDir, index, questionsPath }) {
   return {
     schema: 'audit8-representativeness-result/1',
     generatedBy: 'scripts/analyze_pick_representativeness.mjs',
-    boundOnMainGate: RESULT_HOME_OF_RECORD_GATE,
+    // Provenance: the gate whose verdict LOGIC (G2–G5) this result derives
+    // from — the original pre-registration, NOT the home-of-record repair gate.
+    boundOnMainGate: BOUND_ON_MAIN_GATE,
     verdict,
     // AUDIT-9: the pooled aggregate verdict, kept as informational even when
     // STOP-BIFURCATION overrides it (so a reader sees what the pooled rate said).

--- a/tests/analyzerResultPointer.test.js
+++ b/tests/analyzerResultPointer.test.js
@@ -1,9 +1,14 @@
-// Regression guard for issue #338 — the analyzer's bounded-run RESULT home-of-record
-// pointer drifted (it hardcoded the original representativeness gate
-// AUDIT8_PRE_REGISTERED_GATE.md instead of the REPAIR gate that authors the
-// bounded run). A mis-pointer silently re-routes the next cascade's RESULT to the
-// wrong doc. This pins the home-of-record at the REPAIR gate while preserving the
-// verdict-logic provenance (which legitimately IS the original gate).
+// Regression guard for the analyzer's gate pointers.
+//
+// Two DISTINCT pointers, two distinct meanings — the #339 follow-up fix
+// stopped conflating them:
+//   1. home-of-record (RESULT_HOME_OF_RECORD_GATE) — which gate the bounded-run
+//      RESULT is APPENDED to. That is the REPAIR gate (SHIP clause). Origin of
+//      issue #338: it had drifted to the pre-registration gate.
+//   2. binding provenance (BOUND_ON_MAIN_GATE / the `boundOnMainGate` result
+//      field) — which gate the verdict LOGIC (G2–G5) DERIVES FROM. That is the
+//      ORIGINAL pre-registration gate. #339 mistakenly pointed this field at the
+//      home-of-record gate; this guard pins it back to provenance.
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -12,26 +17,27 @@ import { fileURLToPath } from 'node:url';
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SRC = fs.readFileSync(path.join(ROOT, 'scripts', 'analyze_pick_representativeness.mjs'), 'utf8');
 
-describe('analyzer RESULT home-of-record pointer (#338)', () => {
-  it('defines the home-of-record as the REPAIR gate (single source of truth)', () => {
+describe('analyzer gate pointers (#338 home-of-record + #339 provenance)', () => {
+  it('home-of-record is the REPAIR gate (single source of truth)', () => {
     expect(SRC).toContain("const RESULT_HOME_OF_RECORD_GATE = 'docs/AUDIT8_G5_REPAIR_GATE.md'");
   });
 
-  it('boundOnMainGate + the stdout NOTE use the constant, not a hardcoded gate path', () => {
-    expect(SRC).toMatch(/boundOnMainGate:\s*RESULT_HOME_OF_RECORD_GATE/);
-    // the NOTE interpolates the constant rather than naming a gate literally
-    expect(SRC).toMatch(/RESULT section is appended[\s\S]{0,60}RESULT_HOME_OF_RECORD_GATE/);
+  it('binding provenance is the PRE-REGISTRATION gate (single source of truth)', () => {
+    expect(SRC).toContain("const BOUND_ON_MAIN_GATE = 'docs/AUDIT8_PRE_REGISTERED_GATE.md'");
   });
 
-  it('does NOT mis-point boundOnMainGate or the append NOTE at the pre-registration gate', () => {
-    // The only legitimate AUDIT8_PRE_REGISTERED references are provenance comments
-    // (the "Binding spec" header + the #338 fix note). Neither boundOnMainGate's
-    // value nor the appended-to NOTE may name it.
-    expect(SRC).not.toMatch(/boundOnMainGate:\s*'[^']*AUDIT8_PRE_REGISTERED/);
+  it('boundOnMainGate reports PROVENANCE via the constant, not a hardcoded path', () => {
+    expect(SRC).toMatch(/boundOnMainGate:\s*BOUND_ON_MAIN_GATE/);
+    // and is NOT the home-of-record constant (that conflation was the #339 bug)
+    expect(SRC).not.toMatch(/boundOnMainGate:\s*RESULT_HOME_OF_RECORD_GATE/);
+  });
+
+  it('the append NOTE (home-of-record) uses the REPAIR-gate constant, not pre-registration', () => {
+    expect(SRC).toMatch(/RESULT section is appended[\s\S]{0,60}RESULT_HOME_OF_RECORD_GATE/);
     expect(SRC).not.toMatch(/RESULT section is appended[\s\S]{0,80}AUDIT8_PRE_REGISTERED/);
   });
 
-  it('preserves the verdict-logic provenance (binding spec header still cites the original gate)', () => {
+  it('preserves the verdict-logic provenance in the binding-spec header', () => {
     expect(SRC).toMatch(/Binding spec:\s*docs\/AUDIT8_PRE_REGISTERED_GATE\.md/);
   });
 });


### PR DESCRIPTION
## What this fixes (a #339 follow-up — caught while closing the cascade)

`#339` introduced `RESULT_HOME_OF_RECORD_GATE` and, per my "redirect both" instruction, also pointed the emitted result field **`boundOnMainGate`** at the repair gate. On review that field is **provenance metadata, not routing**:

- it sits at the top of the `audit8-representativeness-result/1` object next to `schema` / `generatedBy`;
- the constant's own comment states the analyzer "is bound to … the original gate's G2–G5 … that provenance is unchanged" — i.e. **bound = pre-registration gate**;
- home-of-record routing is already expressed by the stdout **NOTE** (line ~589). A `boundOnMainGate` carrying the repair gate is therefore both redundant with the NOTE **and** contradicts the binding-spec header.

So `boundOnMainGate` should report the **pre-registration** gate (provenance); the **NOTE + append target** stay on the **repair** gate (home-of-record). This is the inverted form of the #338 bug.

## Change
- New `BOUND_ON_MAIN_GATE = 'docs/AUDIT8_PRE_REGISTERED_GATE.md'` constant (provenance); `boundOnMainGate` now points at it.
- `RESULT_HOME_OF_RECORD_GATE` (repair) unchanged — still drives the NOTE + append.
- Field **name kept** (`boundOnMainGate`) for result.json schema continuity — only its value changed.
- Guard test rewritten to pin **both** pointers with separated semantics (was asserting the conflated #339 behavior).

## Safety
- **No functional consumer** of the field (set once, read only by the guard test + a doc mention) → verdict unchanged.
- Touches only `scripts/` + `tests/` → no Trinity version bump, js-integrity untouched.
- Local: `analyzerResultPointer` 5/5, `audit8AnalyzeRepresentativeness` 15/15.

## ⚠️ Held as DRAFT for your call
This is a **semantic judgment about an audit field in your framework**, made from the offline-CC session. Evidence is strong but the determination is yours. Review the reasoning, then mark ready + merge (or close if you read `boundOnMainGate` differently). I did **not** merge.
