### PR TITLE
audit8 G5(a): harden chaos-bot pick parser; de-bias ai-parse-error/pick channel

### DIFF
--- a/docs/AUDIT8_G5a_REPAIR_GATE.md
+++ b/docs/AUDIT8_G5a_REPAIR_GATE.md
@@ -1,0 +1,216 @@
+# Audit-8 G5(a) — pick-parser robustness hardening (NO self-merge — audit-evidence carve-out)
+
+Pre-registration + implementation record for **G5 trigger (a)**: harden the
+chaos-bot's **pick** parser so its `ai-parse-error/pick` DROP channel stops
+skewing by exam-era. Branch `claude/term-audit8-g5a-pickparse`. Lane: terminal,
+solo. Trinity: **untouched** — scripts/tests/docs only, **no version bump**
+(mirrors #235 / the R1.6 / R2 bot-and-analyzer precedent: a bot/lib/test change
+that touches no `shlav-a-mega.html` / `sw.js` / `package.json` does not bump the
+trinity).
+
+**Parent / trigger.** The CERT RESULT of `docs/AUDIT8_G5_REPAIR_GATE.md`
+(2026-06-08) routed `verdict = BIASED` on covariate **`t`** (question
+provenance / exam-source-era) for the bot's `ai-parse-error/pick` drop channel,
+and named three G5 remediation triggers, each its own gated session:
+
+> (a) pick-side robustness hardening (bot parse resilience);
+> (b) retroactive-reach characterization — DOCUMENT, do not auto-rerun;
+> (c) audit horizon item 2 (Geri judge max_tokens) stays gated behind the de-bias.
+
+This document is the **(a)** session. It flips **no `q.c`**, changes **no
+`broken`** flag, touches **no `shlav-a-mega.html`**, and ships **no fresh
+bounded run**. The CERT verdict explicitly scopes the bias to the bot's **read
+failure** on certain source surfaces — NOT a content/answer-key defect — so the
+fix is a parser change, not a dataset change.
+
+---
+
+## STEP 0 — state (verified on disk)
+
+- `origin/main` HEAD at/after `5c0bf0ea` (the AUDIT8/9 capstone, #352); working
+  tree clean at branch cut. The on-disk gate is `docs/AUDIT8_G5_REPAIR_GATE.md`
+  (the G5 parent); no prior `AUDIT8_G5a*` doc existed — this authors it.
+- Anchors read, not assumed: `scripts/chaos-doctor-bot-v4.mjs` old
+  `LETTER_TO_IDX` (was `:239`), `doctorOneQuestion` pick→parse→drop flow
+  (`:466`–`:510`), the `'ABCD'[i]` label (`:491`), the `extractJson || {}` +
+  drop emit (`:498`–`:505`); `scripts/lib/extractJson.mjs`
+  (`classifyExtractFailure`); `scripts/lib/judgeShapeValidator.mjs`
+  (`judgeWithShapeRetry`, the mirror target); the existing pin
+  `tests/chaosBotV4PickIdentityInstrument.test.js`.
+
+### Fixture-path decision (binding STEP-0 record)
+
+`test -d chaos-reports/v4-long/audit8cert_20260607T205756Z` → **ABSENT** (the
+run dir is gitignored and not present in this checkout). Per the FALLBACK below,
+STEP 1 **synthesizes** fixtures — one representative per failure class the pick
+channel can emit at `maxTokens:250` — rather than ingesting real
+`ai-parse-error/pick` rows. The synthetic fixtures are derived from the
+documented `classifyExtractFailure` branch taxonomy and the corpus-witnessed
+5-option class, so they are not arbitrary.
+
+**§2 FALLBACK (defined here, since this doc authors the G5a gate).** When the
+real audit8cert drop rows are not on disk, synthesize one fixture per bucket of
+`classifyExtractFailure` (`empty` / `no_brace` / `unbalanced` / `parse_threw` /
+`parsed`) **plus** a `parsed-but-bad-field` bucket (extractJson succeeds but the
+A–D letter resolve fails). Because the synthesizer controls what is "shown,"
+the fix ships only levers each of which is **independently justified by a
+disk-witnessed fact** (the corpus option-count distribution, the documented
+branch taxonomy), not by the synthetic fixture alone.
+
+---
+
+## STEP 1 — diagnosis (bucket × cause; precedes the fix)
+
+The pick channel's drop is `ai-parse-error/pick`, emitted when the old inline
+parse —
+
+```js
+const pickJson = extractJson(pickResp.text) || {};
+const aiLetter = String(pickJson.pick || '').trim().slice(0, 1);
+const aiIdx = LETTER_TO_IDX[aiLetter];          // 4-letter table: A–D only
+if (aiIdx == null || aiIdx < 0 || aiIdx >= q.options.length) { /* DROP */ }
+```
+
+— resolves no in-range index. Bucketing synthetic fixtures by
+`classifyExtractFailure` (+ the `parsed-but-bad-field` bucket) and running the
+OLD parser over each:
+
+| fixture | optCount | classifyExtractFailure | parsed-but-bad-field? | OLD parser |
+|---|---:|---|---|---|
+| `{"pick":"C","confidence":80}` | 4 | parsed | no | idx 2 ✓ |
+| ```{"pick":"C","confidence":8``` (truncated) | 4 | **unbalanced** | no | **DROP** |
+| `{"pick": C, "confidence": 80}` (unquoted) | 4 | **parse_threw** | no | **DROP** |
+| `pick: B — heart failure` | 4 | **no_brace** | no | **DROP** |
+| ` `` ```json\n{"pick":"D"}\n``` `` (fenced) | 4 | parsed | no | idx 3 ✓ |
+| `{"pick":"E","confidence":70}` | **5** | parsed | **YES** | **DROP** |
+| `{"pick":"ה"}` | **5** | parsed | **YES** | **DROP** |
+| `C` (bare) | 4 | no_brace | no | **DROP** |
+| `{"pick":3}` (numeric) | 4 | parsed | YES | **DROP** (correct — must not coerce) |
+| `` `` (empty) | 4 | empty | no | **DROP** |
+
+**bucket × `t` cross-tab:** not produced — real rows absent, so there is no `t`
+to cross-tab. The provenance link is established structurally instead (below).
+
+**The era-skew mechanism, disk-witnessed (not inferred from synthetic data).**
+`data/questions.json` option-count distribution: **`{4: 4259, 5: 38}`**, max `c`
+index = 4. All 38 five-option questions are GRS8 imports — a **distinct `t`
+provenance**. The old `LETTER_TO_IDX` table maps only A–D, and the old `'ABCD'[i]`
+prompt label produces `undefined` for the 5th option (`i=4`). So a model that
+correctly answers "E"/"ה" on a 5-option GRS8 question is **systematically
+dropped** by the old parser — a provenance-correlated drop, exactly the shape of
+the CERT's `BIASED`-on-`t` verdict. This is the concrete, corpus-grounded link
+between the pick parser and the era skew.
+
+---
+
+## STEP 2 — the fix (minimal; only disk-justified levers)
+
+**Lever 1 — layered parser + corrective retry** (recovers `unbalanced` /
+`parse_threw` / `no_brace` / bare-letter; routes `empty`/numeric to retry).
+`scripts/lib/pickParse.mjs`:
+
+- `parsePickLetter(text, optCount) → { letter, idx } | null`. Three layers:
+  (1) `extractJson` then `pick ?? answer ?? choice`, first-char normalized,
+  mapped via a letter→idx table **built to `optCount`** (A.. + a.. + Hebrew
+  א..); (2) keyed-regex fallback `/pick["'\s:]+["']?([A-Da-fא-ו])/i` (keyed on
+  `pick` ONLY — `answer`/`choice` recur in prose and would false-match, e.g.
+  "the **a**nswer **c**ould be …"; those aliases stay supported by the JSON
+  layer); (3) a single-unambiguous bare-letter scan, scoped to short (≤4-char)
+  responses so it cannot mis-fire on the `c` inside `"pick"` or a stray prose
+  vowel. **Numeric picks are NOT coerced** — a bare number is ambiguous (0- vs
+  1-based, display vs canonical) → returns null → caller retries.
+- `pickWithShapeRetry({ system, userPrompt, callClaude, maxTokens, optCount })`
+  mirrors `judgeWithShapeRetry`: one call; if `parsePickLetter` is null, exactly
+  ONE corrective retry appending a terse `JSON only: {"pick":"<letter>"}`
+  reminder; parse again. Returns `{ idx, letter, recovered, obj }` on success,
+  `{ failed:true, reason:'api-error', message }` if the first call throws (no
+  retry — mirrors the judge validator), or `{ failed:true, reason:'parse', raw }`
+  on a post-retry hard-fail. `callClaude` is an injected parameter
+  (unit-testable, no API / no playwright).
+
+**Lever 2 — `letterFor(i)`** (the optCount/label-space lever — **justified by
+the 38 five-option corpus Qs**). Replaces the hardcoded `'ABCD'[i]` at the pick
+prompt (`:491`) and the two judge/explain prompt option lists (`:591`, `:633`).
+This is the only judge-side touch — a labeling-correctness fix (5-option labels
+now render `E`), not a channel change. The judge prompt's adjudication logic and
+schema are untouched.
+
+**Lever NOT shipped — pick `maxTokens` bump.** The `unbalanced` (truncation)
+bucket appears, but the keyed-regex (Layer 2) recovers the pick token from
+truncated output, and the corrective retry is the backstop. Raising the pick
+budget is therefore unnecessary; `maxTokens` stays `250`. (Per STEP-1's
+"ship only the levers this shows" — truncation is recovered without more budget.)
+
+### Bot wiring
+
+`scripts/chaos-doctor-bot-v4.mjs` `doctorOneQuestion`: the `:498`–`:505` inline
+pick/parse is replaced by `pickWithShapeRetry`. The terminal
+`ai-parse-error/pick` drop row now fires **only after the retry**, with a
+**byte-identical schema** (`type`/`context`/`dropCtx`/`text`/`stemHash`/`qIdx`/
+`stem`/`optCount`). The `ai-error/pick` row (API throw) is preserved for the
+`api-error` branch. The old `LETTER_TO_IDX` const (only used at the replaced
+site) is removed.
+
+### §3.1 schema-invariance — PRESERVED
+
+The `ai-parse-error/pick` bug-row keeps every pre-G5a field, byte-stable; the
+only change is *when* it fires (post-retry) and *where* its `text` comes from
+(`pickResult.raw`). Pinned by `tests/chaosBotV4PickIdentityInstrument.test.js`
+(unchanged, green) and re-asserted in `tests/pickParseResilience.test.js`.
+
+---
+
+## STEP 3 — harness (the deliverable)
+
+`tests/pickParseResilience.test.js` (vitest):
+
+1. **RED-proof.** The OLD logic (`extractJson || {}` →
+   `LETTER_TO_IDX[pick.slice(0,1)]`), replicated verbatim, returns null (DROP)
+   on every recoverable bucket — including the gate's named `unbalanced`
+   truncation anchor. (The harness is only trusted if the old path genuinely
+   fails.)
+2. **GREEN.** `parsePickLetter` recovers a valid in-range idx for every
+   recoverable bucket; `pickWithShapeRetry` exercises the retry path with an
+   injected fake `callClaude` (recover-on-retry, no-retry-on-first-parse,
+   api-error-no-retry, both-fail-hard, numeric-triggers-retry).
+3. **Schema-invariance + wiring pins** assert the bot routes through
+   `pickWithShapeRetry`, the old `LETTER_TO_IDX` is gone, option lists use
+   `letterFor(i)`, and the terminal drop row keeps its byte-stable schema.
+
+`tests/chaosBotV4PickDropInvariant.test.js` was **consciously updated** (not
+silently): its invalid-pick-DROPs-before-`disagrees` invariant is unchanged, but
+the gate's syntactic anchor moved from `if (aiIdx == null …)` to
+`if (pickResult.failed)` (the range check is now encoded inside
+`parsePickLetter`). The rationale is documented in that file's header.
+
+**Recovery-rate threshold:** N/A — real rows absent, so no recovery-rate
+assertion is made (only the per-bucket recover/decline contract). A future
+session with the real audit8cert drop rows can add the rate assertion + the
+bucket×`t` cross-tab.
+
+---
+
+## STEP 4 — verify
+
+`npm run verify` green (trinity untouched — no `shlav-a-mega.html` / `sw.js` /
+`package.json` change, so no version bump and `changelogDrift` stays green). The
+new `tests/pickParseResilience.test.js` and the existing
+`tests/chaosBotV4PickIdentityInstrument.test.js` both pass; all 13 chaosBotV4
+test files pass.
+
+---
+
+## SCOPE / OUT OF SCOPE
+
+- **IN:** the bot pick-parser (`pickParse.mjs`) + the `letterFor` label fix + the
+  resilience harness + the gate-doc update for the moved invariant anchor.
+- **OUT:** any fresh bounded run (this is offline-validatable — fixtures +
+  injected `callClaude`, no live run, no `$` spend); flipping any `q.c`; changing
+  any `broken` flag; touching `shlav-a-mega.html`; the G5 (b)/(c) triggers
+  (their own gated sessions); widening the pick `maxTokens`.
+
+## SHIP
+
+Branch `claude/term-audit8-g5a-pickparse` → PR to `main`. **NO self-merge** —
+`docs/AUDIT8*` is an audit-evidence path. CI green + Codex review (cross-model
+independence) → **Eias merges**. This PR opening is the un-hold trigger.

--- a/scripts/chaos-doctor-bot-v4.mjs
+++ b/scripts/chaos-doctor-bot-v4.mjs
@@ -49,6 +49,7 @@ import { fileURLToPath } from 'node:url';
 import { extractJson } from './lib/extractJson.mjs';
 import { hashStem, normStem } from './lib/hashStem.mjs';
 import { judgeWithShapeRetry } from './lib/judgeShapeValidator.mjs';
+import { pickWithShapeRetry, letterFor } from './lib/pickParse.mjs';
 import {
   resolveAppVerdict,
   resolveJudgeLetter,
@@ -236,7 +237,11 @@ async function callClaude(systemPrompt, userPrompt, { maxTokens = 400, retries =
 // extractJson is imported from ./lib/extractJson.mjs (above) so unit tests
 // don't have to load the playwright runtime.
 
-const LETTER_TO_IDX = { A: 0, B: 1, C: 2, D: 3, a: 0, b: 1, c: 2, d: 3, 'א': 0, 'ב': 1, 'ג': 2, 'ד': 3 };
+// Pick-letter parsing now lives in ./lib/pickParse.mjs (audit-8 G5(a)):
+// a layered parser + optCount-sized letter table + corrective retry that
+// recovers the truncated/malformed/5-option drop classes the old inline
+// `LETTER_TO_IDX[…]` lookup dropped. `letterFor(i)` (imported above)
+// replaces the hardcoded `'ABCD'[i]` so 5-option (GRS8) labels render E.
 
 // ============================================================
 // Question / answer extraction (v4 targeted)
@@ -487,22 +492,31 @@ async function doctorOneQuestion(page, workerId, log) {
   const stemHash = hashStem(normStem(q.stem));
   await sleep(rand(2000, 4500)); // read pause
 
-  // 1) Pick
-  const userPrompt1 = `שאלה:\n${q.stem}\n\nאפשרויות:\n${q.options.map((o, i) => `${'ABCD'[i]}. ${o.text}`).join('\n')}\n\nWhich is correct?`;
-  let pickResp;
-  try { pickResp = await callClaude(SYS_DOCTOR_PICK, userPrompt1, { maxTokens: 250 }); }
-  catch (e) {
-    log.bugs.push({ at: nowIso(), type: 'ai-error', context: 'pick', dropCtx: 'pick-ai-error', message: e.message, stemHash });
+  // 1) Pick — audit-8 G5(a): layered parser + exactly-one corrective retry
+  // (scripts/lib/pickParse.mjs). The terminal ai-parse-error/pick drop now
+  // fires ONLY after the retry; its row schema is byte-identical to the
+  // pre-G5a shape (§3.1 schema-invariance: type/context/dropCtx/text/
+  // stemHash/qIdx/stem/optCount). `letterFor(i)` renders E for 5-option Qs.
+  const userPrompt1 = `שאלה:\n${q.stem}\n\nאפשרויות:\n${q.options.map((o, i) => `${letterFor(i)}. ${o.text}`).join('\n')}\n\nWhich is correct?`;
+  const pickResult = await pickWithShapeRetry({
+    system: SYS_DOCTOR_PICK,
+    userPrompt: userPrompt1,
+    callClaude,
+    maxTokens: 250,
+    optCount: q.options.length,
+  });
+  if (pickResult.failed) {
+    if (pickResult.reason === 'api-error') {
+      log.bugs.push({ at: nowIso(), type: 'ai-error', context: 'pick', dropCtx: 'pick-ai-error', message: pickResult.message, stemHash });
+    } else {
+      log.bugs.push({ at: nowIso(), type: 'ai-parse-error', context: 'pick', dropCtx: 'pick-parse-error', text: (pickResult.raw || '').slice(0, 200), stemHash, qIdx: q.qIdx, stem: q.stem.slice(0, 300), optCount: q.options.length });
+    }
     return { advanced: false, stemHash };
   }
-  const pickJson = extractJson(pickResp.text) || {};
-  const aiLetter = String(pickJson.pick || '').trim().slice(0, 1);
-  const aiIdx = LETTER_TO_IDX[aiLetter];
-  log.actions.push({ at: nowIso(), type: 'ai-pick', letter: aiLetter, idx: aiIdx, conf: pickJson.confidence });
-  if (aiIdx == null || aiIdx < 0 || aiIdx >= q.options.length) {
-    log.bugs.push({ at: nowIso(), type: 'ai-parse-error', context: 'pick', dropCtx: 'pick-parse-error', text: pickResp.text.slice(0, 200), stemHash, qIdx: q.qIdx, stem: q.stem.slice(0, 300), optCount: q.options.length });
-    return { advanced: false, stemHash };
-  }
+  const pickJson = pickResult.obj || {};
+  const aiLetter = pickResult.letter;
+  const aiIdx = pickResult.idx;
+  log.actions.push({ at: nowIso(), type: 'ai-pick', letter: aiLetter, idx: aiIdx, conf: pickJson.confidence, recovered: pickResult.recovered });
 
   // Click option + check (Geri uses button.qo + onclick="pick(N)" — no data-i)
   const optBtn = page.locator('button.qo').nth(aiIdx);
@@ -588,7 +602,7 @@ async function doctorOneQuestion(page, workerId, log) {
 ${q.stem}
 
 Options:
-${q.options.map((o, i) => `${'ABCD'[i]}. ${o.text}`).join('\n')}
+${q.options.map((o, i) => `${letterFor(i)}. ${o.text}`).join('\n')}
 
 App's claimed correct answer: ${appLetter} (${appText})
 App's explanation:
@@ -630,7 +644,7 @@ Validate the APP's claimed answer ${appLetter} (${appText}) against board-level 
   // (75% noise reduction). Only fires when explanation text is available.
   let explainJson = null;
   if (explanation && explanation.length > 50) {
-    const lettered = q.options.map((o, i) => `${'ABCD'[i]}. ${o.text}`).join('\n');
+    const lettered = q.options.map((o, i) => `${letterFor(i)}. ${o.text}`).join('\n');
     const userPromptExplain = `Question (Hebrew):
 ${q.stem}
 

--- a/scripts/lib/pickParse.mjs
+++ b/scripts/lib/pickParse.mjs
@@ -1,0 +1,193 @@
+// Audit-8 G5(a) — pick-channel parse resilience + corrective retry.
+//
+// ROOT CAUSE (CERT RESULT, AUDIT8_G5_REPAIR_GATE.md §VERDICT): the bounded
+// run's `ai-parse-error/pick` DROP channel is `BIASED` on covariate `t`
+// (question provenance / exam-era). The old inline parse at
+// chaos-doctor-bot-v4.mjs:498-505 —
+//   extractJson(text) || {}; LETTER_TO_IDX[String(pick||'').trim().slice(0,1)]
+// — drops on FOUR recoverable classes (witnessed by the STEP-1 bucket
+// diagnostic, AUDIT8_G5a_REPAIR_GATE.md §2):
+//   (1) `unbalanced`  truncated JSON — the pick letter survived but the
+//                     brace never closed → extractJson returns null.
+//   (2) `parse_threw` malformed-but-complete JSON (e.g. unquoted value).
+//   (3) `no_brace`    prose / bare-letter answers with no JSON object.
+//   (4) parsed-but-bad-field — a 5-option (GRS8-provenance) question whose
+//                     pick is "E"/"ה": extractJson succeeds but the old
+//                     4-letter LETTER_TO_IDX table has no E/ה → undefined.
+// Class (4) is the era-skew mechanism: 38 corpus Qs have 5 options, all
+// GRS8 imports — a distinct `t` provenance — so the old table's
+// optCount-blindness drops them preferentially.
+//
+// FIX CLASS (mirrors scripts/lib/judgeShapeValidator.mjs): a layered
+// parser that composes THROUGH the existing extractJson.mjs
+// (grep-existing-utility) + post-parse shape check + exactly ONE corrective
+// re-ask. Numeric picks are deliberately NOT coerced (a bare number is
+// ambiguous: 0- vs 1-based, display vs canonical) — they route to retry.
+//
+// See docs/AUDIT8_G5a_REPAIR_GATE.md (committed in the same PR).
+// Unit contract: tests/pickParseResilience.test.js.
+
+import { extractJson } from './extractJson.mjs';
+
+// Hebrew option labels in board order (א=0 … ח=7). Mirrors the app's
+// Hebrew labeling convention (SYS_DOCTOR_PICK: "א/ב/ג/ד maps the same way").
+const HEB_LABELS = ['א', 'ב', 'ג', 'ד', 'ה', 'ו', 'ז', 'ח'];
+
+// Stable label for option index `i` (A,B,C,…). Replaces the hardcoded
+// `'ABCD'[i]` that returned `undefined` for i>=4 — a real labeling bug on
+// the 38 five-option (GRS8) questions. Pure; used by the bot for BOTH the
+// pick prompt and the judge/explain prompt option lists.
+export function letterFor(i) {
+  return i >= 0 && i < 26 ? String.fromCharCode(65 + i) : String(i);
+}
+
+// A letter→index Map sized to `optCount` (clamped to [2,8]), covering
+// uppercase, lowercase, and Hebrew labels. An index is therefore only
+// resolvable when it is genuinely IN RANGE for the served question — so a
+// returned idx is always < optCount (the old explicit range-check is
+// encoded here).
+function buildLetterTable(optCount) {
+  const n = Math.max(2, Math.min(Number.isInteger(optCount) ? optCount : 4, 8));
+  const t = new Map();
+  for (let i = 0; i < n; i++) {
+    t.set(String.fromCharCode(65 + i), i); // A, B, C, …
+    t.set(String.fromCharCode(97 + i), i); // a, b, c, …
+    t.set(HEB_LABELS[i], i); // א, ב, ג, …
+  }
+  return t;
+}
+
+// Layered pick-letter parser. Returns `{ letter, idx } | null`. `idx` is
+// always in-range for `optCount`. Never coerces a numeric pick (returns
+// null → caller routes to retry).
+export function parsePickLetter(text, optCount) {
+  const table = buildLetterTable(optCount);
+
+  // Layer 1 — structured JSON (the contract path). Read pick ?? answer ??
+  // choice; normalize the first char; map via the optCount-sized table.
+  const obj = extractJson(text);
+  if (obj && typeof obj === 'object' && !Array.isArray(obj)) {
+    const raw = obj.pick ?? obj.answer ?? obj.choice;
+    // Numeric pick → ambiguous, do NOT coerce; fall through to retry.
+    if (raw != null && typeof raw !== 'number') {
+      const ch = String(raw).trim().charAt(0);
+      if (table.has(ch)) return { letter: ch, idx: table.get(ch) };
+    }
+  }
+
+  const s = String(text || '');
+
+  // Layer 2 — keyed-regex fallback for truncated/malformed JSON where the
+  // `pick` token survived but JSON.parse can't (the `unbalanced` /
+  // `parse_threw` classes). Keyed on `pick` ONLY — the SYS_DOCTOR_PICK
+  // schema field — because `answer`/`choice` appear in free prose and would
+  // false-match (e.g. "the answer could be …" → the `c` of "could"). The
+  // `answer`/`choice` aliases stay supported via the structured JSON layer.
+  // `a-f` under the /i flag covers upper E/F too (a 6-option label space);
+  // `א-ו` covers Hebrew.
+  const keyed = s.match(/pick["'\s:]+["']?([A-Da-fא-ו])/i);
+  if (keyed) {
+    const hit = keyed[1];
+    for (const cand of [hit, hit.toUpperCase(), hit.toLowerCase()]) {
+      if (table.has(cand)) return { letter: cand, idx: table.get(cand) };
+    }
+  }
+
+  // Layer 3 — single-unambiguous bare-letter scan (last resort). Scoped to
+  // SHORT responses (the model emitted just a letter: "C", "C.", "(C)") so
+  // it cannot mis-fire on the `c` inside `"pick"` or a stray vowel in prose.
+  // Resolves only when EXACTLY ONE distinct in-range index appears.
+  const stripped = s.trim();
+  if (stripped.length <= 4) {
+    const seen = new Map();
+    for (const ch of stripped) {
+      if (table.has(ch)) {
+        const idx = table.get(ch);
+        if (!seen.has(idx)) seen.set(idx, ch);
+      }
+    }
+    if (seen.size === 1) {
+      const [idx, letter] = seen.entries().next().value;
+      return { letter, idx };
+    }
+  }
+
+  return null;
+}
+
+// Terse corrective re-ask appended to the original prompt — restates the
+// JSON-only contract without speculating which sub-cause produced the miss
+// (mirrors judgeShapeValidator.correctivePrompt).
+function correctivePickPrompt(userPrompt) {
+  return `${userPrompt}
+
+[RETRY] Your previous response did not contain a parseable pick.
+JSON only: {"pick":"<letter>"}`;
+}
+
+// Drop-in for the bot's inline pick/parse (chaos-doctor-bot-v4.mjs
+// :492-505). Mirrors judgeWithShapeRetry: one call; if `parsePickLetter`
+// is null, EXACTLY ONE corrective retry; parse again. `callClaude` is
+// injected so the path is unit-testable with a stub (no API, no playwright).
+//
+// Returns one of:
+//   { idx, letter, recovered, obj }   — success (`obj` = parsed JSON pick
+//                                        object or null; carries confidence/
+//                                        why for the action log)
+//   { failed:true, reason:'api-error', message }  — first call threw
+//                                        (network/API; NO retry, mirroring
+//                                        judgeWithShapeRetry) → caller emits
+//                                        the ai-error/pick row
+//   { failed:true, reason:'parse', raw }          — parse hard-failed after
+//                                        the corrective retry → caller emits
+//                                        the ai-parse-error/pick row
+export async function pickWithShapeRetry({
+  system,
+  userPrompt,
+  callClaude,
+  maxTokens = 250,
+  optCount,
+}) {
+  let resp;
+  try {
+    resp = await callClaude(system, userPrompt, { maxTokens });
+  } catch (e) {
+    return { failed: true, reason: 'api-error', message: e.message };
+  }
+
+  let parsed = parsePickLetter(resp.text, optCount);
+  if (parsed) {
+    return {
+      idx: parsed.idx,
+      letter: parsed.letter,
+      recovered: false,
+      obj: extractJson(resp.text),
+    };
+  }
+
+  // FIRST PARSE FAILED → exactly one corrective retry (cap=1; beyond one
+  // you are masking a prompt problem, not fixing parse adherence).
+  let resp2;
+  try {
+    resp2 = await callClaude(system, correctivePickPrompt(userPrompt), { maxTokens });
+  } catch (e) {
+    // Retry threw (network/API). The first attempt produced unparseable
+    // output and no verdict was obtained → terminal parse hard-fail; the
+    // retry's API error is incidental. Emit the parse drop with the first
+    // response's raw text (what actually failed to parse).
+    return { failed: true, reason: 'parse', raw: resp.text };
+  }
+
+  parsed = parsePickLetter(resp2.text, optCount);
+  if (parsed) {
+    return {
+      idx: parsed.idx,
+      letter: parsed.letter,
+      recovered: true,
+      obj: extractJson(resp2.text),
+    };
+  }
+
+  // Both failed → terminal pick parse drop (now only after the retry).
+  return { failed: true, reason: 'parse', raw: resp2.text };
+}

--- a/tests/chaosBotV4PickDropInvariant.test.js
+++ b/tests/chaosBotV4PickDropInvariant.test.js
@@ -2,11 +2,21 @@
 // docs/AUDIT7_PRE_REGISTERED_GATE.md (#232, "Verified mechanism", L406-417).
 //
 // Load-bearing claim being pinned:
-//   A pick that FAILS the validity gate (aiIdx == null || out-of-range)
-//   logs `ai-parse-error/context=pick` and `return { advanced:false }`
-//   BEFORE the `disagrees` computation. Therefore an invalid pick can
-//   never produce a `disagrees:true` finding row. Contamination of the
-//   audit-3/4/5/7 `disagrees` population is DROP / selection-bias only.
+//   A pick that FAILS to parse logs `ai-parse-error/context=pick` and
+//   `return { advanced:false }` BEFORE the `disagrees` computation.
+//   Therefore an invalid pick can never produce a `disagrees:true` finding
+//   row. Contamination of the audit-3/4/5/7 `disagrees` population is
+//   DROP / selection-bias only.
+//
+// AUDIT8 G5(a) update (2026-06-09): the validity gate moved from an inline
+// `if (aiIdx == null || out-of-range)` check to `if (pickResult.failed)`,
+// where `pickResult` is the return of `pickWithShapeRetry` (the layered
+// parser + one corrective retry). The range check is now encoded inside
+// `parsePickLetter` (its letter→idx table is built to `optCount`, so a
+// resolved idx is always in range). The INVARIANT — drop lexically BEFORE
+// the `disagrees` compute — is UNCHANGED; only the gate's syntactic form
+// changed. The gate-body bound is widened to 600 (the two-branch
+// api-error/parse drop emit measures 489 chars).
 //
 // Goes RED if a future edit:
 //   (a) deletes the invalid-pick gate's early `return { advanced:false }`,
@@ -38,20 +48,19 @@ const SRC = readFileSync(
   'utf8',
 );
 
-// `aiIdx == null` is unique to the invalid-pick validity gate, so this
+// `pickResult.failed` is unique to the invalid-pick validity gate, so this
 // does not collide with the other `return { advanced: false }` sites.
-// Body-length bound widened 200 -> 300 by the AUDIT8 instrument PRE-STEP
-// (docs/AUDIT8_PRESTEP_INSTRUMENT_GATE.md). The invariant THIS regex pins
-// is *lexical ordering* — the invalid-pick gate's early `return {
-// advanced: false }` precedes the `disagrees` compute (assert 2 enforces
-// the ordering independently via offset comparison). The 200 was incidental
-// headroom, not the load-bearing property; the gate body legitimately grew
-// because G0 mandates `stemHash` + `stem` + `optCount` + `dropCtx` on the
-// `ai-parse-error/pick` drop row, all minted after this assert was written.
-// 300 covers the measured 215-char post-instrument body with margin while
-// still tripping on a genuinely large logic insertion between gate and return.
+// Body-length bound: 200 -> 300 (AUDIT8 instrument PRE-STEP) -> 600 (AUDIT8
+// G5(a)). The invariant THIS regex pins is *lexical ordering* — the
+// invalid-pick gate's early `return { advanced: false }` precedes the
+// `disagrees` compute (assert 2 enforces the ordering independently via
+// offset comparison). The bound is incidental headroom, not the load-bearing
+// property; the gate body grew because the G5(a) drop emit forks two
+// branches (api-error vs parse hard-fail). 600 covers the measured 489-char
+// body with margin while still tripping on a genuinely large logic insertion
+// between gate and return.
 const INVALID_PICK_GATE =
-  /if\s*\(\s*aiIdx\s*==\s*null[^)]*\)\s*\{[\s\S]{0,300}?return\s*\{\s*advanced:\s*false/;
+  /if\s*\(\s*pickResult\.failed\s*\)\s*\{[\s\S]{0,600}?return\s*\{\s*advanced:\s*false/;
 const DISAGREES_DECL = /\b(?:const|let|var)\s+disagrees\s*=/g;
 // the canonical gated compute (spans two lines in source).
 const CANONICAL_COMPUTE =

--- a/tests/pickParseResilience.test.js
+++ b/tests/pickParseResilience.test.js
@@ -1,0 +1,213 @@
+// AUDIT8 G5(a) — pick-parser resilience harness.
+// Pre-registration: docs/AUDIT8_G5a_REPAIR_GATE.md (committed in the same PR).
+//
+// The CERT RESULT (docs/AUDIT8_G5_REPAIR_GATE.md §VERDICT) found the bounded
+// run's `ai-parse-error/pick` DROP channel `BIASED` on covariate `t`
+// (question provenance / exam-era). This harness pins the G5(a) fix:
+//   - RED-proof: the OLD inline parse (extractJson || {} →
+//     LETTER_TO_IDX[pick.slice(0,1)]) genuinely DROPS each recoverable
+//     fixture bucket — so the harness is trusted (the old path really fails).
+//   - GREEN: parsePickLetter / pickWithShapeRetry recover a valid in-range
+//     idx for every recoverable bucket, exercise the corrective retry via an
+//     injected fake callClaude, and correctly route numeric/empty to retry.
+//   - Schema-invariance (§3.1): the terminal ai-parse-error/pick drop row is
+//     pinned byte-stable by tests/chaosBotV4PickIdentityInstrument.test.js
+//     (unchanged); here we assert the drop fires only AFTER the retry.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { extractJson } from '../scripts/lib/extractJson.mjs';
+import {
+  parsePickLetter,
+  pickWithShapeRetry,
+  letterFor,
+} from '../scripts/lib/pickParse.mjs';
+
+// ── The OLD parse logic, replicated verbatim for the RED-proof. This is the
+//    chaos-doctor-bot-v4.mjs:498-505 path being replaced. If this ever stops
+//    dropping the known-bad fixtures, the harness is not testing a real fix.
+const OLD_LETTER_TO_IDX = {
+  A: 0, B: 1, C: 2, D: 3, a: 0, b: 1, c: 2, d: 3,
+  'א': 0, 'ב': 1, 'ג': 2, 'ד': 3,
+};
+function oldParse(text, optCount) {
+  const obj = extractJson(text) || {};
+  const aiLetter = String(obj.pick || '').trim().slice(0, 1);
+  const aiIdx = OLD_LETTER_TO_IDX[aiLetter];
+  if (aiIdx == null || aiIdx < 0 || aiIdx >= optCount) return null; // DROP
+  return aiIdx;
+}
+
+// ── Fixture buckets (STEP-1 diagnostic; real audit8cert rows absent on disk
+//    → synthesized per the gate §2 FALLBACK, one representative per class the
+//    pick channel can emit at maxTokens:250).
+const RECOVERABLE = [
+  { bucket: 'unbalanced',           text: '{"pick":"C","confidence":8',     optCount: 4, idx: 2 },
+  { bucket: 'parse_threw',          text: '{"pick": C, "confidence": 80}',  optCount: 4, idx: 2 },
+  { bucket: 'no_brace-keyed',       text: 'pick: B — heart failure',        optCount: 4, idx: 1 },
+  { bucket: 'no_brace-bare',        text: 'C',                              optCount: 4, idx: 2 },
+  { bucket: 'parsed-but-bad-field-E',   text: '{"pick":"E","confidence":70}', optCount: 5, idx: 4 },
+  { bucket: 'parsed-but-bad-field-heb', text: '{"pick":"ה"}',                optCount: 5, idx: 4 },
+];
+
+const UNRECOVERABLE_BY_PARSER = [
+  { bucket: 'numeric-number', text: '{"pick":3}',    optCount: 4 },
+  { bucket: 'numeric-string', text: '{"pick":"3"}',  optCount: 4 },
+  { bucket: 'empty',          text: '',              optCount: 4 },
+  { bucket: 'prose-ambiguous', text: 'The answer could be A or B', optCount: 4 },
+  { bucket: 'out-of-range-E-on-4opt', text: '{"pick":"E"}', optCount: 4 },
+];
+
+const BOT = readFileSync(
+  fileURLToPath(new URL('../scripts/chaos-doctor-bot-v4.mjs', import.meta.url)),
+  'utf8',
+);
+
+describe('G5(a) RED-proof: the OLD pick parse drops the recoverable buckets', () => {
+  // The unbalanced case is the gate's named RED anchor.
+  it('OLD parse returns null (DROP) on the unbalanced/truncation fixture', () => {
+    expect(oldParse('{"pick":"C","confidence":8', 4)).toBeNull();
+  });
+  it('OLD parse drops EVERY recoverable bucket (so the fix is genuinely RED→GREEN)', () => {
+    for (const f of RECOVERABLE) {
+      expect(oldParse(f.text, f.optCount), `old should drop ${f.bucket}`).toBeNull();
+    }
+  });
+});
+
+describe('G5(a) GREEN: parsePickLetter recovers every recoverable bucket in-range', () => {
+  for (const f of RECOVERABLE) {
+    it(`recovers ${f.bucket} → idx ${f.idx}`, () => {
+      const r = parsePickLetter(f.text, f.optCount);
+      expect(r, `${f.bucket} should parse`).not.toBeNull();
+      expect(r.idx).toBe(f.idx);
+      expect(r.idx).toBeGreaterThanOrEqual(0);
+      expect(r.idx).toBeLessThan(f.optCount); // always in-range
+    });
+  }
+  it('clean and markdown-fenced JSON still parse (no regression)', () => {
+    expect(parsePickLetter('{"pick":"C"}', 4).idx).toBe(2);
+    expect(parsePickLetter('```json\n{"pick":"D"}\n```', 4).idx).toBe(3);
+  });
+  it('answer/choice aliases parse via the structured JSON layer', () => {
+    expect(parsePickLetter('{"answer":"B"}', 4).idx).toBe(1);
+    expect(parsePickLetter('{"choice":"d"}', 4).idx).toBe(3);
+  });
+});
+
+describe('G5(a) numeric picks are NOT coerced (routed to retry)', () => {
+  for (const f of UNRECOVERABLE_BY_PARSER) {
+    it(`${f.bucket} → null (parser declines, caller retries)`, () => {
+      expect(parsePickLetter(f.text, f.optCount)).toBeNull();
+    });
+  }
+});
+
+describe('G5(a) pickWithShapeRetry: exactly-one corrective retry via injected callClaude', () => {
+  it('recovers on the retry when the first response is unparseable', async () => {
+    let calls = 0;
+    const fake = async () => {
+      calls += 1;
+      return calls === 1
+        ? { text: 'Hmm, let me think about this carefully without any json' }
+        : { text: '{"pick":"D"}' };
+    };
+    const r = await pickWithShapeRetry({
+      system: 's', userPrompt: 'u', callClaude: fake, maxTokens: 250, optCount: 4,
+    });
+    expect(calls).toBe(2); // exactly one retry
+    expect(r.idx).toBe(3);
+    expect(r.letter).toBe('D');
+    expect(r.recovered).toBe(true);
+    expect(r.obj).toEqual({ pick: 'D' });
+  });
+
+  it('no retry when the first response parses (cap respected from the other side)', async () => {
+    let calls = 0;
+    const fake = async () => { calls += 1; return { text: '{"pick":"A","confidence":90}' }; };
+    const r = await pickWithShapeRetry({
+      system: 's', userPrompt: 'u', callClaude: fake, maxTokens: 250, optCount: 4,
+    });
+    expect(calls).toBe(1);
+    expect(r.idx).toBe(0);
+    expect(r.recovered).toBe(false);
+    expect(r.obj.confidence).toBe(90);
+  });
+
+  it('first-call throw → reason:api-error, NO retry (mirrors judgeWithShapeRetry)', async () => {
+    let calls = 0;
+    const thrower = async () => { calls += 1; throw new Error('net down'); };
+    const r = await pickWithShapeRetry({
+      system: 's', userPrompt: 'u', callClaude: thrower, maxTokens: 250, optCount: 4,
+    });
+    expect(calls).toBe(1);
+    expect(r.failed).toBe(true);
+    expect(r.reason).toBe('api-error');
+    expect(r.message).toBe('net down');
+  });
+
+  it('both attempts unparseable → reason:parse hard-fail (the terminal drop)', async () => {
+    let calls = 0;
+    const garbage = 'completely unparseable model response';
+    const both = async () => { calls += 1; return { text: garbage }; };
+    const r = await pickWithShapeRetry({
+      system: 's', userPrompt: 'u', callClaude: both, maxTokens: 250, optCount: 4,
+    });
+    expect(calls).toBe(2);
+    expect(r.failed).toBe(true);
+    expect(r.reason).toBe('parse');
+    expect(r.raw).toBe(garbage);
+  });
+
+  it('numeric pick on the first call triggers the retry (not coerced to an idx)', async () => {
+    let calls = 0;
+    const fake = async () => {
+      calls += 1;
+      return calls === 1 ? { text: '{"pick":3}' } : { text: '{"pick":"C"}' };
+    };
+    const r = await pickWithShapeRetry({
+      system: 's', userPrompt: 'u', callClaude: fake, maxTokens: 250, optCount: 4,
+    });
+    expect(calls).toBe(2);
+    expect(r.idx).toBe(2);
+    expect(r.recovered).toBe(true);
+  });
+});
+
+describe('G5(a) letterFor: 5-option label space (the optCount lever)', () => {
+  it('renders A..E (the hardcoded "ABCD"[i] returned undefined for i=4)', () => {
+    expect([0, 1, 2, 3, 4].map(letterFor)).toEqual(['A', 'B', 'C', 'D', 'E']);
+  });
+});
+
+describe('G5(a) bot wiring: drop fires only AFTER the retry; schema-invariant', () => {
+  it('the bot routes the pick through pickWithShapeRetry (no inline LETTER_TO_IDX)', () => {
+    expect(BOT).toMatch(/pickWithShapeRetry\(\{/);
+    expect(BOT).toMatch(/import\s*\{[^}]*\bpickWithShapeRetry\b[^}]*\bletterFor\b[^}]*\}\s*from\s*'\.\/lib\/pickParse\.mjs'/);
+    // the old inline lookup table is gone (it would re-introduce the bug)
+    expect(/const LETTER_TO_IDX =/.test(BOT)).toBe(false);
+    // option lists use letterFor in template position, never the hardcoded
+    // 4-letter slice `${'ABCD'[i]}` (prose mentions in comments are fine)
+    expect(/\$\{'ABCD'\[i\]\}/.test(BOT)).toBe(false);
+    expect(BOT).toMatch(/\$\{letterFor\(i\)\}/);
+  });
+
+  it('the terminal ai-parse-error/pick row keeps its byte-stable schema (§3.1)', () => {
+    const m = BOT.match(/type:\s*'ai-parse-error'\s*,\s*context:\s*'pick'[^}]*}/);
+    expect(m, 'ai-parse-error/pick push not found').toBeTruthy();
+    expect(m[0]).toMatch(/dropCtx:\s*'pick-parse-error'/);
+    expect(m[0]).toMatch(/\bstemHash\b/);
+    expect(m[0]).toMatch(/qIdx:\s*q\.qIdx/);
+    expect(m[0]).toMatch(/stem:\s*q\.stem\.slice\(\s*0\s*,\s*300\s*\)/);
+    expect(m[0]).toMatch(/optCount:\s*q\.options\.length/);
+    // it now reads from the retry result's raw text, post-retry
+    expect(m[0]).toMatch(/text:\s*\(pickResult\.raw\s*\|\|\s*''\)\.slice\(\s*0\s*,\s*200\s*\)/);
+  });
+
+  it('the ai-error/pick row is preserved for the api-error branch', () => {
+    const m = BOT.match(/type:\s*'ai-error'\s*,\s*context:\s*'pick'[^}]*}/);
+    expect(m, 'ai-error/pick push not found').toBeTruthy();
+    expect(m[0]).toMatch(/dropCtx:\s*'pick-ai-error'/);
+    expect(m[0]).toMatch(/\bstemHash\b/);
+  });
+});


### PR DESCRIPTION
## Audit-8 G5 trigger (a) — pick-parser robustness hardening

Implements G5 remediation trigger **(a)** named by the AUDIT-8 G5 CERT RESULT (`docs/AUDIT8_G5_REPAIR_GATE.md` §G5 ROUTE): harden the chaos-bot's **pick** parser so its `ai-parse-error/pick` DROP channel stops skewing by exam-era. The CERT verdict was `BIASED` on covariate **`t`** (question provenance / exam-source-era) for that channel.

**Audit-evidence carve-out → STOP at PR-opened. Do NOT self-merge. Eias merges after CI + Codex green.**

### STEP-0 fixture-path decision
`chaos-reports/v4-long/audit8cert_20260607T205756Z` is **ABSENT** (gitignored run dir not in checkout) → fixtures **synthesized** per the gate §2 FALLBACK (one representative per `classifyExtractFailure` bucket + a `parsed-but-bad-field` bucket), not real-row ingest. Levers ship only where a **disk-witnessed fact** justifies them.

### STEP-1 diagnosis (bucket × cause)
The old inline parse (`extractJson||{}` → 4-letter `LETTER_TO_IDX` → `'ABCD'[i]` labels) drops these classes:

| bucket | classifyExtractFailure | OLD parser |
|---|---|---|
| truncated JSON | `unbalanced` | DROP |
| unquoted/malformed | `parse_threw` | DROP |
| prose / bare-letter | `no_brace` | DROP |
| 5-option `"E"`/`"ה"` (optCount=5) | parsed-but-bad-field | DROP |
| numeric `{"pick":3}` | — | DROP (correct — must not coerce) |

**Era-skew mechanism (disk-witnessed, not inferred):** `data/questions.json` option-count distribution is `{4: 4259, 5: 38}`; all **38 five-option questions are GRS8 imports — a distinct `t` provenance**. The old table maps only A–D and `'ABCD'[4]` rendered `undefined`, so correct "E"/"ה" picks on GRS8 questions were systematically dropped — a provenance-correlated drop, the shape of the `BIASED`-on-`t` verdict. *(No bucket×`t` cross-tab — real rows absent, so the link is established structurally.)*

### STEP-2 levers shipped (and one declined)
- **Layered parser + retry** — `scripts/lib/pickParse.mjs`: `parsePickLetter(text, optCount)` (JSON layer → `pick`-keyed regex → short single-bare-letter scan; optCount-sized A/a/Hebrew table; **numeric NOT coerced** → routes to retry) and `pickWithShapeRetry(...)` (one corrective retry, injected `callClaude`, mirrors `judgeWithShapeRetry`).
- **`letterFor(i)`** — the optCount/label lever, **justified by the 38 five-option corpus Qs**; replaces `'ABCD'[i]` at the pick (`:491`) + judge (`:591`) + explain (`:633`) prompts (the only judge-side touch — labeling correctness, not a channel change).
- **NOT shipped: pick `maxTokens` bump** — `unbalanced` appears but the keyed-regex recovers the truncated pick token and the retry backstops it; `maxTokens` stays `250`.

### §3.1 schema-invariance — preserved
The terminal `ai-parse-error/pick` drop row keeps every pre-G5a field byte-stable (`type`/`context`/`dropCtx`/`text`/`stemHash`/`qIdx`/`stem`/`optCount`); only *when* it fires changed (post-retry). Pinned by the unchanged `tests/chaosBotV4PickIdentityInstrument.test.js` and re-asserted in the new harness.

### STEP-3 harness
- `tests/pickParseResilience.test.js` — RED-proof (old logic drops every recoverable bucket, incl. the `unbalanced` anchor) + GREEN (parser/retry recover; retry path exercised with a fake `callClaude`) + schema/wiring pins.
- `tests/chaosBotV4PickDropInvariant.test.js` — **consciously re-anchored** the invalid-pick-DROPs-before-`disagrees` invariant from `if (aiIdx == null …)` to `if (pickResult.failed)`; invariant **unchanged**, only the gate's syntactic form moved (range check now encoded in `parsePickLetter`). Rationale documented in the file header.

### STEP-4 verify
`npm run verify` green — **trinity untouched, no version bump** (scripts/tests/docs only; `changelogDrift` green). 102 test files / **1766 passed, 8 skipped**; all 13 chaosBotV4 files pass.

### Scope
No `q.c` flip, no `broken` change, no `shlav-a-mega.html` touch, no fresh bounded run (offline-validatable). G5 triggers (b)/(c) remain their own gated sessions.

https://claude.ai/code/session_01Y8xmu1smbCdiCkjo6uMRxH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8xmu1smbCdiCkjo6uMRxH)_