### PR TITLE
fix(audit7): raise judge token budget 400 → 1024 (preamble-truncation class)

### DIFF
--- a/scripts/chaos-doctor-bot-v4.mjs
+++ b/scripts/chaos-doctor-bot-v4.mjs
@@ -595,7 +595,15 @@ Validate the APP's claimed answer ${appLetter} (${appText}) against board-level 
   const judgeJson = await judgeWithShapeRetry({
     system: SYS_DOCTOR_JUDGE,
     userPrompt: userPrompt2,
-    maxTokens: 400,
+    // audit-7: 400 → 1024. In R3, ~101 judge calls truncated at stop_reason=max_tokens
+    // with first_branch=no_brace — RL'd-in JSON preamble exhausted the 400-tok budget
+    // before the model emitted any '{', so the brace-extractor + corrective retry had
+    // nothing to recover (38 residual hard ai-parse-errors fed N_drop). SYS_DOCTOR_JUDGE
+    // already mandates JSON-only; the preamble defies it, and prefill is NOT usable here
+    // (the proxy's Sonnet 4.6 returns 400 on assistant prefill — deploy-primitives §4).
+    // Budget is the available lever: ~800 tok preamble headroom + the ~200-tok verdict.
+    // Verdict-safe — more budget lets a response complete, it cannot change a verdict.
+    maxTokens: 1024,
     callJudge: callClaude,
     log,
     nowIso,

--- a/scripts/lib/judgeShapeValidator.mjs
+++ b/scripts/lib/judgeShapeValidator.mjs
@@ -54,7 +54,9 @@ Your previous (rejected) output started: ${String(badText || '').slice(0, 120)}`
 export async function judgeWithShapeRetry({
   system,
   userPrompt,
-  maxTokens = 400,
+  // audit-7: was 400. Default raised so the corrective retry also clears the
+  // preamble-truncation class (see the judge call in chaos-doctor-bot-v4.mjs).
+  maxTokens = 1024,
   callJudge,
   log,
   nowIso,

--- a/tests/judgeMaxTokensBudget.test.js
+++ b/tests/judgeMaxTokensBudget.test.js
@@ -1,0 +1,40 @@
+// audit-7 regression guard for the judge token budget.
+//
+// In R3, ~101 judge calls truncated at stop_reason=max_tokens with
+// first_branch=no_brace: RL'd-in JSON preamble exhausted the 400-token budget
+// before the model emitted even a '{', so neither the brace-balanced
+// extractJson nor the one corrective retry could recover (38 residual hard
+// ai-parse-errors, which feed N_drop). SYS_DOCTOR_JUDGE already demands
+// JSON-only and the preamble defies it; assistant-prefill is NOT available on
+// this stack (the proxy's Sonnet 4.6 returns 400 on prefill — deploy-primitives
+// §4). The budget is therefore the lever. This guard pins it at >= 1024 so a
+// silent revert to 400 (which reopens the truncation class) fails CI. The bound
+// is a floor, not an exact value — future upward tuning stays green.
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const BOT = fs.readFileSync(path.join(ROOT, 'scripts', 'chaos-doctor-bot-v4.mjs'), 'utf8');
+const VAL = fs.readFileSync(path.join(ROOT, 'scripts', 'lib', 'judgeShapeValidator.mjs'), 'utf8');
+
+const MIN_JUDGE_BUDGET = 1024;
+
+describe('audit-7 judge token budget (>= 1024)', () => {
+  it('judgeWithShapeRetry default maxTokens is >= 1024', () => {
+    const m = VAL.match(/maxTokens\s*=\s*(\d+)/);
+    expect(m).not.toBeNull();
+    expect(Number(m[1])).toBeGreaterThanOrEqual(MIN_JUDGE_BUDGET);
+  });
+
+  it('the chaos-bot judge call passes maxTokens >= 1024 (and not the pick/explain/source budgets)', () => {
+    // Isolate the judgeWithShapeRetry({ ... }) call block so we read the JUDGE
+    // budget specifically, not the pick (250) / explain (400) / source (300) ones.
+    const block = BOT.match(/judgeWithShapeRetry\(\{[\s\S]*?\}\)/);
+    expect(block).not.toBeNull();
+    const m = block[0].match(/maxTokens:\s*(\d+)/);
+    expect(m).not.toBeNull();
+    expect(Number(m[1])).toBeGreaterThanOrEqual(MIN_JUDGE_BUDGET);
+  });
+});


### PR DESCRIPTION
## What & why
Raises the **judge** token budget **400 → 1024**. R3 telemetry showed ~101 judge calls truncating at `stop_reason=max_tokens` with `first_branch=no_brace` — i.e. RL'd-in JSON preamble exhausted the 400-token budget *before the model emitted any `{`*, so the brace-balanced `extractJson` and the existing one-shot corrective retry had nothing to recover. The residual 38 hard `ai-parse-error`s feed `N_drop` (the same power lever that just blocked covariate `t` in the cascade).

The parse side is already solved (brace-balanced extractor + corrective retry) and `SYS_DOCTOR_JUDGE` **already mandates** "one JSON line, no markdown" — the preamble defies an instruction that's already there. So a stronger prompt won't help.

## Correction to my earlier recommendation
Last turn I suggested prefilling the judge's assistant turn with `{`. **That's wrong for this stack** — the Toranot proxy's default model (Sonnet 4.6) returns **400 on assistant prefill** (deploy-primitives §4). Prefilling would break the judge calls outright. Scrapped. The token budget is the only safe, verdict-preserving lever here.

## Scope (deliberately narrow)
- `chaos-doctor-bot-v4.mjs` — the `judgeWithShapeRetry` **call site** (judge channel) → 1024.
- `judgeShapeValidator.mjs` — the `judgeWithShapeRetry` **default** → 1024 (so the corrective retry clears it too).
- **Untouched:** pick (250), explain (400), source (300), and the `callClaude` default. Different channels / different audits.

## Safety
- **Verdict-safe**: more budget lets a response *complete*; it cannot change a verdict.
- Existing judge tests pass `maxTokens: 400` as an **input** and assert call-counts / branches / stop-reasons — none assert the default or call-site value, so the bump doesn't disturb them.
- Live judge gate is env-gated (`CHAOS_LIVE_SMOKE=1`); CI runs only its structural pins, untouched here.
- New `tests/judgeMaxTokensBudget.test.js` pins the judge budget at **>= 1024** (floor — future tuning stays green; a revert to 400 fails CI).
- Local: `judgeMaxTokensBudget` 2/2, `chaosBotV4JudgeShapeValidator` 17/17, `chaosBotV4ParseFailureTelemetry` 10/10.

## Note
Opened from the offline-CC session via the sanctioned PAT path. **I did not merge** — CI (`validate` + `js-integrity`) is the authoritative gate; merge is yours. Touches `scripts/` + `tests/` only → no Trinity bump.
