### PR TITLE
feat(track): add progress donut and mobile RTL/a11y polish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.162",
+  "version": "10.64.163",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -459,6 +459,27 @@ body.dark .chat-disclaimer{background:#422006;border-color:rgb(var(--yellow-fg))
 .track-kpi__value--accent{color:#7c3aed}
 .track-kpi__value--info{color:#0ea5e9}
 .track-kpi__label{font-size:9px;color:rgb(var(--fg2))}
+.track-donut{padding:14px;margin-bottom:12px;display:grid;grid-template-columns:auto minmax(0,1fr);gap:14px;align-items:center}
+.track-donut__ring{width:126px;height:126px;border-radius:50%;padding:10px;background:rgb(var(--bg2));box-shadow:inset 0 0 0 1px rgb(var(--brd));flex-shrink:0}
+.track-donut__ring>div{width:100%;height:100%;border-radius:50%;display:grid;place-items:center;background:conic-gradient(#059669 0 var(--ok-deg),#dc2626 var(--ok-deg) var(--wrong-deg),#cbd5e1 var(--wrong-deg) 360deg);position:relative}
+.track-donut__ring>div::after{content:'';position:absolute;inset:16px;border-radius:50%;background:rgb(var(--card-bg));box-shadow:0 0 0 1px rgb(var(--brd))}
+.track-donut__center{position:relative;z-index:1;text-align:center;line-height:1.1}
+.track-donut__pct{font-size:24px;font-weight:800;color:rgb(var(--fg));font-variant-numeric:tabular-nums}
+.track-donut__pct-label{font-size:9px;color:rgb(var(--fg2));font-weight:700}
+.track-donut__body{min-width:0}
+.track-donut__title{font-size:13px;font-weight:800;margin-bottom:4px}
+.track-donut__sub{font-size:10px;color:rgb(var(--fg2));margin-bottom:10px}
+.track-donut__legend{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:6px}
+.track-donut__item{border:1px solid rgb(var(--brd));border-radius:12px;padding:8px;background:rgb(var(--bg3));min-width:0}
+.track-donut__item-head{display:flex;align-items:center;gap:5px;font-size:10px;color:rgb(var(--fg2));font-weight:700;white-space:nowrap}
+.track-donut__swatch{width:10px;height:10px;border-radius:999px;flex-shrink:0}
+.track-donut__swatch--ok{background:#059669}
+.track-donut__swatch--wrong{background:#dc2626}
+.track-donut__swatch--unanswered{background:#cbd5e1;border:1px solid #94a3b8}
+.track-donut__value{font-size:17px;font-weight:800;margin-top:2px;font-variant-numeric:tabular-nums}
+.track-donut__value--ok{color:#047857}
+.track-donut__value--wrong{color:#b91c1c}
+.track-donut__value--unanswered{color:#475569}
 .track-due{padding:12px;margin-bottom:8px;background:rgb(var(--red-bg));border:1px solid rgb(var(--red-brd));display:flex;align-items:center;gap:8px}
 .track-due__icon{font-size:18px}
 .track-due__body{flex:1}
@@ -657,6 +678,33 @@ body.study .track-activity__cell--lvl0{background:#1e293b}
 .track-activity__cell--lvl2{background:#86efac}
 .track-activity__cell--lvl3{background:#22c55e}
 .track-activity__cell--lvl4{background:#15803d}
+.track-due__cta,.track-rescue__cta,.track-final__cta,.track-lb__refresh,.track-syllabus__toggle,.track-cheat-link,.track-version-footer__btn,.track-version-footer__link{min-height:44px;display:inline-flex;align-items:center;justify-content:center}
+.track-lb__head,.track-wsm__head,.track-cm__head,.track-activity__head,.track-bk__folder-head,.track-reread__row,.track-syllabus__topic{min-height:44px}
+.track-wsm__td-cell--ok,.track-wsm__td-cell--mid,.track-wsm__td-cell--low{color:#0f172a}
+body.dark .track-matrix__title,body.study .track-matrix__title{color:rgb(var(--fg))}
+body.dark .track-final--calm{background:linear-gradient(135deg,#172554,#1e3a8a);border-color:#3b82f6}
+body.dark .track-final--urgent{background:linear-gradient(135deg,#451a03,#78350f);border-color:#f59e0b}
+body.dark .track-final__sub,body.dark .track-rescue__topics{color:#e2e8f0}
+body.dark .track-final__title--calm{color:#bfdbfe}
+body.dark .track-final__title--urgent{color:#fde68a}
+body.dark .track-rescue{background:linear-gradient(135deg,#450a0a,#422006);border-color:#ef4444}
+body.dark .track-rescue__title{color:#fecaca}
+body.dark .track-reread__row,body.dark .track-bk__row{border-bottom-color:#334155}
+@media(max-width:480px){
+.track-kpi-row{grid-template-columns:repeat(2,minmax(0,1fr))}
+.track-kpi{padding:12px 8px;min-height:72px}
+.track-donut{grid-template-columns:1fr;justify-items:center;text-align:center}
+.track-donut__ring{width:148px;height:148px}
+.track-donut__legend{width:100%}
+.track-donut__item{padding:9px 6px}
+.track-final,.track-rescue,.track-due{align-items:stretch;flex-wrap:wrap}
+.track-final__body,.track-rescue__body,.track-due__body{min-width:180px}
+.track-final__cta,.track-rescue__cta,.track-due__cta{margin-inline-start:auto}
+.track-heatmap__grid{grid-template-columns:repeat(auto-fill,minmax(76px,1fr));gap:6px}
+.track-heatmap__cell{height:70px;padding:7px}
+.track-wsm__table{min-width:620px}
+.track-activity__grid{gap:4px}
+}
 .track-daily{padding:14px;margin-bottom:10px;border-left:4px solid #059669}
 .track-daily__title{font-weight:700;font-size:13px;margin-bottom:4px;color:#059669}
 .track-daily__meta{font-size:10px;color:rgb(var(--fg2));margin-bottom:10px}
@@ -5823,6 +5871,31 @@ function renderStudyPlan(){
 
 
 // ===== TRACK HELPERS (_rt* prefix) =====
+function renderProgressDonut(){
+const bank=QZ.length||4297;
+const ok=Math.max(0,Number(S.qOk)||0);
+const wrong=Math.max(0,Number(S.qNo)||0);
+const attempts=ok+wrong;
+const unanswered=Math.max(0,bank-Math.min(attempts,bank));
+const totalForRing=Math.max(bank,attempts,1);
+const okDeg=ok/totalForRing*360;
+const wrongDeg=(ok+wrong)/totalForRing*360;
+const acc=attempts?Math.round(ok/attempts*100):0;
+const accText=attempts?acc+'%':'—';
+const seen=Math.min(attempts,bank);
+return `<div class="card track-donut" role="img" aria-label="Progress donut: ${ok} correct, ${wrong} wrong, ${unanswered} unanswered, accuracy ${accText}">
+<div class="track-donut__ring"><div style="--ok-deg:${okDeg.toFixed(2)}deg;--wrong-deg:${wrongDeg.toFixed(2)}deg"><div class="track-donut__center"><div class="track-donut__pct">${accText}</div><div class="track-donut__pct-label">Accuracy</div></div></div></div>
+<div class="track-donut__body">
+<div class="track-donut__title">Progress Donut</div>
+<div class="track-donut__sub">${seen} answered out of ${bank} questions · ${unanswered} unanswered</div>
+<div class="track-donut__legend">
+<div class="track-donut__item"><div class="track-donut__item-head"><span class="track-donut__swatch track-donut__swatch--ok"></span>Correct</div><div class="track-donut__value track-donut__value--ok">${ok}</div></div>
+<div class="track-donut__item"><div class="track-donut__item-head"><span class="track-donut__swatch track-donut__swatch--wrong"></span>Wrong</div><div class="track-donut__value track-donut__value--wrong">${wrong}</div></div>
+<div class="track-donut__item"><div class="track-donut__item-head"><span class="track-donut__swatch track-donut__swatch--unanswered"></span>Unanswered</div><div class="track-donut__value track-donut__value--unanswered">${unanswered}</div></div>
+</div>
+</div>
+</div>`;
+}
 function _rtTop(){
 const done=Object.values(S.ck).filter(Boolean).length;
 const tot=S.qOk+S.qNo;const pctN=tot?Math.round(S.qOk/tot*100):0;const pct=tot?pctN+'%':'—';
@@ -5851,6 +5924,7 @@ let h=`<div class="track-kpi-row">
 <div class="track-kpi__label">Accuracy</div>
 </div>
 </div>`;
+h+=renderProgressDonut();
 // SRS due alert
 if(dueN>0){
 h+=`<div class="card track-due">
@@ -7351,8 +7425,9 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.162';
+const APP_VERSION='10.64.163';
 const CHANGELOG={
+'10.64.163':['feat(track): add the missing whole-bank progress donut to the Track tab and tighten mobile RTL/a11y polish. Donut uses S.qOk/S.qNo plus the current QZ.length bank count for correct/wrong/unanswered and shows overall accuracy without re-adding any redundant per-topic accuracy list, radar, heatmap, or weak-spots duplicate. Phone fixes from a 390px RTL audit: KPI cards wrap to 2×2 to prevent squeeze; Track CTAs/collapsible headers/links now meet the 44px tap-target floor; weak-spots table gets horizontal scrolling instead of over-compressing; pastel weak-spots cells and Track matrix title get explicit dark-mode-safe colors; final-stretch/rescue cards get dark-mode gradients. Trinity 10.64.162 to 10.64.163.'],
 '10.64.162':['fix(content): idx 1273 testosterone-therapy contraindication key flip c:1 to 0 (Hgb>16 to treated-prostate-cancer history). 76yo, low T, treated prostate CA (radiation 5y ago, PSA undetectable 3y), Hgb 16.2, asks the STRONGEST contraindication to testosterone replacement. Content-gate — data/notes.json id=43 (Andropause/Aging Man, Hazzard Ch 36+37) VERBATIM: "Contraindications: prostate cancer, breast cancer, severe untreated OSA, hematocrit >50%, severe LUTS (IPSS >19), recent CV event." The keyed [1] cites the wrong metric — the source threshold is HEMATOCRIT >50%, not Hgb >16, and Hgb 16.2 is only marginally elevated; prostate cancer is an EXPLICIT listed contraindication, so [0] is the strongest. Physician-adjudicated flip (Eias) from the 2026-06-10 §3 soft-flag TIER-B set (idx 1273), where it was the one item with material directional pull; the treated/remission nuance (modern data permits cautious therapy) is why the auto-rubric held KEEP, but for the board-frame STRONGEST-contraindication question the textbook + in-repo source answer is the prostate-cancer history. Trinity 10.64.161 to 10.64.162.'],
 '10.64.161':['fix(content): idx 2237 STEMI reperfusion answer-key flip c:2 to 3 (transfer-to-PCI to Tenecteplase 40mg). 81yo anterior STEMI, no PCI on-site, transfer time 140 min, no fibrinolysis contraindication, 72kg. The keyed [2] transfer-for-primary-PCI is wrong per Harrison 22e Ch 286 VERBATIM: "Compared with fibrinolysis, primary PCI is preferred unless the time to delivery of the first coronary device is anticipated to be longer than 120 min" (140>120 so fibrinolysis is the correct strategy). On the 81yo ICH concern, Harrison Ch 286 VERBATIM: "While advanced age is associated with an increase in hemorrhagic complications, the benefit of fibrinolytic therapy in the elderly appears to justify its use if no other contraindications are present, the amount of myocardium in jeopardy appears to be substantial, and timely access to primary PCI is" [not available] — anterior STEMI = substantial myocardium, no contraindications, PCI not timely. Among offered options 72kg maps to the 70-79kg TNK weight band = 40mg, so [3] is the correct lytic dose ([1] 25mg is not a standard band, [0] 35mg is the 60-69kg band). NOTE the STREAM ≥75yo half-dose (15-20mg) refinement is not represented in any option, so the question tests reperfusion STRATEGY + standard weight-band dosing, both satisfied by [3]. Physician-adjudicated flip (Eias) from the 2026-06-01 §3 clinical-sweep FLAG (idx 2237, conf 90); surfaced read-only, applied here with the verbatim source per the content-gate. Trinity 10.64.160 to 10.64.161.'],
 '10.64.160':['fix(account): sync the Anthropic API key to the account at save time (#353). The v10.64.158 security fix removed _apikey from the cloud backup, which also killed the only WRITE path into app_users.api_key (the sync_api_key_from_backup trigger fed off backup writes) — so a key saved or rotated after .158 stayed localStorage-only and auth_login_user restored a stale or null key on the next device. Now the settings Save/Remove buttons route through _apiKeySaveFromInput / _apiKeyRemove: local save happens FIRST (never blocked by network), then for logged-in users the key is synced to the account via the existing auth_set_api_key RPC (SECURITY DEFINER, requires the password — collected with window.prompt, the same pattern as change-password). Cancel = device-only save with an explicit toast; RPC failure keeps the local save and warns; guests are a silent no-op. Empty key clears the account copy too (parity with setApiKey empty-string semantics). Origin: Codex P2 on IM #167 / FM #142, tracked as #353; sibling ports follow. Round-2 Codex P2s folded in: (a) the legacy backup _apikey restore is now FILL-ONLY — a backup _apikey is by definition pre-.158-stale, so it never clobbers a present key and only fills a true fresh device; (b) the has-key settings state gained a sync-to-account button (_apiKeySyncExisting) so a key saved before this release can be pushed to the account without remove + re-enter. Tests: tests/apikeyAccountSync.test.js pins the wiring, the local-save-before-sync order, both P2 fixes, and keeps the .158 regression locks intact. Trinity 10.64.159 to 10.64.160.'],

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.162';
+const CACHE='shlav-a-v10.64.163';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 // CRITICAL_URLS = the bare-minimum app shell required for offline boot.
 // Anything else (data/*.json, fonts, icons) is best-effort in the install


### PR DESCRIPTION
### Motivation
- The Track tab lacked a single-view whole-bank progress visual (correct / wrong / unanswered + accuracy) that complements the existing heatmap and weak-spots map. This change adds that missing visual while keeping the Track view compact and non‑duplicative. 
- A short mobile RTL audit revealed a few small layout/tap-target and dark-mode contrast rough edges on the Track page that reduced usability on phones and for accessibility; these needed targeted CSS/markup fixes.

### Description
- Added a responsive progress donut component (CSS + `renderProgressDonut()` helper) that computes values from `S.qOk`, `S.qNo` and the bank size (`QZ.length`) and renders it beneath the KPI row on the Track tab.  
- Hooked the donut into the Track render flow immediately after the KPI cards (`_rtTop`), including an accessible `role="img"` label and numeric center accuracy display.  
- Mobile/RTL and a11y polish: 2×2 KPI grid on small screens, enforced 44px minimum tap targets for Track CTAs/collapsible controls/links, wider heatmap cells on phones, horizontal scrolling for the weak-spots table, and dark-mode-safe color adjustments for Track cards.  
- Version trinity bumped to `10.64.163` across `package.json`, `APP_VERSION` in `shlav-a-mega.html`, and the service-worker `CACHE` in `sw.js`; changelog entry added; no question/answer content was modified.

### Testing
- Ran the unit/test suite with `npm test` and observed all tests passing: `102 files, 1767 passed | 8 skipped` (Vitest).  
- Ran the full verification gate with `npm run verify` and observed success (version-sync, inline JS checks, innerHTML guards, Harrison baseline scan, and tests).  
- Performed a Playwright mobile RTL smoke (headless Chromium, 390×844) against a local server (`python3 -m http.server 4173`) after installing browsers/deps with `npx playwright install chromium` and `npx playwright install-deps chromium`, confirming the donut renders, no horizontal overflow, no console errors, and no Track tap targets under 44px.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a29ecfd0c0483258958729e3a31e3bd)