### PR TITLE
fix(chaos-bot): pin practice-surface selectors to data-testid hooks (#333)

### DIFF
--- a/scripts/audit8/r15LongProbe.mjs
+++ b/scripts/audit8/r15LongProbe.mjs
@@ -550,7 +550,7 @@ async function probeExtractQuestion(page) {
 }
 
 async function advance(page) {
-  const next0 = page.locator('[aria-label="Next question"], [aria-label="Finish exam"]').first();
+  const next0 = page.locator('[data-testid="advance"], [aria-label*="next question" i], [aria-label*="finish exam" i]').first();
   if ((await next0.count().catch(() => 0)) > 0) {
     await next0.click({ timeout: 2500 }).catch(() => {});
     return 'next-direct';
@@ -559,12 +559,12 @@ async function advance(page) {
   if ((await qo0.count().catch(() => 0)) === 0) return 'no-qo';
   await qo0.click({ timeout: 2500 }).catch(() => {});
   await sleep(150);
-  const check = page.locator('[aria-label="Check answer"]').first();
+  const check = page.locator('[data-testid="check-answer"], [aria-label*="check answer" i]').first();
   if ((await check.count().catch(() => 0)) > 0) {
     await check.click({ timeout: 2500 }).catch(() => {});
     await sleep(250);
   }
-  const next1 = page.locator('[aria-label="Next question"], [aria-label="Finish exam"]').first();
+  const next1 = page.locator('[data-testid="advance"], [aria-label*="next question" i], [aria-label*="finish exam" i]').first();
   if ((await next1.count().catch(() => 0)) > 0) {
     await next1.click({ timeout: 2500 }).catch(() => {});
     return 'next-after-check';

--- a/scripts/audit8/r1RedProbe.mjs
+++ b/scripts/audit8/r1RedProbe.mjs
@@ -102,7 +102,7 @@ async function advance(page) {
   // first option → check → next. This matches the bot's iteration cadence
   // shape; if Next is already showing (e.g., post-check state from a prior
   // attempt) skip directly to Next.
-  const next0 = page.locator('[aria-label="Next question"], [aria-label="Finish exam"]').first();
+  const next0 = page.locator('[data-testid="advance"], [aria-label*="next question" i], [aria-label*="finish exam" i]').first();
   if ((await next0.count().catch(() => 0)) > 0) {
     await next0.click({ timeout: 2500 }).catch(() => {});
     return 'next-direct';
@@ -113,12 +113,12 @@ async function advance(page) {
   if ((await qo0.count().catch(() => 0)) === 0) return 'no-qo';
   await qo0.click({ timeout: 2500 }).catch(() => {});
   await sleep(150);
-  const check = page.locator('[aria-label="Check answer"]').first();
+  const check = page.locator('[data-testid="check-answer"], [aria-label*="check answer" i]').first();
   if ((await check.count().catch(() => 0)) > 0) {
     await check.click({ timeout: 2500 }).catch(() => {});
     await sleep(250);
   }
-  const next1 = page.locator('[aria-label="Next question"], [aria-label="Finish exam"]').first();
+  const next1 = page.locator('[data-testid="advance"], [aria-label*="next question" i], [aria-label*="finish exam" i]').first();
   if ((await next1.count().catch(() => 0)) > 0) {
     await next1.click({ timeout: 2500 }).catch(() => {});
     return 'next-after-check';

--- a/scripts/chaos-doctor-bot-v4.mjs
+++ b/scripts/chaos-doctor-bot-v4.mjs
@@ -510,10 +510,11 @@ async function doctorOneQuestion(page, workerId, log) {
     log.bugs.push({ at: nowIso(), type: 'action-error', context: 'doctor-pick', message: e.message });
   });
   await sleep(rand(400, 900));
-  // Geri's check button onclick="check()". #290 (2026-05-26) made its aria-label
-  // bilingual + confidence-prefixed; match the persistent lowercase "check answer"
-  // fragment case-insensitively so an i18n tweak can't silently re-break the bot.
-  const check = page.locator('[aria-label*="check answer" i]').first();
+  // Geri's check button onclick="check()". #333: pin to the stable, non-translated
+  // data-testid="check-answer" hook (in shlav-a-mega.html) so an i18n/label edit can't
+  // silently re-break the bot (the #290 class). The case-insensitive "check answer"
+  // aria-label fragment stays as a fallback for old cached HTML.
+  const check = page.locator('[data-testid="check-answer"], [aria-label*="check answer" i]').first();
   if ((await check.count().catch(() => 0)) > 0) {
     await tryClick(check, CONFIG.actionTimeoutMs).catch((e) => {
       log.bugs.push({ at: nowIso(), type: 'action-error', context: 'doctor-check', message: e.message });
@@ -568,7 +569,7 @@ async function doctorOneQuestion(page, workerId, log) {
       methodology: 'appIdx-null-post-check',
     });
     // Try to advance even without a verdict
-    const next = page.locator('[aria-label*="next question" i], [aria-label*="finish exam" i]').first();
+    const next = page.locator('[data-testid="advance"], [aria-label*="next question" i], [aria-label*="finish exam" i]').first();
     if ((await next.count().catch(() => 0)) > 0) {
       await tryClick(next, CONFIG.actionTimeoutMs).catch(() => {});
     }
@@ -769,9 +770,9 @@ Is the current q.ref a faithful display of the audit-grade chapter assignment, c
     await maybeReportQuestion(page, log, finding);
   }
 
-  // Advance (onclick="next()"; aria-label "Next question"/"Finish exam"). Match the
-  // English fragment case-insensitively — same #290-class i18n hardening as check-answer.
-  const next = page.locator('[aria-label*="next question" i], [aria-label*="finish exam" i]').first();
+  // Advance (onclick="next()"). #333: pin to the stable data-testid="advance" hook; the
+  // case-insensitive "next question"/"finish exam" aria-label fragments stay as fallback.
+  const next = page.locator('[data-testid="advance"], [aria-label*="next question" i], [aria-label*="finish exam" i]').first();
   if ((await next.count().catch(() => 0)) > 0) {
     await tryClick(next, CONFIG.actionTimeoutMs).catch(() => {});
     log.actions.push({ at: nowIso(), type: 'next' });
@@ -884,7 +885,7 @@ export async function ensureOnPracticeQuiz(page, log) {
 
   // Step 2: if button.qo + check button are visible, we're in practice mode.
   const optsCount = await page.locator('button.qo').count().catch(() => 0);
-  const checkVisible = await page.locator('[aria-label*="check answer" i]').count().catch(() => 0);
+  const checkVisible = await page.locator('[data-testid="check-answer"], [aria-label*="check answer" i]').count().catch(() => 0);
   if (optsCount >= 2 && checkVisible > 0) return true;
 
   // Step 3: if options visible but no check button, we're in exam mode.
@@ -911,7 +912,7 @@ export async function ensureOnPracticeQuiz(page, log) {
   // Step 5: confirm options + check button now both visible.
   try {
     await page.locator('button.qo').first().waitFor({ state: 'visible', timeout: 6000 });
-    await page.locator('[aria-label*="check answer" i]').first().waitFor({ state: 'attached', timeout: 4000 });
+    await page.locator('[data-testid="check-answer"], [aria-label*="check answer" i]').first().waitFor({ state: 'attached', timeout: 4000 });
     log.actions.push({ at: nowIso(), type: 'mode-start', action: 'practice' });
     return true;
   } catch (_) {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -3200,7 +3200,7 @@ if(ans){cls+=' lk';if(isOk(q,i))cls+=' ok';else if(i===sel)cls+=' no';else cls+=
 else if(i===sel)cls+=' sel';
 h+=`<button class="${cls}" onclick="pick(${i})" aria-label="Option ${i+1}: ${sanitize(o)}">${sanitize(o)}</button>`;
 });
-if(!ans)h+=`<button class="btn btn-p" onclick="sdCheck()"${sel===null?' disabled':''} aria-label="בדוק — check answer">בדוק</button>`;
+if(!ans)h+=`<button class="btn btn-p" data-testid="check-answer" onclick="sdCheck()"${sel===null?' disabled':''} aria-label="בדוק — check answer">בדוק</button>`;
 else h+=`<button class="btn btn-d" onclick="sdNext()" aria-label="הבאה — next question">הבאה ←</button>`;
 h+=`</div>`;
 // Leaderboard
@@ -3257,13 +3257,13 @@ let h='';
 h+=`<div style="display:flex;flex-direction:column;gap:8px;margin-top:14px">`;
 if(!ans){
 const _confLabel='';
-h+=`<div style="display:flex;gap:6px;align-items:center"><button class="btn btn-p tap-min" onclick="check()"${sel===null?' disabled':''} aria-label="${_confLabel} בדוק — check answer" style="flex:1">${_confLabel} בדוק</button>`;if(!examMode)h+=`<button class="btn tap-min" onclick="showAnswerHardFail()" style="background:rgb(var(--yellow-bg));color:rgb(var(--yellow-fg));font-size:11px;padding:6px 14px;border:1px solid rgb(var(--yellow-brd))" aria-label="לא יודע — show me the answer">👁 לא יודע</button>`;h+=`</div>`;}
+h+=`<div style="display:flex;gap:6px;align-items:center"><button class="btn btn-p tap-min" data-testid="check-answer" onclick="check()"${sel===null?' disabled':''} aria-label="${_confLabel} בדוק — check answer" style="flex:1">${_confLabel} בדוק</button>`;if(!examMode)h+=`<button class="btn tap-min" onclick="showAnswerHardFail()" style="background:rgb(var(--yellow-bg));color:rgb(var(--yellow-fg));font-size:11px;padding:6px 14px;border:1px solid rgb(var(--yellow-brd))" aria-label="לא יודע — show me the answer">👁 לא יודע</button>`;h+=`</div>`;}
 else{
 // POST-ANSWER LAYOUT: Next button FIRST (primary action), then secondary UI
 // Top row: Prev + Next (always visible, always tappable)
 h+=`<div style="display:flex;gap:6px;align-items:center;margin-bottom:8px">`;
 if(!examMode)h+=`<button id="prev-btn" class="btn btn-o tap-min" onclick="prev()" style="flex:0 0 auto;padding:0 14px;font-size:11px;border:1px solid rgb(var(--brd));border-radius:10px;${qi<=0?'opacity:0.4;pointer-events:none;':''}" aria-label="קודמת — previous question">קודמת ←</button>`;
-h+=`<button id="next-btn" class="btn btn-d" onclick="next()" style="flex:1;min-height:48px;padding:10px 18px;font-size:14px" aria-label="${examMode&&qi+1>=150?'Finish exam':'Next question'}">${examMode&&qi+1>=150?'סיים':'→ הבאה'}</button>`;
+h+=`<button id="next-btn" data-testid="advance" class="btn btn-d" onclick="next()" style="flex:1;min-height:48px;padding:10px 18px;font-size:14px" aria-label="${examMode&&qi+1>=150?'Finish exam':'Next question'}">${examMode&&qi+1>=150?'סיים':'→ הבאה'}</button>`;
 if(!examMode&&ans){
 h+=`<button onclick="document.getElementById('report-wrong-expand').style.display=document.getElementById('report-wrong-expand').style.display==='none'?'block':'none'" style="font-size:10px;padding:4px 8px;background:none;color:rgb(var(--fg3));cursor:pointer;border:none" title="Report wrong answer key">⚠️</button>`;
 }

--- a/tests/chaosBotV4DataTestid.test.js
+++ b/tests/chaosBotV4DataTestid.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+// #333 — practice-surface controls carry stable, non-translated `data-testid` hooks so
+// an i18n / aria-label edit (the #290 failure class that silently blinded the bot for
+// ~11 days) can't re-break the measurement instrument. The bot pins to those hooks and
+// keeps the case-insensitive aria-label fragment only as a fallback for old cached HTML.
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const html = readFileSync(join(ROOT, 'shlav-a-mega.html'), 'utf-8');
+const bot = readFileSync(join(ROOT, 'scripts', 'chaos-doctor-bot-v4.mjs'), 'utf-8');
+
+describe('#333 data-testid practice-surface hooks', () => {
+  it('monolith: both check controls (practice check() + sudden-death sdCheck()) carry data-testid="check-answer"', () => {
+    const n = (html.match(/data-testid="check-answer"/g) || []).length;
+    expect(n).toBeGreaterThanOrEqual(2);
+    expect(html).toMatch(/data-testid="check-answer"[^>]*onclick="check\(\)"/);
+    expect(html).toMatch(/data-testid="check-answer"[^>]*onclick="sdCheck\(\)"/);
+  });
+
+  it('monolith: the advance control (onclick="next()") carries data-testid="advance"', () => {
+    expect(html).toContain('data-testid="advance"');
+    expect(html).toMatch(/data-testid="advance"[^>]*onclick="next\(\)"/);
+  });
+
+  it('bot: check + advance selectors are pinned to the data-testid hooks (decoupled from i18n)', () => {
+    expect(bot).toContain('[data-testid="check-answer"]');
+    expect(bot).toContain('[data-testid="advance"]');
+  });
+
+  it('bot: keeps the case-insensitive aria-label fragment as a fallback', () => {
+    expect(bot).toMatch(/aria-label\*="check answer" i/);
+    expect(bot).toMatch(/aria-label\*="next question" i/);
+  });
+});


### PR DESCRIPTION
## Closes #333 — pin chaos-bot practice-surface selectors to stable `data-testid` hooks

**Problem:** the v4 chaos bot located the check-answer + advance controls by `aria-label` (an i18n surface). PR #290 made the check-answer label bilingual → the bot went silently inert (0 judge calls) for ~11 days until an R3 pre-flight caught it. #332 hardened to case-insensitive substring matchers but those *still* pin to the translated string. This is the permanent class-killer.

**Fix:**
- **`shlav-a-mega.html`** — add non-translated `data-testid="check-answer"` to the practice `check()` + sudden-death `sdCheck()` buttons, and `data-testid="advance"` to the `next()` button. aria-labels kept (a11y unchanged).
- **`chaos-doctor-bot-v4.mjs`** — re-pin all 5 selector sites to a comma-union `[data-testid=...], [aria-label*=... i]`. data-testid matches the deployed control regardless of label drift; the aria-label fragment stays as a fallback for old cached HTML.
- **`scripts/audit8/{r15LongProbe,r1RedProbe}.mjs`** — sweep the two dormant probes off the already-broken exact-match `[aria-label="Check answer"]` to the same form (issue: "sweep before any reuse"). Probes are dormant; no landed audit result is affected.
- **`tests/chaosBotV4DataTestid.test.js`** — pins the hooks (monolith), the bot pinning, and the retained fallback.

**Regression-proof by construction:** the bot selector is a *union* — worst case (data-testid somehow doesn't resolve) it falls back to today's aria-label behavior. The change can only make the bot *more* robust, never worse.

**No version bump (deliberate):** data-testid hooks are test-only instrument plumbing — invisible to users, and the bot (fresh Chromium) bypasses the SW cache, so no cache-bust is needed. Trinity stays aligned at `10.64.159`. `npm run verify` green (100 files, 1734 tests, 8 skipped).

**Runtime backstop:** the #332 live-judge gate hard-fails on a 0-judge-call run, so any future selector regression is caught by a live run, not silently.

@codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
