### PR TITLE
docs: trim stale release/count line from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,6 @@
 
 Israeli geriatrics board-exam study PWA. Live: https://eiasash.github.io/Geriatrics/
 Stack: SINGLE-FILE HTML PWA, **no build** — the whole app is `shlav-a-mega.html` (~8,560 lines, vanilla JS). Data in `data/*.json`. Hebrew RTL.
-Current release: `10.64.164`; question count: 4,297.
 
 ## Setup & commands
 ```bash


### PR DESCRIPTION
Removes the self-updating `Current release / question count` line Codex added in #373 — it goes stale on every version bump, and code is the source of truth. Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)