### PR TITLE
fix(ui): guard geri minimal quiz mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geriatrics",
-  "version": "10.64.141",
+  "version": "10.64.165",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geriatrics",
-      "version": "10.64.141",
+      "version": "10.64.165",
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.5",
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.164",
+  "version": "10.64.165",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -170,6 +170,11 @@ html[data-skin="geriatrics"] .tabs button.on{color:#b45309}
 body.dark[data-skin="geriatrics"] .tabs button.on,html[data-skin="geriatrics"] body.dark .tabs button.on{color:var(--app-primary)}
 .tabs .ic{font-size:18px}
 .ct{max-width:640px;margin:0 auto;padding:12px 12px 80px}
+/* === minimal mode (enable with ?minimal=1): strip feature chrome to just the quiz === */
+body.minimal-mode .tabs{display:none!important}
+body.minimal-mode .ct{padding-bottom:24px}
+body.minimal-mode .hdr-titleblock #hdr-sub{display:none}
+body.minimal-mode .hdr h1{font-size:16px}
 .card{background:rgb(var(--card-bg));border-radius:16px;border:1px solid rgb(var(--brd));box-shadow:0 1px 3px rgba(0,0,0,.04);overflow:hidden;margin-bottom:10px}
 .pill{display:inline-block;padding:5px 12px;border-radius:20px;font-size:11px;font-weight:600;transition:.15s;cursor:pointer}
 .pill.on{background:var(--app-primary);color:var(--app-on-primary);box-shadow:0 2px 6px rgba(59,130,246,.25);border:1px solid transparent}
@@ -1944,6 +1949,8 @@ let TABS=[];
 
 // ===== END DATA LOADER =====
 
+const MINIMAL_MODE=(()=>{try{const p=new URLSearchParams(location.search);return p.get('minimal')==='1'||p.get('mode')==='minimal'||location.hash==='#minimal';}catch(e){return false;}})();
+if(MINIMAL_MODE)document.body.classList.add('minimal-mode');
 let tab='quiz';
 let learnSub='study'; // sub-tab within Learn: study|flash
 let _studyMode='learn'; // v10.54.0: 'learn'|'lib' — which mode in unified Study tab
@@ -7228,6 +7235,7 @@ function render(){
 setTimeout(()=>{
 const el=document.getElementById('ct');
 if(!el)return; // defensive: container could be detached if app teardown raced render
+if(MINIMAL_MODE&&tab!=='quiz')tab='quiz';
 const focused=document.activeElement?.id;
 const sv={srchi:document.getElementById('srchi')?.value,nfilt:document.getElementById('nfilt')?.value};
 if(tab!==lastTab){el.classList.remove('fade-in');void el.offsetWidth;el.classList.add('fade-in');window.scrollTo({top:0});lastTab=tab;}
@@ -7425,8 +7433,9 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.164';
+const APP_VERSION='10.64.165';
 const CHANGELOG={
+'10.64.165':['ui(minimal): add an explicitly gated quiz-only minimal mode for claude/geri-minimal. Minimal mode now activates only via ?minimal=1, ?mode=minimal, or #minimal, adds body.minimal-mode, hides the tab bar under that class, and normalizes non-quiz renders back to quiz only while MINIMAL_MODE is enabled. The normal GitHub Pages app keeps Learn/Track/More/library navigation. No question content touched. Trinity 10.64.164 to 10.64.165.'],
 '10.64.164':['fix(content): idx 4043 hypertension target key flip c:0 to 3 (<140 to <130). PR #369 near-miss review rechecked every named candidate from docs/AUDIT_AI2026HY_CLINICAL_SWEEP_2026-06-10.md against in-repo sources. Hazzard Ch 79 VERBATIM: "Its recommendation for ambulatory, community-living older adults is a SBP goal of 130 mm Hg." data/notes.json Hypertension likewise states: "Target BP: <130/80 for most elderly" and reserves SBP 130-150 for frail patients (CFS >=5). The stem is a 78yo community clinic patient with HTN, T2D, and MCI, not frailty or limited life expectancy; options <120, <150, and <140 are therefore inferior to <130. The other PR #369 near-misses remain KEEP: sarcopenia has no "probable sarcopenia" option, fiber has overlapping 25-30 source vs 20-25/30-38 options, NSAID avoidance direction is correct despite over-specific eGFR<45 wording, ISH initiation threshold lacks a verbatim initiation source, transfusion is 7/8 vs 8/9 but symptomatic/case-by-case, elder-abuse figures match notes, and VTE prophylaxis has source support but no sourced 35-day hip protocol. Trinity 10.64.163 to 10.64.164.'],
 '10.64.163':['feat(track): add the missing whole-bank progress donut to the Track tab and tighten mobile RTL/a11y polish. Donut uses S.qOk/S.qNo plus the current QZ.length bank count for correct/wrong/unanswered and shows overall accuracy without re-adding any redundant per-topic accuracy list, radar, heatmap, or weak-spots duplicate. Phone fixes from a 390px RTL audit: KPI cards wrap to 2×2 to prevent squeeze; Track CTAs/collapsible headers/links now meet the 44px tap-target floor; weak-spots table gets horizontal scrolling instead of over-compressing; pastel weak-spots cells and Track matrix title get explicit dark-mode-safe colors; final-stretch/rescue cards get dark-mode gradients. Trinity 10.64.162 to 10.64.163.'],
 '10.64.162':['fix(content): idx 1273 testosterone-therapy contraindication key flip c:1 to 0 (Hgb>16 to treated-prostate-cancer history). 76yo, low T, treated prostate CA (radiation 5y ago, PSA undetectable 3y), Hgb 16.2, asks the STRONGEST contraindication to testosterone replacement. Content-gate — data/notes.json id=43 (Andropause/Aging Man, Hazzard Ch 36+37) VERBATIM: "Contraindications: prostate cancer, breast cancer, severe untreated OSA, hematocrit >50%, severe LUTS (IPSS >19), recent CV event." The keyed [1] cites the wrong metric — the source threshold is HEMATOCRIT >50%, not Hgb >16, and Hgb 16.2 is only marginally elevated; prostate cancer is an EXPLICIT listed contraindication, so [0] is the strongest. Physician-adjudicated flip (Eias) from the 2026-06-10 §3 soft-flag TIER-B set (idx 1273), where it was the one item with material directional pull; the treated/remission nuance (modern data permits cautious therapy) is why the auto-rubric held KEEP, but for the board-frame STRONGEST-contraindication question the textbook + in-repo source answer is the prostate-cancer history. Trinity 10.64.161 to 10.64.162.'],

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.164';
+const CACHE='shlav-a-v10.64.165';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 // CRITICAL_URLS = the bare-minimum app shell required for offline boot.
 // Anything else (data/*.json, fonts, icons) is best-effort in the install

--- a/tests/minimalModeGuard.test.js
+++ b/tests/minimalModeGuard.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const html = readFileSync(
+  resolve(import.meta.dirname, '..', 'shlav-a-mega.html'),
+  'utf-8'
+);
+
+describe('minimal mode routing guard', () => {
+  it('does not hide the tab bar unless an explicit minimal URL signal is present', () => {
+    expect(html).toContain("p.get('minimal')==='1'");
+    expect(html).toContain("p.get('mode')==='minimal'");
+    expect(html).toContain("location.hash==='#minimal'");
+    expect(html).toContain("document.body.classList.add('minimal-mode')");
+    expect(html).toContain('body.minimal-mode .tabs{display:none!important}');
+    expect(html).not.toMatch(/(^|\n)\.tabs\{display:none!important\}/);
+  });
+
+  it('forces quiz rendering only after minimal mode is enabled', () => {
+    expect(html).toContain("if(MINIMAL_MODE&&tab!=='quiz')tab='quiz';");
+  });
+
+  it('normalizes tab before render uses lastTab or switch(tab)', () => {
+    const guard = html.indexOf("if(MINIMAL_MODE&&tab!=='quiz')tab='quiz';");
+    const lastTabCheck = html.indexOf('if(tab!==lastTab)', guard);
+    const tabSwitch = html.indexOf('switch(tab)', guard);
+    expect(guard).toBeGreaterThan(-1);
+    expect(lastTabCheck).toBeGreaterThan(guard);
+    expect(tabSwitch).toBeGreaterThan(guard);
+  });
+});


### PR DESCRIPTION
## Summary
- Keep `claude/geri-minimal` quiz-only after hiding the tab bar by normalizing non-quiz renders back to `quiz`.
- Add a source-level guard test for the minimal-mode routing contract.
- Bump release markers to `10.64.165` across package/version, APP_VERSION/changelog, SW cache, and lockfile root fields.

## Review note
The bug found during local review: hidden tabs did not prevent inline handlers from setting `tab='lib'`, `tab='more'`, or `tab='track'`, which could strand a user in a non-quiz view with no visible navigation back.

## Testing
- `git diff --check`
- `PYTHONUTF8=1 npm run verify` via temporary local `python3` shim on Windows: 103 test files passed, 1769 tests passed, 8 skipped

No question/answer content was edited.