### PR TITLE
ci(governance): CODEOWNERS for audit-evidence paths (no-self-merge enforcement)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,3 +15,13 @@
 # App
 shlav-a-mega.html @Eiasash
 scripts/ @Eiasash
+
+# --- audit-evidence (no self-merge) ---
+/docs/AUDIT*                 @Eiasash
+/scripts/chaos-*             @Eiasash
+/scripts/analyze_*           @Eiasash
+/scripts/build_stemhash*     @Eiasash
+/scripts/lib/audit8*         @Eiasash
+/scripts/lib/hashStem*       @Eiasash
+/tests/chaosBot*             @Eiasash
+/tests/*audit8*              @Eiasash


### PR DESCRIPTION
Makes the no-self-merge carve-out (a) GitHub-enforced instead of honor-system, for the highest-integrity paths.

Owner-gated patterns (`.github/CODEOWNERS`):
```
/docs/AUDIT*                 @Eiasash
/scripts/chaos-*             @Eiasash
/scripts/analyze_*           @Eiasash
/scripts/build_stemhash*     @Eiasash
/scripts/lib/audit8*         @Eiasash
/scripts/lib/hashStem*       @Eiasash
/tests/chaosBot*             @Eiasash
/tests/*audit8*              @Eiasash
```
Currently-tracked files this covers: **40**.

ACTION REQUIRED to make it bite: enable **Settings -> Branches -> branch protection on `main` -> "Require review from Code Owners"**. Until that toggle is on, this file only auto-requests your review; it does not block merges.

No breach occurred (you merged #359 yourself) — this is belt-and-suspenders. NO self-merge — for your merge.