### PR TITLE
chore: remove throwaway AI-integration smoke-test doc

### DIFF
--- a/docs/ai-integration-smoke.md
+++ b/docs/ai-integration-smoke.md
@@ -1,8 +1,0 @@
-# AI integration smoke test — 2026-06-11
-
-Throwaway PR to confirm this repo's AI PR bots respond:
-
-- **@claude** review — anthropics/claude-code-action@v1 via `claude-code-review.yml` (auto on PR open)
-- **@codex review** — chatgpt-codex-connector[bot]
-
-No app code touched. Safe to close without merging.


### PR DESCRIPTION
Removes `docs/ai-integration-smoke.md`, the inert smoke-test doc that landed on main via #377 (used to confirm the @claude and @codex bots, both verified working). No app/runtime impact.