### PR TITLE
chore(lockfile): refresh stale version metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geriatrics",
-  "version": "10.64.182",
+  "version": "10.64.190",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geriatrics",
-      "version": "10.64.182",
+      "version": "10.64.190",
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.5",
         "acorn": "^8.16.0",


### PR DESCRIPTION
P2 hygiene: package-lock.json top-level + root version fields lagged package.json (version bumps did not run npm install). Surgical 2-field update to match; no dependency-tree changes. Cosmetic (npm ci was unaffected). Fresh branch off origin/main.