### PR TITLE
DRAFT - DO NOT MERGE until Netlify API_SECRET dual-accept + UPSTASH set (P0 proxy JWT cutover)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geriatrics",
-  "version": "10.64.190",
+  "version": "10.64.191",
   "private": true,
   "type": "module",
   "scripts": {

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -6636,9 +6636,10 @@ const messages=history.filter(function(m){return m.role==='user'||m.role==='assi
 try{
 const ctrl=new AbortController();
 const timeout=setTimeout(function(){ctrl.abort();},45000);
+const _authz=await getProxyBearer();
 const resp=await fetch(AI_PROXY,{
 method:'POST',
-headers:{'Content-Type':'application/json','x-api-secret':AI_SECRET},
+headers:{'Content-Type':'application/json','Authorization':_authz},
 body:JSON.stringify({model:'sonnet',max_tokens:1024,system:CHAT_SYSTEM,messages:messages}),
 signal:ctrl.signal
 });
@@ -7336,8 +7337,9 @@ const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=
 
 
 // ===== FEEDBACK & DIAGNOSTICS =====
-const APP_VERSION='10.64.190';
+const APP_VERSION='10.64.191';
 const CHANGELOG={
+'10.64.191':['DRAFT (do-not-deploy until Netlify dual-accept): P0 proxy secret-cutover. Removed the hardcoded shared x-api-secret from the client; /api/claude is now authenticated with a Supabase GoTrue anonymous session JWT, minted + cached via raw GoTrue REST (POST /auth/v1/signup — CSP-safe since script-src is self-only and the Supabase origin is already in connect-src). Both proxy call sites (chat + callAI) send Authorization: Bearer. No question/content changes.'],
 '10.64.190':['chore(cache): version bump so existing clients pull the 2026-Jun syllabus_data.json cross-repo sync (data changed in 20cb3ea without a marker bump, leaving the SW serving the stale cached copy). Also: weekly-audit live-judge-gate execFileSync timeout 180s→400s (bot real runtime ~351s was ETIMEDOUT-killed at 180s; vitest test timeout 210s→420s to match) + added gitleaks secret-scanning CI. No question/content changes.'],
 '10.64.189':['content(2026+2025): added three real IMA geriatrics exams. (1) 2026 basic Shlav-A (150 Qs, tag 2026-Jun-Basic, 18.06.26) transcribed verbatim from the official question PDF; post-appeal published key (run 138) with 5 dual-accept items; canonical Maraeh-Makom sourcing (book+chapter+page+figure) on every question; 9 image-dependent questions wired to the question-images bucket; full AI-authored clinical explanations (parallel Claude workflow). (2) 2026 subspecialty (100 Qs, 2026-Jun-Subspec) verified identical to basic Q1-100 (positional answer + stem match), re-tagged with allow_dup so the toggle shows the full sitting. (3) 2025 subspecialty (100 Qs, 2025-Jun-Subspec, 12.06.25) = 91 re-tagged duplicates + 9 net-new transcribed verbatim, post-appeal key run 338, canonical sourcing, authored explanations. Dataset 4297 to 4647. Derived files regenerated; count-locks, tag allowlists, EXAM_YEARS, study-plan fixture, truncation baseline (519 to 542) updated in-PR. Rebased onto main v10.64.188 (Toranot proxy-secret rotation). Trinity 10.64.188 to 10.64.189.'],
 '10.64.188':['security: rotated the shared Toranot AI-proxy secret (x-api-secret header) after the 2026-07-13 weekly audit flagged it as hardcoded client-visible plaintext, unchanged since introduction. Coordinated rotation across Geriatrics/InternalMedicine/FamilyMedicine + the Netlify-side proxy config, so the previous value is now invalid everywhere. Note: this invalidates anyone who scraped the old value, but does not change the underlying architecture — the new value is embedded in client code and repo docs the same way the old one was, since this is a public static-site repo with no server-authenticated user session. A real fix needs per-user tokens, not a shared static secret. No question content, answer keys, or explanations touched.'],
@@ -8294,7 +8296,27 @@ function getTopicTrend(ti){
 
 // ===== SHARED AI PROXY =====
 const AI_PROXY='https://toranot.netlify.app/api/claude';
-const AI_SECRET='toranot-proxy-34207b1d12f35873d7f22d8ca0388b2a-r2';
+// P0 cutover (runbook §3): the shared proxy x-api-secret was removed from the
+// bundle. /api/claude is now authenticated with a Supabase GoTrue anonymous
+// session JWT, minted + cached via RAW GoTrue REST. Geri has no supabase-js
+// client and its CSP is script-src 'self' (no CDN import allowed), and the
+// Supabase origin is already in connect-src — so raw REST is the CSP-safe path.
+// Verified against the live project: POST /auth/v1/signup {} -> 200 {access_token,
+// expires_in:3600, user.is_anonymous:true}. Token cached 1h in localStorage,
+// re-minted on expiry. REVIEW NOTE: expiry mints a fresh anonymous user; a
+// refresh_token grant could avoid that if you prefer.
+async function getProxyBearer(){
+  try{
+    const c=JSON.parse(localStorage.getItem('samega_proxy_jwt')||'null');
+    if(c&&c.token&&c.exp&&Date.now()<c.exp-120000)return 'Bearer '+c.token;
+  }catch(_){}
+  const r=await fetch(SUPA_URL+'/auth/v1/signup',{method:'POST',headers:{apikey:SUPA_ANON,'Content-Type':'application/json'},body:'{}'});
+  if(!r.ok)throw new Error('proxy auth failed ('+r.status+')');
+  const d=await r.json();
+  if(!d.access_token)throw new Error('proxy auth: no token');
+  try{localStorage.setItem('samega_proxy_jwt',JSON.stringify({token:d.access_token,exp:Date.now()+(d.expires_in||3600)*1000}));}catch(_){}
+  return 'Bearer '+d.access_token;
+}
 // Per-call AbortController (was singleton in v10.38.1; cancelled in-flight peers,
 // breaking bulk explainWithAI). Concurrent callers no longer cancel each other.
 async function callAI(messages,maxTokens=400,model='sonnet',ground=null){
@@ -8315,9 +8337,10 @@ function _aiErrFromStatus(status){
 }
 try{
 try{
+const _authz=await getProxyBearer();
 const pr=await fetch(AI_PROXY,{
 method:'POST',
-headers:{'Content-Type':'application/json','x-api-secret':AI_SECRET},
+headers:{'Content-Type':'application/json','Authorization':_authz},
 body:JSON.stringify(ground?{model,max_tokens:maxTokens,messages,ground}:{model,max_tokens:maxTokens,messages}),
 signal
 });

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='shlav-a-v10.64.190';
+const CACHE='shlav-a-v10.64.191';
 const HTML_URLS=['shlav-a-mega.html','manifest.json','shared/fsrs.js','shared/tokens.css','shared/install-promo.js','src/storage.js','src/sw-update.js','src/study_plan_algorithm.js','src/study_plan.js','icons/icon-192.png','icons/icon-512.png'];
 // CRITICAL_URLS = the bare-minimum app shell required for offline boot.
 // Anything else (data/*.json, fonts, icons) is best-effort in the install

--- a/tests/coverageGaps.test.js
+++ b/tests/coverageGaps.test.js
@@ -12,8 +12,12 @@ describe('AI Proxy Routing', () => {
     expect(html).toContain("const AI_PROXY='https://toranot.netlify.app/api/claude'");
   });
 
-  it('has AI_SECRET for proxy authentication', () => {
-    expect(html).toMatch(/const AI_SECRET='[^']+'/);
+  it('authenticates the proxy with an anonymous Supabase JWT (no shared secret)', () => {
+    // P0 cutover (runbook §3): the client-shipped AI_SECRET was removed; the
+    // proxy is now authenticated with an anonymous Supabase session JWT minted
+    // by getProxyBearer(). Guard against the shared secret ever coming back.
+    expect(html).not.toMatch(/const AI_SECRET='[^']+'/);
+    expect(html).toContain('async function getProxyBearer(');
   });
 
   it('callAI tries proxy first before direct API', () => {
@@ -26,8 +30,12 @@ describe('AI Proxy Routing', () => {
     expect(proxyIdx).toBeLessThan(directIdx);
   });
 
-  it('sends x-api-secret header to proxy', () => {
-    expect(html).toContain("'x-api-secret':AI_SECRET");
+  it('sends the Authorization: Bearer JWT header to the proxy', () => {
+    // P0 cutover: replaces the x-api-secret shared-secret header with the
+    // anonymous Supabase session JWT resolved by getProxyBearer().
+    expect(html).not.toContain("'x-api-secret':AI_SECRET");
+    expect(html).toContain('const _authz=await getProxyBearer();');
+    expect(html).toContain("'Authorization':_authz");
   });
 
   it('callAI falls back to user API key when proxy fails', () => {


### PR DESCRIPTION
# DO NOT MERGE until Netlify API_SECRET dual-accept + UPSTASH set (see runbook)

**HARD BLOCK: merging before Eias flips the Netlify env would 401 the live clinical study app for real users.** Draft status is deliberate.

## What this does (runbook §3 — Geriatrics, the careful one)

Removes the hardcoded shared proxy `x-api-secret` (`AI_SECRET`) from the single-file client and authenticates `/api/claude` with a **Supabase GoTrue anonymous session JWT** at both proxy call sites (chat `sendChat` + `callAI`).

### Why raw GoTrue REST (not supabase-js like the siblings)
Geriatrics has **no supabase-js client** (it talks to Supabase entirely via raw REST), and its **CSP is `script-src 'self' 'unsafe-inline'`** — a dynamic supabase-js CDN import would be **blocked**. But the Supabase origin is already in `connect-src`, so I mint the anonymous JWT via **raw GoTrue REST**, which is both CSP-safe and consistent with Geri's architecture.

- `getProxyBearer()` — `POST {SUPA_URL}/auth/v1/signup` (empty body, anon apikey). **Verified live: 200 → `{access_token, token_type:bearer, expires_in:3600, user.is_anonymous:true}`.** Token cached in `localStorage['samega_proxy_jwt']` (new key; does NOT touch the protected `samega*` keys) and re-minted 2 min before expiry.
- Both proxy fetches send `Authorization: Bearer` instead of `x-api-secret`.
- Version bumped 10.64.190 → **10.64.191** (trinity HTML/sw.js/package.json + changelog) so the SW cache busts and existing clients actually pull the cutover on merge.

## REVIEW NOTES (please eyeball these — Geri was flagged risky)
1. **Anon-user growth on expiry.** On cache expiry (1 h) `getProxyBearer` mints a *fresh* anonymous user rather than refreshing. Fine functionally (matches ward-helper's posture; 77 anon users already exist), but if you'd rather not accrue anon users, swap the re-mint for a `POST /auth/v1/token?grant_type=refresh_token` using the stored `refresh_token`. Left as signup-only for simplicity + because it needs your call.
2. **No unit test.** Geri's proxy path has no existing unit test; I verified via the deterministic suite (below) + a live endpoint probe, not a mocked test.

## Verified
`check-version-sync` (all 10.64.191), `check-brace-balance` (3761 pairs), `check-inline-js` (4 inline scripts parse cleanly — validates the added JS), `check-innerhtml` all green. Source: 0 `AI_SECRET`/proxy-secret literals, `getProxyBearer` at both call sites. Anonymous sign-ins confirmed enabled on the shared project.

## Merge prerequisites (Eias — see SECRET_ROTATION_RUNBOOK.md §4)
1. Netlify `API_SECRET` in dual-accept (OLD + SERVER_ONLY).  2. `UPSTASH_*` set.  3. Un-draft + merge all 4 cutovers; verify AI works logged-in AND as a guest; only then drop OLD + rotate.
