### PR TITLE
docs(audit8/g5a): correction marker — bilingual-artifact direction inverted (t effect below floor; verdict still BIASED on under-powered bilingual)

### DIFF
--- a/docs/AUDIT8_G5a_REPAIR_GATE.md
+++ b/docs/AUDIT8_G5a_REPAIR_GATE.md
@@ -357,3 +357,12 @@ certifiable as real nor dismissible** at this power.
   defect. **No `q.c` flip, no `broken` change, no auto-rerun.** The `bilingual` flag, if pursued,
   is its own separately-gated characterization session (and per G5 ROUTE, would need a power
   argument the $20 cap does not provide). G5 triggers (b)/(c) remain their own gated sessions.
+
+## Corrections
+- 2026-06-10: The bilingual-mechanism paragraph above states the recovered drops were
+  "disproportionately mono (Hebrew-only)." That is inverted. Bilingual's share of drops
+  FELL 31.9% -> 16.7%, which forces the recovered (drop->retain) questions to have been
+  disproportionately BILINGUAL (~10 of the 17 recovered, from the figures above), not mono.
+  The contingency table [[5,25],[578,593]] already carries the correct values; only the
+  prose gloss was wrong. Mechanism narrative only — does not change the verdict (still
+  BIASED; bilingual under-powered, n=5).


### PR DESCRIPTION
Follow-up to the merged #358 (couldn't amend — #358 merged at 11:25Z as `98bcbff`). Single-file dated-marker correction to `docs/AUDIT8_G5a_REPAIR_GATE.md`, **NO self-merge** (audit-evidence → Eias merges).

## What's wrong in the merged RESULT
The bilingual-mechanism prose said the recovered drops were *"disproportionately mono (Hebrew-only)."* **Inverted.** From the two committed tables:
- bilingual drops fell **15→5** (−10); mono fell **32→25** (−7); total **47→30** (−17)
- ~**10 of 17** recovered questions were bilingual → **disproportionately bilingual**, not mono

The `31.9%→16.7%` figures and the `[[5,25],[578,593]]` table were already correct; only the prose gloss was backwards.

## Correction mechanism
Per your choice + `feedback_spec_provenance_append_only`: a **dated `## Corrections` marker** appended (verbatim), leaving the original merged paragraph intact rather than rewriting it. Mechanism narrative only — **verdict unchanged** (still BIASED; bilingual under-powered, n=5).

## Verification (no rerun)
Spot-checked the 3 headline figures + the L389 `biasSignal = holmReject && meetsFloor` formula against the **persisted** analyzer JSON — all reproduce: `t` V=0.087/pAdj=0.0102/biasSignal=false; `bilingual` φ=0.102/pAdj=0.0016/`[[5,25],[578,593]]`/biasSignal=true.

Docs-only; `npm run verify` green (102 files / 1767 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)