### PR TITLE
ci(weekly-audit): drop live-judge-gate job (manual R3 pre-flight only)

### DIFF
--- a/.github/workflows/weekly-audit.yml
+++ b/.github/workflows/weekly-audit.yml
@@ -241,26 +241,14 @@ jobs:
               print(f'OK: CLAUDE.md references v{ver}')
           PYEOF
 
-  # AUDIT-8 #332 follow-up — catch the "inert bot" failure class LOUDLY.
-  # The v4 chaos bot locates the practice surface by live aria-labels; an a11y/i18n
-  # label edit (cf. #290, merged 2026-05-26) silently zeroes its judge calls, so it
-  # reports "0 findings = clean" while measuring nothing. Every v4 "0 findings" GREEN
-  # dated 2026-05-26 → #332-merge is therefore VACUOUS (the bot was blind ~11 days),
-  # NOT clean. This gate runs the live judge-call smoke and hard-fails when the bot's
-  # own ai-judge counter is 0, so future label drift surfaces as a red weekly run
-  # instead of a fake-clean report. (Requires the gate test added in #332.)
-  live-judge-gate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
-        with:
-          node-version: '20'
-      - name: Install dependencies
-        run: npm ci
-      - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
-      - name: Live judge-call gate (fails loud if the bot is inert)
-        env:
-          CHAOS_LIVE_SMOKE: '1'
-        run: npx vitest run tests/chaosBotV4LiveJudgeGate.test.js
+  # AUDIT-8 #332 live judge-call gate (tests/chaosBotV4LiveJudgeGate.test.js):
+  # the v4 chaos bot locates the practice surface by live aria-labels, so an
+  # a11y/i18n label edit can silently zero its judge calls (cf. #290). The gate's
+  # cheap structural pins (selector contract + judge-counter existence) already
+  # run in normal ci.yml on every push. The LIVE smoke is intentionally NOT a
+  # weekly job: this scheduled run provides no AI credentials (no CHAOS_USE_PROXY
+  # / API key), so the bot could never complete judge calls and only timed out
+  # (spawnSync ETIMEDOUT @170s), red-flagging the weekly audit every run without
+  # measuring anything. Per its own docstring it is a MANUAL R3 pre-flight — run
+  # before firing an R3 chaos run:
+  #   CHAOS_LIVE_SMOKE=1 npx vitest run tests/chaosBotV4LiveJudgeGate.test.js


### PR DESCRIPTION
## Why
The just-restored monitor flagged the Geri weekly-audit as still red even after #394 greened the `audit` job — because a **second** job, `live-judge-gate`, fails independently **every** week.

Root cause (from run 27557144392): it spawns `chaos-doctor-bot-v4.mjs` as a live AI-judge smoke with a 170s timeout, but the scheduled job sets only `CHAOS_LIVE_SMOKE=1` — **no `CHAOS_USE_PROXY`, no API credentials**. So the bot can't complete judge calls and just **times out (`spawnSync ETIMEDOUT`)**, red-flagging the audit without ever measuring judge-call count. The gate isn't doing its job; it's pure noise.

## Decision (user-chosen)
Per the gate's **own docstring** it is a **manual R3 pre-flight** ("Run it as the R3 pre-flight gate. Do NOT fire R3 unless this gate is green") — not unattended weekly automation. So: remove the job from the weekly schedule.

- The test file **stays** — runnable manually: `CHAOS_LIVE_SMOKE=1 npx vitest run tests/chaosBotV4LiveJudgeGate.test.js`
- Its **cheap structural pins** (selector-contract + judge-counter existence, the #290 label-drift guards) **already run in normal `ci.yml`** on every push — label-drift protection is unchanged.
- A comment in `weekly-audit.yml` preserves the rationale + manual command.

No app/data/version change. With this + #394, the weekly audit should go fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)