### PR TITLE
fix(app-logic): four defensive guards (wrong-review crash, boot, chat, leaderboard) — v10.64.182

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geriatrics",
-  "version": "10.64.180",
+  "version": "10.64.182",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geriatrics",
-      "version": "10.64.180",
+      "version": "10.64.182",
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.5",
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.181",
+  "version": "10.64.182",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -2228,7 +2228,7 @@ function getWrongReviewPool(){
     const i=+k;
     if(!Number.isInteger(i)||i<0||i>=QZ.length)continue;
     const e=S.wrongQs[k];if(!e||(e.streak||0)>=2)continue;
-    const q=QZ[i];if(!q)return;
+    const q=QZ[i];if(!q)continue;
     const ti=Number.isInteger(q.ti)?q.ti:0;
     const w=Number.isFinite(IMA_WEIGHTS[ti])?IMA_WEIGHTS[ti]:4;
     // priority = recency-weight (newer = higher) × topic weight
@@ -3127,8 +3127,10 @@ render();
 }
 // Load saved images on startup
 (function(){
+try{
 const imgMap=JSON.parse(localStorage.getItem('shlav_q_images')||'{}');
 Object.entries(imgMap).forEach(([idx,url])=>{if(QZ[parseInt(idx)])QZ[parseInt(idx)].img=url;});
+}catch(e){/* corrupt shlav_q_images must not abort boot */}
 })();
 function viewImg(src){
 const ov=document.createElement('div');
@@ -4437,7 +4439,9 @@ try{
   const res=await fetch(SUPA_URL+'/rest/v1/shlav_leaderboard?select=uid,answered,correct,streak,readiness,accuracy,ts&order=accuracy.desc.nullslast,answered.desc&limit=20',{
     headers:{'apikey':SUPA_ANON}
   });
-  return await res.json();
+  if(!res.ok)return[];
+  const d=await res.json();
+  return Array.isArray(d)?d:[];
 }catch(e){console.warn('Leaderboard fetch failed',e);return[];}
 }
 let _leaderboardData=null;
@@ -6641,7 +6645,7 @@ signal:ctrl.signal
 clearTimeout(timeout);
 if(!resp.ok){const e=await resp.json().catch(function(){return{};});throw new Error(e.error&&e.error.message?e.error.message:'HTTP '+resp.status);}
 const data=await resp.json();
-S.chat.push({role:'assistant',text:data.content[0].text});
+S.chat.push({role:'assistant',text:data?.content?.[0]?.text||'⚠️ לא התקבלה תשובה מהשרת'});
 }catch(e){
 const offline=!navigator.onLine||e.message.includes('Failed to fetch');
 const timedOut=e.name==='AbortError';
@@ -7332,8 +7336,9 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.181';
+const APP_VERSION='10.64.182';
 const CHANGELOG={
+'10.64.182':['fix(app-logic): four small defensive guards, no clinical content touched. (1) getWrongReviewPool() now uses continue instead of a bare return when a wrongQs index points at a missing question — a stale index (indices persist across corpus refreshes) previously aborted the whole pool build and returned undefined, crashing the quiz card on "Review wrong". (2) The startup shlav_q_images loader is wrapped in try/catch so a corrupt value can no longer abort app boot (matches the two sibling readers already guarded). (3) sendChat() reads data?.content?.[0]?.text with a Hebrew fallback so a 200 with an unexpected body no longer throws. (4) fetchLeaderboard() returns [] on a non-ok response and coerces non-array bodies to []. No question content, answer keys, explanations, or source mappings changed. Trinity 10.64.181 to 10.64.182.'],
 '10.64.181':['data(keys): apply the official IMA post-appeal answer key to 5 questions in the 21.12.21 (2021-Dec) subspecialty sitting. Added multi-accept c_accept where the published post-appeal key accepts more than one option (Q1 ג+ד, Q32 א+ג, Q55 א+ג, Q97 ג+ד) and marked the nullified Q14 (memantine efficacy) as accepting all four options. No primary answer (c) was flipped — only c_accept was broadened to match the official key. No question text, options, explanations, or source mappings changed. Trinity 10.64.180 to 10.64.181.'],
 '10.64.180':['ui(a11y): finish the Geri mobile touch-target pass. Header toolbar buttons, Quiz speech/share/note/bookmark/timer controls, Study subnav/jump controls, Track compact actions, Settings form fields, sliders, and account/data controls now meet the 44px mobile target without changing clinical content or navigation logic. No question content, answer keys, explanations, source mappings, or audit queues changed. Trinity 10.64.179 to 10.64.180.'],
 '10.64.179':['ui(settings/study-plan): further declutter Settings after mobile review. Data Management is now split into primary backup/export, secondary restore/import, and a collapsed reset danger area; AI credentials are a compact optional disclosure next to account state; study-plan hour/mock sliders update their visible numbers while dragging; generated study-plan topics now show mapped source chapters from the existing question-to-chapter map (Hazzard/Harrison/GRS8) and include them in calendar export. No clinical question content, keys, explanations, source mappings, or audit queues changed. Trinity 10.64.178 to 10.64.179.'],

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.181';
+const CACHE='shlav-a-v10.64.182';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 // CRITICAL_URLS = the bare-minimum app shell required for offline boot.
 // Anything else (data/*.json, fonts, icons) is best-effort in the install

--- a/tests/wrongReviewPoolStaleIndex.test.js
+++ b/tests/wrongReviewPoolStaleIndex.test.js
@@ -1,0 +1,100 @@
+/**
+ * Regression: getWrongReviewPool() must PRUNE a stale wrong-answer index, not
+ * ABORT the whole pool build on the first one.
+ *
+ * Bug (pre-v10.64.182): inside `for(const k in S.wrongQs)`, the guard
+ *   `const q=QZ[i];if(!q)return;`
+ * used a bare `return` — so the FIRST wrongQs index that no longer resolves to
+ * a live question (indices persist across corpus refreshes / question-bank
+ * trims) exited the entire function and returned `undefined`. The "Review wrong"
+ * pool path (`filt==='wrong'`) then assigned `pool=undefined`, and the quiz card
+ * crashed on click. The sibling guard one line up already used `continue`.
+ *
+ * Fix: `if(!q)continue;` — skip the stale entry, keep building the pool.
+ *
+ * This test extracts the REAL function body from shlav-a-mega.html and executes
+ * it, so it fails if the source ever reverts to a bare `return` (a hand-copied
+ * duplicate could silently drift from the monolith).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const html = readFileSync(resolve(ROOT, 'shlav-a-mega.html'), 'utf-8');
+
+// Extract the getWrongReviewPool source. The body ends at the line
+// `return out.map(o=>o.i);}` which is the function's final statement.
+function buildGetWrongReviewPool() {
+  const m = html.match(/function getWrongReviewPool\(\)\{[\s\S]+?return out\.map\(o=>o\.i\);\s*\}/);
+  if (!m) throw new Error('getWrongReviewPool source not extractable from HTML');
+  // The function reads globals S, QZ, IMA_WEIGHTS — inject them as params.
+  const factory = new Function('S', 'QZ', 'IMA_WEIGHTS', m[0] + '\nreturn getWrongReviewPool;');
+  // factory(S,QZ,IMA_WEIGHTS) returns getWrongReviewPool closed over those
+  // globals; invoking it () runs the real (no-arg) function body.
+  return (S, QZ, IMA_WEIGHTS) => factory(S, QZ, IMA_WEIGHTS)();
+}
+
+// Minimal IMA_WEIGHTS stand-in (the function only indexes it by ti and
+// falls back to 4 for out-of-range / non-finite). A short array is enough.
+const WEIGHTS = [5, 3, 6, 5, 8];
+
+// A valid (in-bounds, resolvable) question object.
+function q(ti = 0) {
+  return { ti, q: 'x', o: ['a', 'b', 'c', 'd'], c: 0 };
+}
+
+describe('getWrongReviewPool stale-index pruning', () => {
+  it('source no longer contains the bare-return abort pattern', () => {
+    const m = html.match(/function getWrongReviewPool\(\)\{[\s\S]+?return out\.map\(o=>o\.i\);\s*\}/);
+    expect(m, 'getWrongReviewPool not found').toBeTruthy();
+    // The in-bounds null/missing-question guard must use `continue`, not `return`.
+    expect(m[0]).toContain('const q=QZ[i];if(!q)continue;');
+    expect(m[0]).not.toContain('const q=QZ[i];if(!q)return;');
+  });
+
+  it('prunes an out-of-bounds (>= QZ.length) wrong index and still builds the pool', () => {
+    const getWrongReviewPool = buildGetWrongReviewPool();
+    const QZ = [q(0), q(1)]; // length 2 — index 99 is stale/out-of-bounds
+    const S = {
+      wrongQs: {
+        0: { streak: 0, ts: Date.now() },
+        99: { streak: 0, ts: Date.now() }, // stale — would have aborted via the i>=QZ.length guard
+        1: { streak: 0, ts: Date.now() },
+      },
+    };
+    const pool = getWrongReviewPool(S, QZ, WEIGHTS);
+    expect(Array.isArray(pool)).toBe(true);
+    // Both live indices survive; the stale 99 is excluded.
+    expect([...pool].sort((a, b) => a - b)).toEqual([0, 1]);
+    expect(pool).not.toContain(99);
+  });
+
+  it('prunes an in-bounds-but-missing question slot without aborting (the bare-return bug site)', () => {
+    const getWrongReviewPool = buildGetWrongReviewPool();
+    // QZ has a hole at index 1 (e.g. a question removed but its wrongQs entry
+    // persisted). This is the exact `const q=QZ[i];if(!q)...` path.
+    const QZ = [q(0), undefined, q(2)];
+    const S = {
+      wrongQs: {
+        0: { streak: 0, ts: Date.now() },
+        1: { streak: 0, ts: Date.now() }, // QZ[1] is undefined -> must `continue`, not `return`
+        2: { streak: 0, ts: Date.now() },
+      },
+    };
+    const pool = getWrongReviewPool(S, QZ, WEIGHTS);
+    expect(Array.isArray(pool)).toBe(true);
+    // Pre-fix, the bare `return` exited on index 1 (in iteration order) and
+    // returned undefined; index 2 would never be reached. Post-fix, 0 and 2
+    // both survive.
+    expect([...pool].sort((a, b) => a - b)).toEqual([0, 2]);
+    expect(pool).not.toContain(1);
+  });
+
+  it('returns [] (not undefined) when S.wrongQs is absent', () => {
+    const getWrongReviewPool = buildGetWrongReviewPool();
+    const pool = getWrongReviewPool({}, [q(0)], WEIGHTS);
+    expect(pool).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Four small, verified defensive fixes in `shlav-a-mega.html`. App-logic + guards only — **no question content, answer keys, explanations, or source mappings touched**. Trinity bumped 10.64.181 → 10.64.182.

### 1. (REAL BUG) `getWrongReviewPool()` aborts on stale wrong-answer index
Inside `for(const k in S.wrongQs)`, `const q=QZ[i];if(!q)return;` used a bare `return`. wrongQs indices persist across corpus refreshes, so the **first** index that no longer resolves to a live question exited the entire function and returned `undefined`. The `filt==='wrong'` path then assigned `pool=undefined` → quiz card crashes on "Review wrong". The sibling guard one line up already used `continue`. Fixed to `continue`.

New regression test `tests/wrongReviewPoolStaleIndex.test.js` extracts the **real** function body from the monolith and asserts a stale (out-of-bounds) and an in-bounds-but-missing index are pruned, not aborted. Watch-it-fail verified: reverting only this site to `return` fails 2 of the 4 cases.

### 2. (boot guard) Startup `shlav_q_images` loader
The startup IIFE `JSON.parse(localStorage.getItem('shlav_q_images')||'{}')` had no try/catch — a corrupt value aborts app boot. Wrapped in try/catch defaulting to a no-op, matching the two sibling readers already guarded at the upload/remove paths.

### 3. (chat hardening) `sendChat()` response parse
`data.content[0].text` had no optional chaining; a 200 with an unexpected body throws. Now `data?.content?.[0]?.text` with a Hebrew fallback (`⚠️ לא התקבלה תשובה מהשרת`). `callAI` already uses the `d.content?.[0]?.text||''` idiom.

### 4. (leaderboard hardening) `fetchLeaderboard()`
Added `if(!res.ok)return[];` and coerce a non-array body via `Array.isArray(d)?d:[]`, so `showLeaderboard()`'s `.length`/`.forEach` consumers never see a non-array.

## Verification
`npm run verify` green: version-sync (10.64.182 aligned), brace balance, inline-JS parse, innerHTML audits, Harrison Hebrew baseline, and **1790 tests passed / 8 skipped across 108 files** (one new test file).

## Trinity
- `package.json` version → 10.64.182
- `APP_VERSION` (shlav-a-mega.html) → 10.64.182
- `sw.js` CACHE → `shlav-a-v10.64.182`
- CHANGELOG entry added for 10.64.182 (satisfies `changelogDrift.test.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)