### PR TITLE
fix(chaos-bot): allow E in the pick contract (#355 Codex P2 follow-up)

### DIFF
--- a/scripts/chaos-doctor-bot-v4.mjs
+++ b/scripts/chaos-doctor-bot-v4.mjs
@@ -362,8 +362,9 @@ async function extractExplanationAndSource(page) {
 const SYS_DOCTOR_PICK = `You are an experienced board-certified geriatrician taking the Israeli geriatric medicine board exam (Shlav A, P005-2026). Questions are in Hebrew. Your reference frame is Hazzard 8e, Harrison 22e, GRS8, and Israeli MOH regulation. You read carefully, reason step by step in your head, and answer with discipline.
 
 Output format (strict): respond with ONLY a JSON object on a single line, no markdown, no prose. Schema:
-{"pick":"A"|"B"|"C"|"D","confidence":0..100,"why":"<=200 chars terse reasoning"}
-A=index 0, B=index 1, C=index 2, D=index 3 (Hebrew labeling א/ב/ג/ד maps the same way).`;
+{"pick":"<letter>","confidence":0..100,"why":"<=200 chars terse reasoning"}
+"pick" must be EXACTLY one of the option letters shown in the question: A/B/C/D for four-option questions, or A/B/C/D/E when a fifth option E is shown.
+A=index 0, B=index 1, C=index 2, D=index 3, E=index 4 (Hebrew labeling א/ב/ג/ד/ה maps the same way).`;
 
 // v4 judge prompt — audit-3 channel (answer-correctness validation).
 // v10.64.118 redesign: split off from SYS_DOCTOR_EXPLAIN (audit-1) so each

--- a/tests/chaosBotV4Persona.test.js
+++ b/tests/chaosBotV4Persona.test.js
@@ -40,6 +40,16 @@ describe('chaos-doctor-bot v4 — Geri persona pins', () => {
     it('cites Geri-canon textbooks (Hazzard / Harrison / GRS8)', () => {
       expect(PICK).toMatch(/Hazzard/);
     });
+    it('pick contract permits E on five-option (GRS8) questions — Codex P2 on #355', () => {
+      // G5(a) made the parser + option list E-aware (letterFor), but the
+      // contract text still forbade E, so compliant models kept suppressing
+      // correct-E picks on the 38 five-option GRS8 Qs at the PROMPT layer.
+      expect(PICK).toMatch(/A\/B\/C\/D\/E/);
+      expect(PICK).toContain('E=index 4');
+      expect(PICK).toContain('א/ב/ג/ד/ה');
+      // No strict A-D-only enum may return.
+      expect(PICK).not.toContain('"pick":"A"|"B"|"C"|"D"');
+    });
   });
 
   describe('SYS_DOCTOR_JUDGE (audit-3 — answer-correctness only)', () => {


### PR DESCRIPTION
Closes the Codex P2 on #355 (`discussion_r3383678131`): the G5(a) lever made the parser and option list E-aware, but `SYS_DOCTOR_PICK` still mandated `"pick":"A"|"B"|"C"|"D"` — so a compliant model was explicitly told never to answer E, and correct-E picks on the 38 five-option GRS8 questions stayed suppressed at the prompt layer. The era-skew mechanism #355 targeted survived in a different layer.

**Fix**: the contract now permits exactly the letters shown (A–D, or A–E when a fifth option is rendered) and extends the Hebrew mapping to א/ב/ג/ד/ה. Range safety is unchanged — `buildLetterTable` is sized to `optCount`, so an out-of-range E on a 4-option question still fails resolution → retry/drop. Filed as a follow-up rather than a commit on #355 because that PR's head exists only as `refs/pull/355/head` (API-created, no pushable branch).

**Gate**: `npm run verify` green — 102 files / 1767 tests, including a new persona-test pin that also ratchets against the strict A–D enum returning. Scripts/tests only, trinity untouched (same posture as #355).

🤖 Generated with [Claude Code](https://claude.com/claude-code)