### PR TITLE
fix(weekly-audit): exempt SZMC-Rescue Qs from ref requirement

### DIFF
--- a/.github/workflows/weekly-audit.yml
+++ b/.github/workflows/weekly-audit.yml
@@ -46,7 +46,15 @@ jobs:
                   errors.append(f'Q{i}: invalid topic index (must be 0..{topic_count-1})')
               if not q.get('t'):
                   errors.append(f'Q{i}: missing year field')
-              if not q.get('ref'):
+              # SZMC-Rescue Qs are intentionally unsourced: bespoke Israeli-context
+              # content with no real textbook source, left empty per the
+              # anti-fabrication rule (CLAUDE.md; #307 recovered the only 5 with a
+              # genuine _refs_orig). The vitest suite already allows empty refs
+              # (dataIntegrity.test.js: "empty ref allowed"); this exemption keeps the
+              # weekly audit consistent. The bounded invariant — empty ref ⟹ SZMC-Rescue
+              # — is pinned in tests/rescueRefExemption.test.js so a non-rescue ref loss
+              # is still caught on every CI run.
+              if not q.get('ref') and q.get('t') != 'SZMC-Rescue':
                   errors.append(f'Q{i}: missing citation (ref)')
           if errors:
               print(f'ERRORS ({len(errors)}):')

--- a/tests/rescueRefExemption.test.js
+++ b/tests/rescueRefExemption.test.js
@@ -1,0 +1,67 @@
+/**
+ * SZMC-Rescue ref exemption — bounded invariant guard.
+ *
+ * The 75 SZMC-Rescue questions are intentionally unsourced: bespoke
+ * Israeli-context content with no real textbook source, left with an empty
+ * `ref` per the anti-fabrication rule (CLAUDE.md; #307 recovered the only 5
+ * that had a genuine `_refs_orig`). Auto-attaching the topic-default chapter
+ * from question_chapters.json would BE the fabrication the policy forbids
+ * (that map is "reliable as a floor… does NOT carry per-Q curatorial
+ * specificity" — q.ref rebuild caveat 2026-05-13).
+ *
+ * weekly-audit.yml used to require `ref` on every question, so it failed
+ * weekly on these 75. That check is now exempt for `t === 'SZMC-Rescue'`.
+ *
+ * This test moves the *real* guard onto every CI run: the exemption must stay
+ * BOUNDED — an empty/missing ref is allowed ONLY on SZMC-Rescue questions. If a
+ * regular (sourced) question ever loses its ref, this fails loudly instead of
+ * being silently swallowed by the now-relaxed weekly audit.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const rootDir = resolve(import.meta.dirname, '..');
+const questions = JSON.parse(
+  readFileSync(resolve(rootDir, 'data/questions.json'), 'utf-8'),
+);
+
+describe('SZMC-Rescue ref exemption is bounded', () => {
+  it('every question with an empty/missing ref is tagged SZMC-Rescue', () => {
+    const offenders = [];
+    for (let i = 0; i < questions.length; i++) {
+      const ref = String(questions[i].ref || '').trim();
+      if (!ref && questions[i].t !== 'SZMC-Rescue') {
+        offenders.push({ idx: i, t: questions[i].t, q: String(questions[i].q || '').slice(0, 50) });
+      }
+    }
+    expect(
+      offenders,
+      `${offenders.length} non-SZMC-Rescue questions are missing a ref ` +
+        `(empty ref is only allowed on SZMC-Rescue): ${JSON.stringify(offenders.slice(0, 5))}`,
+    ).toEqual([]);
+  });
+
+  it('the SZMC-Rescue batch genuinely contains unsourced questions (sanity)', () => {
+    const rescue = questions.filter((q) => q.t === 'SZMC-Rescue');
+    const unsourced = rescue.filter((q) => !String(q.ref || '').trim());
+    // The batch exists and at least some are intentionally unsourced — guards
+    // against the test silently passing because the tag was renamed/removed.
+    expect(rescue.length, 'expected a non-empty SZMC-Rescue batch').toBeGreaterThan(0);
+    expect(
+      unsourced.length,
+      'expected SZMC-Rescue to include intentionally-unsourced questions',
+    ).toBeGreaterThan(0);
+  });
+
+  it('weekly-audit.yml ref check carries the SZMC-Rescue exemption', () => {
+    const yml = readFileSync(
+      resolve(rootDir, '.github/workflows/weekly-audit.yml'),
+      'utf-8',
+    );
+    // Pin the exemption so a future edit that re-tightens the audit (and would
+    // re-break it weekly) is caught here instead of in production.
+    expect(yml).toMatch(/q\.get\('t'\)\s*!=\s*'SZMC-Rescue'/);
+  });
+});


### PR DESCRIPTION
## Problem
The **Weekly Audit** has failed every Sunday since 2026-05-24 (4 consecutive runs). Root cause: its inline validator requires `ref` on every question, but the **75 SZMC-Rescue** questions are **intentionally unsourced** — bespoke Israeli-context content with no real textbook source, left empty per the anti-fabrication rule (CLAUDE.md; #307 recovered the only 5 with a genuine `_refs_orig`).

The rest of the suite already treats this as valid — `tests/dataIntegrity.test.js` explicitly: `if (!ref) continue; // empty ref allowed`. So main CI is green while only the weekly audit cries wolf.

## Why not "just add citations" (the rejected path)
The only available auto-mapping is `question_chapters.json`, which the repo's own `q.ref` rebuild caveat warns is a topic-default that "does NOT carry per-Q curatorial specificity." Attaching those to bespoke questions with no real source **is** the fabrication the policy forbids (v9.81 idx-510 lesson). So the correct fix aligns the audit with the documented policy.

## Change
- `weekly-audit.yml`: ref check now exempts `t === 'SZMC-Rescue'` (with the rationale inline).
- **`tests/rescueRefExemption.test.js`** (new): relocates the *real* guard onto every CI run —
  - empty/missing `ref` is allowed **only** on SZMC-Rescue (bounded exemption → a regular question losing its ref still fails loudly),
  - the SZMC-Rescue batch genuinely contains unsourced Qs (guards against tag rename),
  - the workflow keeps the exemption (pin).

## Verified
- Weekly-audit ref/year logic after fix → **0 errors** (was 75).
- Test data-invariant: 0 non-rescue empty-ref offenders; 80 SZMC-Rescue / 75 unsourced.
- `node --check` clean.
- No app/data/version change — version trinity untouched (stays 10.64.181).

🤖 Generated with [Claude Code](https://claude.com/claude-code)