### PR TITLE
fix(tests): isolate tagger idempotency test to temp file (kill CI flake)

### DIFF
--- a/scripts/regen_derived.cjs
+++ b/scripts/regen_derived.cjs
@@ -78,7 +78,12 @@ function runTagger(scriptPath, label) {
   if (!fs.existsSync(scriptPath)) {
     throw new Error(`${label}: script not found at ${scriptPath}`);
   }
-  const r = spawnSync('node', [scriptPath], { cwd: ROOT, encoding: 'utf-8' });
+  // Strip QCHAP_OUT so a stray value in the env can't redirect tag_chapters.cjs
+  // to a temp path and let the drift check pass a stale committed file — that
+  // override is for the isolation test only. (Codex P2 #396)
+  const env = { ...process.env };
+  delete env.QCHAP_OUT;
+  const r = spawnSync('node', [scriptPath], { cwd: ROOT, encoding: 'utf-8', env });
   if (r.status !== 0) {
     throw new Error(`${label} exited ${r.status}\nstdout: ${r.stdout}\nstderr: ${r.stderr}`);
   }

--- a/scripts/tag_chapters.cjs
+++ b/scripts/tag_chapters.cjs
@@ -37,7 +37,14 @@ const HAR_PATH = fs.existsSync(path.join(ROOT, 'harrison_chapters.json'))
   ? path.join(ROOT, 'harrison_chapters.json')
   : path.join(ROOT, 'harrison_index.json');
 const GRS_PATH = path.join(ROOT, 'data/grs8_chapters.json');
-const OUT_PATH = path.join(ROOT, 'data/question_chapters.json');
+// Output path; overridable via QCHAP_OUT so isolation tests write to a temp
+// file instead of clobbering the shared tracked data/question_chapters.json
+// (otherwise the truncate+write races parallel vitest files reading it →
+// intermittent empty read. Mirrors regen_derived --check 'must not dirty the
+// worktree'). Default is unchanged for the regen pipeline.
+const OUT_PATH = process.env.QCHAP_OUT
+  ? path.resolve(ROOT, process.env.QCHAP_OUT)
+  : path.join(ROOT, 'data/question_chapters.json');
 
 const VERBOSE = process.argv.includes('--verbose');
 

--- a/tests/chapterLinking.test.js
+++ b/tests/chapterLinking.test.js
@@ -16,9 +16,10 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { readFileSync, existsSync } from 'fs';
+import { readFileSync, existsSync, rmSync } from 'fs';
 import { resolve } from 'path';
 import { execSync } from 'child_process';
+import { tmpdir } from 'os';
 
 const rootDir = resolve(import.meta.dirname, '..');
 const html = readFileSync(resolve(rootDir, 'shlav-a-mega.html'), 'utf-8');
@@ -91,11 +92,24 @@ describe('data/question_chapters.json shape', () => {
 });
 
 describe('scripts/tag_chapters.cjs idempotency', () => {
-  it('running the tagger twice produces byte-identical output', () => {
+  it('tagger reproduces the committed question_chapters.json (idempotent)', () => {
     const before = readFileSync(qcPath, 'utf-8');
-    execSync('node scripts/tag_chapters.cjs', { cwd: rootDir, stdio: 'pipe' });
-    const after = readFileSync(qcPath, 'utf-8');
-    expect(after).toBe(before);
+    // Write the fresh tagger output to a per-process temp file via QCHAP_OUT
+    // instead of clobbering the shared tracked data/question_chapters.json —
+    // clobbering it races parallel test files reading the same path (truncate
+    // window → intermittent empty read → spurious red CI). Same assertion.
+    const tmpOut = resolve(tmpdir(), `qchap-${process.pid}-${Date.now()}.json`);
+    try {
+      execSync('node scripts/tag_chapters.cjs', {
+        cwd: rootDir,
+        stdio: 'pipe',
+        env: { ...process.env, QCHAP_OUT: tmpOut },
+      });
+      const after = readFileSync(tmpOut, 'utf-8');
+      expect(after).toBe(before);
+    } finally {
+      try { rmSync(tmpOut, { force: true }); } catch {}
+    }
   });
 });
 


### PR DESCRIPTION
## What the monitor caught
The (just-restored) auto-audit monitor flagged 🔴 **Geri CI failure on main at `f5b9675`** — which is #394's merge. But #394 only changed `weekly-audit.yml` + a rescue test, which **cannot** touch the tagger, and the commit right before it was green. A no-op **re-run went green** → confirmed **flake, not regression**.

## Root cause
`tests/chapterLinking.test.js`'s idempotency test runs `scripts/tag_chapters.cjs`, which **truncates + rewrites the shared, tracked `data/question_chapters.json`**. Vitest runs test *files* in parallel, so other files reading that path (`regenDerived`, `textbookChapters`, `geriBotQueueSourceReview`, and this file's own top-level reads) intermittently hit the truncate window → empty read → `expected '' to be '{...}'`.

`regen_derived --check` already avoids this by writing to `.tmp/` ("must not dirty the worktree", Codex P2 #259) — this applies the same principle to the tagger test, the only remaining test that clobbers the real file.

## Fix
- `tag_chapters.cjs`: add a `QCHAP_OUT` output-path override. **Default is unchanged** — the regen pipeline and a bare `node scripts/tag_chapters.cjs` still write `data/question_chapters.json`.
- `tests/chapterLinking.test.js`: write the fresh tagger output to a per-process temp file and compare to the committed file. **Same assertion**, no shared-file mutation, no race.

## Verified locally
With `QCHAP_OUT` set: the real `question_chapters.json` md5 is **unchanged** (isolation works) and the temp output **byte-matches** the committed file (idempotency holds → test passes). No app/data/version change — trinity untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)