### PR TITLE
Round-2: FSRS anchor reschedule + streak/autopsy/proxy-401 (G5 held)

### DIFF
--- a/shared/fsrs.js
+++ b/shared/fsrs.js
@@ -23,6 +23,13 @@ const FSRS_W=[0.40255,1.18385,3.1262,15.4722,7.2102,0.5316,1.0651,0.06362,
 const FSRS_DECAY=-0.5;
 const FSRS_FACTOR=19/81;
 const FSRS_RETENTION=0.90; // target 90% retention
+// Canonical FSRS-4.5 initial difficulty for rating "Easy" (rating 4 -> r=3):
+// D0_Easy = clamp(FSRS_W[4] - e^(FSRS_W[5]*3) + 1) ~= 3.28. Used as the difficulty
+// mean-reversion anchor in fsrsUpdate(). 2026-07-18 correction: fsrsUpdate previously
+// reverted difficulty toward FSRS_W[4] (~7.21), which inflated D over repeated reviews
+// and, because stability growth carries an (11-D) factor, roughly halved interval
+// growth. Reverting toward D0_Easy matches canonical FSRS-4.5 and fsrsInitNew(4).d.
+const FSRS_D0_EASY=Math.min(10,Math.max(1,FSRS_W[4]-Math.exp(FSRS_W[5]*3)+1));
 
 function fsrsR(t,s){
   if(!s||s<=0)return 0;
@@ -54,7 +61,7 @@ function fsrsUpdate(s,d,rPrev,rating){
     newS=Math.max(0.1,newS);
   }
   const deltaD=-FSRS_W[6]*(rating-3);
-  const mr=FSRS_W[7]*(FSRS_W[4]-d);
+  const mr=FSRS_W[7]*(FSRS_D0_EASY-d); // 2026-07-18: revert toward D0_Easy (~3.28), not FSRS_W[4] (~7.21)
   newD=Math.min(10,Math.max(1,d+deltaD+mr));
   return{s:newS,d:newD};
 }

--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -1427,12 +1427,18 @@ if(typeof window!=='undefined'){
   window.addEventListener('offline',()=>{updateSyncPill();});
 }
 (function updateStreak(){
-const today=new Date().toISOString().slice(0,10);
+// G7 (2026-07-18): S.streak must reflect REAL study activity, not app-opens.
+// Previously the streak was bumped merely for opening the app on consecutive
+// days, and "today" came from toISOString() (UTC), which drifts across the local
+// midnight boundary. Now "today" is the LOCAL date and S.streak mirrors the
+// activity-based getStudyStreak() (consecutive days with dailyAct[key].q>0),
+// so opening the app without studying can never inflate the streak.
+const now=new Date();
+const today=now.getFullYear()+'-'+String(now.getMonth()+1).padStart(2,'0')+'-'+String(now.getDate()).padStart(2,'0');
 if(S.lastDay===today)return;
-const yest=new Date(Date.now()-86400000).toISOString().slice(0,10);
-if(S.lastDay===yest)S.streak++;
-else if(S.lastDay!==today)S.streak=1;
-S.lastDay=today;save();
+S.lastDay=today;
+S.streak=getStudyStreak();
+save();
 })();
 
 // ===== INDEXEDDB MIGRATION =====
@@ -3502,7 +3508,13 @@ if(!q.e&&Array.isArray(EX)&&EX[pool[qi]])q.e=EX[pool[qi]];
 h+=`<div style="padding:12px;margin-top:10px;border:1px solid rgb(var(--brd));border-radius:12px;background:rgb(var(--bg2))">
 <div style="font-weight:700;font-size:11px;margin-bottom:8px">🔬 Distractor Autopsy — למה כל תשובה שגויה</div>`;
 if(_dist){
-  q.o.forEach((opt,i)=>{
+  // G6 (2026-07-18): iterate autopsy rows in getOptShuffle DISPLAY order so the
+  // per-option rows line up with the shuffled quiz options and the correct-answer
+  // explanation's display-letter references (remapExplanationLetters below). The
+  // markers still key off the ORIGINAL index i (isOk/sel/_dist[i]) so scoring is
+  // unaffected — this is a display-ordering fix only.
+  getOptShuffle(_qIdx,q).forEach((i)=>{
+    const opt=q.o[i];
     const _isCorrect=isOk(q,i);
     const _isUserPick=(i===sel);
     const _rationale=_dist[i];
@@ -8367,6 +8379,23 @@ signal
 });
 if(pr.ok){const d=await pr.json();return d.content?.[0]?.text||'';}
 console.warn('Proxy status:',pr.status);
+// G8 (2026-07-18): a 401/403 means the cached anonymous JWT was revoked (but not
+// yet expired), so getProxyBearer would keep returning the stale token for up to
+// ~1h. Invalidate the cached JWT and retry the proxy ONCE with a freshly minted
+// bearer. If the retry also fails, fall through to the personal-key path exactly
+// as before. Never touches the user's personal API key.
+if(pr.status===401||pr.status===403){
+  try{localStorage.removeItem('samega_proxy_jwt');}catch(_){}
+  const _authz2=await getProxyBearer();
+  const pr2=await fetch(AI_PROXY,{
+    method:'POST',
+    headers:{'Content-Type':'application/json','Authorization':_authz2},
+    body:JSON.stringify(ground?{model,max_tokens:maxTokens,messages,ground}:{model,max_tokens:maxTokens,messages}),
+    signal
+  });
+  if(pr2.ok){const d=await pr2.json();return d.content?.[0]?.text||'';}
+  console.warn('Proxy retry status:',pr2.status);
+}
 }catch(e){
 if(e&&e.name==='AbortError')throw e;
 console.warn('Proxy:',e.message);

--- a/tests/autopsyOptionOrder.test.js
+++ b/tests/autopsyOptionOrder.test.js
@@ -1,0 +1,57 @@
+/**
+ * G6 (2026-07-18): the Distractor Autopsy previously iterated q.o in ORIGINAL
+ * data order while the quiz displayed options in getOptShuffle DISPLAY order and
+ * the correct-answer explanation used display-letter references — an internal
+ * ordering inconsistency. The fix iterates the autopsy rows in getOptShuffle
+ * order. Row markers still key off the ORIGINAL index (isOk/sel/_dist[i]) so
+ * scoring is unaffected — this is display-ordering only.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+let html, getOptShuffle;
+
+beforeAll(() => {
+  html = readFileSync(resolve(import.meta.dirname, "..", "shlav-a-mega.html"), "utf-8");
+  const src = html.match(/function getOptShuffle\(qIdx,q\)\{[\s\S]*?return map;\s*\}/)[0];
+  // Stub isMetaOption -> false so getOptShuffle shuffles all options.
+  getOptShuffle = new Function(
+    `let _optShuffle=null;\nfunction isMetaOption(){return false;}\n${src}\nreturn getOptShuffle;`
+  )();
+});
+
+describe("distractor autopsy row order (G6)", () => {
+  it("source: autopsy iterates getOptShuffle DISPLAY order, not q.o original order", () => {
+    // The quiz option render and the autopsy both derive order from the SAME shuffle.
+    expect(html).toContain("const _qIdx=pool[qi];");
+    expect(html).toContain("getOptShuffle(_qIdx,q).forEach((i)=>{");
+    expect(html).toContain("getOptShuffle(pool[qi],q)"); // quiz-option render uses same shuffle
+  });
+
+  it("getOptShuffle returns a full permutation of every option index (no drop/dup)", () => {
+    const q = { o: ["a", "b", "c", "d"] };
+    const shuf = getOptShuffle(7, q);
+    expect([...shuf].sort((a, b) => a - b)).toEqual([0, 1, 2, 3]);
+  });
+
+  it("autopsy order equals the displayed shuffle order and differs from original data order", () => {
+    const q = { o: ["a", "b", "c", "d", "e"] };
+    const original = q.o.map((_, i) => i); // [0,1,2,3,4] = old (buggy) autopsy order
+    // Find a question index whose shuffle is non-identity (shuffle is seeded by qIdx).
+    let qIdx = -1, displayOrder = null;
+    for (let cand = 0; cand < 200; cand++) {
+      const s = getOptShuffle(cand, q);
+      if (JSON.stringify(s) !== JSON.stringify(original)) { qIdx = cand; displayOrder = s; break; }
+    }
+    expect(qIdx).toBeGreaterThanOrEqual(0); // a shuffled ordering exists
+
+    // The fixed autopsy iterates `getOptShuffle(_qIdx,q)` — the SAME call the quiz
+    // display uses — so its row order matches the display order, not the original.
+    const autopsyOrder = getOptShuffle(qIdx, q);
+    expect(autopsyOrder).toEqual(displayOrder);
+    expect(autopsyOrder).not.toEqual(original);
+    // still a complete permutation (every distractor row rendered exactly once)
+    expect([...autopsyOrder].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4]);
+  });
+});

--- a/tests/coverageGaps.test.js
+++ b/tests/coverageGaps.test.js
@@ -21,7 +21,8 @@ describe('AI Proxy Routing', () => {
   });
 
   it('callAI tries proxy first before direct API', () => {
-    const callAIBlock = html.slice(html.indexOf('async function callAI('), html.indexOf('async function callAI(') + 2000);
+    const _cs = html.indexOf('async function callAI(');
+    const callAIBlock = html.slice(_cs, html.indexOf('}finally{clearTimeout(_timeoutId);}', _cs));
     // Proxy fetch comes before direct API fetch
     const proxyIdx = callAIBlock.indexOf('AI_PROXY');
     const directIdx = callAIBlock.indexOf('api.anthropic.com');
@@ -39,7 +40,10 @@ describe('AI Proxy Routing', () => {
   });
 
   it('callAI falls back to user API key when proxy fails', () => {
-    const callAIBlock = html.slice(html.indexOf('async function callAI('), html.indexOf('async function callAI(') + 2000);
+    // Slice the whole callAI body (grew with the G8 proxy-401 re-mint/retry block,
+    // 2026-07-18) up to its finally-clause, rather than a fixed char window.
+    const _cs = html.indexOf('async function callAI(');
+    const callAIBlock = html.slice(_cs, html.indexOf('}finally{clearTimeout(_timeoutId);}', _cs));
     expect(callAIBlock).toContain('getApiKey()');
     expect(callAIBlock).toContain("throw new Error('no_key')");
   });

--- a/tests/fsrsAnchorCorrection.test.js
+++ b/tests/fsrsAnchorCorrection.test.js
@@ -1,0 +1,95 @@
+/**
+ * FSRS difficulty mean-reversion anchor correction (2026-07-18).
+ *
+ * Before this fix, fsrsUpdate() reverted difficulty toward FSRS_W[4] (~7.21),
+ * inflating D over repeated reviews. Because stability growth carries an (11-D)
+ * factor, an inflated D suppressed interval growth. The corrected anchor reverts
+ * difficulty toward D0_Easy = fsrsInitNew(4).d (~3.28) — the canonical FSRS-4.5
+ * "Easy" initial difficulty — so repeated success drives D down (not up) and the
+ * card is rescheduled with faster stability/interval growth.
+ *
+ * Every number below is a genuine recomputed value from the corrected
+ * shared/fsrs.js (canonical md5 7cb675ea3865d8accdc7bcd3a0cc5fa8).
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+let f;
+beforeAll(() => {
+  const code = readFileSync(join(__dirname, "..", "shared", "fsrs.js"), "utf-8");
+  f = new Function(code + "\nreturn {FSRS_W,fsrsInterval,fsrsInitNew,fsrsUpdate};")();
+});
+
+describe("FSRS anchor correction — difficulty mean-reverts to D0_Easy (~3.28)", () => {
+  it("D0_Easy = fsrsInitNew(4).d is ~3.28, far below the old FSRS_W[4] anchor (~7.21)", () => {
+    expect(f.fsrsInitNew(4).d).toBeCloseTo(3.2829, 3);
+    expect(f.fsrsInitNew(4).d).toBeLessThan(4);
+    expect(f.FSRS_W[4]).toBeCloseTo(7.2102, 4);
+  });
+
+  it("repeated Good (rating 3) from an inflated d=7 drives difficulty DOWN toward ~3.28, not up toward 7.21", () => {
+    const anchor = f.fsrsInitNew(4).d; // ~3.2829
+    let s = 10, d = 7;
+    // Single step already decreases; the OLD anchor (revert toward 7.21) would have
+    // nudged d UP from 7. Corrected: d falls to ~6.7635.
+    const one = f.fsrsUpdate(s, d, 0.9, 3);
+    expect(one.d).toBeCloseTo(6.7635, 3);
+    expect(one.d).toBeLessThan(7);
+    // Full trajectory: monotone non-increasing, converging on D0_Easy from above.
+    let prev = d;
+    for (let i = 0; i < 60; i++) {
+      const o = f.fsrsUpdate(s, d, 0.9, 3);
+      s = o.s; d = o.d;
+      expect(d).toBeLessThanOrEqual(prev + 1e-12);
+      prev = d;
+    }
+    expect(d).toBeGreaterThan(anchor);      // approaches from above, never overshoots below
+    expect(d).toBeLessThan(anchor + 0.1);   // within 0.1 of D0_Easy after 60 reviews
+    expect(d).toBeCloseTo(3.3549, 3);
+  });
+
+  it("repeated Good from a very low d=1 pushes difficulty UP toward the same ~3.28 anchor (two-sided reversion)", () => {
+    const anchor = f.fsrsInitNew(4).d;
+    let s = 5, d = 1, prev = d;
+    for (let i = 0; i < 60; i++) {
+      const o = f.fsrsUpdate(s, d, 0.9, 3);
+      s = o.s; d = o.d;
+      expect(d).toBeGreaterThanOrEqual(prev - 1e-12);
+      prev = d;
+    }
+    expect(d).toBeLessThan(anchor);         // approaches from below
+    expect(d).toBeGreaterThan(anchor - 0.1);
+    expect(d).toBeCloseTo(3.2386, 3);
+  });
+
+  it("faster interval growth: 5 Good reviews outgrow the counterfactual where D stays pinned at 7.21", () => {
+    // Well-known card: s=10, d=7, rPrev=0.9. Corrected trajectory lets D fall each
+    // review; the counterfactual pins D at FSRS_W[4] (7.2102 — the old anchor's steady
+    // state) every step using the SAME stability formula, so D is the only difference.
+    const W4 = f.FSRS_W[4];
+    let cs = 10, cd = 7, ks = 10;
+    for (let i = 0; i < 5; i++) {
+      const co = f.fsrsUpdate(cs, cd, 0.9, 3);
+      cs = co.s; cd = co.d;
+      ks = f.fsrsUpdate(ks, W4, 0.9, 3).s; // difficulty stuck at 7.21
+    }
+    // Concrete recomputed values:
+    expect(cs).toBeCloseTo(511.5976, 2);
+    expect(ks).toBeCloseTo(357.1742, 2);
+    expect(f.fsrsInterval(cs)).toBe(512);
+    expect(f.fsrsInterval(ks)).toBe(357);
+    // Corrected anchor schedules the card meaningfully further out.
+    expect(cs).toBeGreaterThan(ks);
+    expect(f.fsrsInterval(cs)).toBeGreaterThan(f.fsrsInterval(ks));
+  });
+
+  it("single + double Good review pin concrete corrected stability and difficulty", () => {
+    const o1 = f.fsrsUpdate(10, 7, 0.9, 3);
+    expect(o1.s).toBeCloseTo(23.9088, 3);
+    expect(o1.d).toBeCloseTo(6.7635, 3);
+    const o2 = f.fsrsUpdate(o1.s, o1.d, 0.9, 3);
+    expect(o2.s).toBeCloseTo(54.6942, 3);
+    expect(o2.d).toBeCloseTo(6.5421, 3);
+  });
+});

--- a/tests/fsrsCanonicalDrift.test.js
+++ b/tests/fsrsCanonicalDrift.test.js
@@ -17,7 +17,9 @@ import { readFileSync } from "fs";
 import { createHash } from "crypto";
 import { join } from "path";
 
-const CANONICAL_FSRS_MD5 = "71f9f2d406a1935911e86612439ea58a";
+// 2026-07-18: FSRS difficulty mean-reversion anchor corrected to D0_Easy
+// (fsrsInitNew(4).d); reschedules cards toward canonical FSRS-4.5.
+const CANONICAL_FSRS_MD5 = "7cb675ea3865d8accdc7bcd3a0cc5fa8";
 
 describe("FSRS canonical drift guard", () => {
   it("shared/fsrs.js md5 matches the pinned canonical value", () => {

--- a/tests/proxyJwtInvalidation.test.js
+++ b/tests/proxyJwtInvalidation.test.js
@@ -1,0 +1,115 @@
+/**
+ * G8 (2026-07-18): callAI's proxy branch must invalidate the cached anonymous JWT
+ * on a proxy 401/403 (revoked-but-unexpired token) and retry the proxy ONCE with a
+ * freshly minted bearer, before falling through to the personal-key path. Without
+ * this, getProxyBearer keeps returning the stale cached token for up to ~1h.
+ *
+ * These tests extract getProxyBearer + callAI from the monolith and run them with a
+ * mocked fetch + localStorage. The happy path (proxy 200) must be unchanged.
+ */
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const SUPA_URL = "https://supa.test";
+const SUPA_ANON = "anon-key";
+const AI_PROXY = "https://proxy.test/api/claude";
+
+let gpbSrc, callAISrc;
+
+beforeAll(() => {
+  const html = readFileSync(resolve(import.meta.dirname, "..", "shlav-a-mega.html"), "utf-8");
+  gpbSrc = html.match(/async function getProxyBearer\(\)\{[\s\S]*?return 'Bearer '\+d\.access_token;\s*\}/)[0];
+  callAISrc = html.match(/async function callAI\([\s\S]*?\}finally\{clearTimeout\(_timeoutId\);\}\s*\}/)[0];
+});
+
+class FakeAbort { constructor() { this.signal = { aborted: false }; } abort() { this.signal.aborted = true; } }
+const quietConsole = { warn() {}, log() {}, error() {} };
+
+function makeLS(initial) {
+  const store = { ...initial };
+  const calls = { removed: [], set: [] };
+  const ls = {
+    getItem: (k) => (k in store ? store[k] : null),
+    setItem: (k, v) => { store[k] = String(v); calls.set.push(k); },
+    removeItem: (k) => { delete store[k]; calls.removed.push(k); },
+  };
+  return { ls, store, calls };
+}
+
+function buildCallAI({ fetch, localStorage, getApiKey }) {
+  const factory = new Function(
+    "fetch", "AI_PROXY", "getApiKey", "AbortController", "setTimeout", "clearTimeout", "console", "localStorage", "SUPA_URL", "SUPA_ANON",
+    `${gpbSrc}\n${callAISrc}\nreturn {callAI, getProxyBearer};`
+  );
+  return factory(fetch, AI_PROXY, getApiKey, FakeAbort, () => 0, () => {}, quietConsole, localStorage, SUPA_URL, SUPA_ANON);
+}
+
+describe("proxy JWT invalidation on 401/403 (G8)", () => {
+  it("a proxy 401 clears samega_proxy_jwt, re-mints a fresh bearer, and retries the proxy once", async () => {
+    const { ls, store, calls } = makeLS({
+      samega_proxy_jwt: JSON.stringify({ token: "STALE", exp: Date.now() + 3600000 }),
+    });
+    const proxyAuths = [];
+    const fetch = vi.fn(async (url, init) => {
+      if (url === SUPA_URL + "/auth/v1/signup") {
+        return { ok: true, status: 200, json: async () => ({ access_token: "FRESH", expires_in: 3600 }) };
+      }
+      if (url === AI_PROXY) {
+        proxyAuths.push(init.headers["Authorization"]);
+        if (init.headers["Authorization"] === "Bearer STALE") return { ok: false, status: 401, json: async () => ({}) };
+        if (init.headers["Authorization"] === "Bearer FRESH") return { ok: true, status: 200, json: async () => ({ content: [{ text: "RETRY_OK" }] }) };
+      }
+      throw new Error("unexpected fetch " + url);
+    });
+    const getApiKey = vi.fn(() => "sk-personal"); // present, but must NOT be used
+    const { callAI } = buildCallAI({ fetch, localStorage: ls, getApiKey });
+
+    const out = await callAI([{ role: "user", content: "hi" }]);
+    expect(out).toBe("RETRY_OK");
+    expect(proxyAuths).toEqual(["Bearer STALE", "Bearer FRESH"]); // stale then fresh
+    expect(calls.removed).toContain("samega_proxy_jwt");          // stale JWT invalidated
+    expect(JSON.parse(store.samega_proxy_jwt).token).toBe("FRESH"); // fresh JWT cached
+    expect(getApiKey).not.toHaveBeenCalled();                     // personal key untouched
+  });
+
+  it("happy path (proxy 200 on first try) is unchanged: no re-mint, no retry, JWT untouched", async () => {
+    const { ls, store, calls } = makeLS({
+      samega_proxy_jwt: JSON.stringify({ token: "GOOD", exp: Date.now() + 3600000 }),
+    });
+    const fetch = vi.fn(async (url, init) => {
+      if (url === AI_PROXY && init.headers["Authorization"] === "Bearer GOOD") {
+        return { ok: true, status: 200, json: async () => ({ content: [{ text: "HAPPY" }] }) };
+      }
+      throw new Error("should not reach " + url);
+    });
+    const getApiKey = vi.fn(() => "sk-personal");
+    const { callAI } = buildCallAI({ fetch, localStorage: ls, getApiKey });
+
+    const out = await callAI([{ role: "user", content: "hi" }]);
+    expect(out).toBe("HAPPY");
+    expect(fetch).toHaveBeenCalledTimes(1);                     // no signup, no retry
+    expect(calls.removed).not.toContain("samega_proxy_jwt");    // JWT untouched
+    expect(JSON.parse(store.samega_proxy_jwt).token).toBe("GOOD");
+    expect(getApiKey).not.toHaveBeenCalled();
+  });
+
+  it("if the retry also 401s, it falls through to the personal-key path (fail-safe, unchanged)", async () => {
+    const { ls, calls } = makeLS({
+      samega_proxy_jwt: JSON.stringify({ token: "STALE", exp: Date.now() + 3600000 }),
+    });
+    const fetch = vi.fn(async (url) => {
+      if (url === SUPA_URL + "/auth/v1/signup") return { ok: true, status: 200, json: async () => ({ access_token: "FRESH2", expires_in: 3600 }) };
+      if (url === AI_PROXY) return { ok: false, status: 401, json: async () => ({}) }; // both attempts 401
+      if (url === "https://api.anthropic.com/v1/messages") return { ok: true, status: 200, json: async () => ({ content: [{ text: "PERSONAL_OK" }] }) };
+      throw new Error("unexpected " + url);
+    });
+    const getApiKey = vi.fn(() => "sk-personal");
+    const { callAI } = buildCallAI({ fetch, localStorage: ls, getApiKey });
+
+    const out = await callAI([{ role: "user", content: "hi" }]);
+    expect(out).toBe("PERSONAL_OK");
+    expect(calls.removed).toContain("samega_proxy_jwt"); // still invalidated once
+    expect(getApiKey).toHaveBeenCalled();                // fell through to personal key
+  });
+});

--- a/tests/streakActivityBased.test.js
+++ b/tests/streakActivityBased.test.js
@@ -1,0 +1,100 @@
+/**
+ * G7 (2026-07-18): S.streak must reflect REAL study activity, not app-opens.
+ *
+ * The updateStreak IIFE previously did S.streak++ merely for opening the app on
+ * consecutive days, and computed "today" from toISOString() (UTC) which drifts
+ * across the local midnight boundary. The fix makes S.streak mirror the
+ * activity-based getStudyStreak() and derives "today" from the LOCAL date.
+ *
+ * These tests extract the two functions from the monolith and run them against a
+ * controllable Date so the behaviour is pinned without a browser.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+let gssSrc, usSrc, htmlAutopsyGuard;
+
+beforeAll(() => {
+  const html = readFileSync(resolve(import.meta.dirname, "..", "shlav-a-mega.html"), "utf-8");
+  gssSrc = html.match(/function getStudyStreak\(\)\{[\s\S]*?return streak;\s*\}/)[0];
+  usSrc = html.match(/\(function updateStreak\(\)\{[\s\S]*?save\(\);\s*\}\)\(\);/)[0];
+  htmlAutopsyGuard = html;
+});
+
+// A frozen Date subclass: new Date() -> the fixed instant, arithmetic still real.
+function frozenDate(nowMs) {
+  return class extends Date {
+    constructor(...args) { if (args.length === 0) super(nowMs); else super(...args); }
+    static now() { return nowMs; }
+  };
+}
+
+// Run the extracted getStudyStreak + updateStreak IIFE against a Date impl.
+function runUpdate(initialS, DateImpl) {
+  const S = JSON.parse(JSON.stringify(initialS));
+  let saves = 0;
+  const factory = new Function("Date", "S", "save", `${gssSrc}\n${usSrc}\nreturn;`);
+  factory(DateImpl, S, () => { saves++; });
+  return { S, saves };
+}
+
+describe("streak is activity-based, not app-open based (G7)", () => {
+  it("source no longer increments S.streak for opening the app; mirrors getStudyStreak()", () => {
+    expect(usSrc).toContain("S.streak=getStudyStreak()");
+    expect(usSrc).not.toMatch(/S\.streak\+\+/);
+    // "today" comes from LOCAL date parts, not UTC toISOString()
+    expect(usSrc).toContain("now.getFullYear()");
+    expect(usSrc).toContain("now.getDate()");
+    expect(usSrc).not.toMatch(/toISOString\(\)\.slice\(0,10\)/);
+  });
+
+  it("opening the app with no answers does NOT inflate the streak — it reflects real activity", () => {
+    const D = frozenDate(Date.UTC(2026, 6, 20, 12, 0, 0)); // day1 = "today"
+    const keyDaysAgo = (n) => { const d = new D(); d.setDate(d.getDate() - n); return d.toISOString().slice(0, 10); };
+    const dailyAct = {};
+    dailyAct[keyDaysAgo(1)] = { q: 4 }; // studied yesterday
+    dailyAct[keyDaysAgo(2)] = { q: 5 }; // and the day before
+    dailyAct[keyDaysAgo(3)] = { q: 6 }; // and the day before that
+    // Stored streak is inflated (99) from the old buggy app-open counter; today has
+    // NO activity (user just opened the app). Real streak = 3 (yesterday .. 3d ago).
+    const r = runUpdate({ streak: 99, lastDay: keyDaysAgo(1), dailyAct }, D);
+    expect(r.S.streak).toBe(3);          // corrected to the real activity streak
+    expect(r.S.streak).not.toBe(100);    // did NOT increment for the open
+    expect(r.saves).toBeGreaterThan(0);  // persisted
+  });
+
+  it("opening the app two days running with no answers never increments the streak", () => {
+    const D1 = frozenDate(Date.UTC(2026, 6, 20, 12, 0, 0));
+    const keyD1 = (n) => { const d = new D1(); d.setDate(d.getDate() - n); return d.toISOString().slice(0, 10); };
+    const dailyAct = {};
+    dailyAct[keyD1(1)] = { q: 3 };
+    dailyAct[keyD1(2)] = { q: 3 };
+    // Day 1 open (no answers today): streak reflects the 2 real study days.
+    const r1 = runUpdate({ streak: 2, lastDay: keyD1(1), dailyAct }, D1);
+    expect(r1.S.streak).toBe(2);
+    // Day 2 open, still no answers. The OLD code would have bumped the streak by +1
+    // for a second consecutive app-open. It must not.
+    const D2 = frozenDate(Date.UTC(2026, 6, 21, 12, 0, 0));
+    const r2 = runUpdate({ streak: r1.S.streak, lastDay: r1.S.lastDay, dailyAct }, D2);
+    expect(r2.S.streak).not.toBe(r1.S.streak + 1); // key: opening did not add a day
+    expect(r2.S.streak).toBeLessThanOrEqual(r1.S.streak);
+    expect(r2.S.streak).toBe(0); // day-2's "yesterday" had no study → streak legitimately broke
+  });
+
+  it("local-date day boundary: 'today' uses LOCAL date parts, not UTC toISOString()", () => {
+    // A Date whose LOCAL calendar day is 2026-07-19 but whose UTC (toISOString) has
+    // already rolled to 2026-07-20 — e.g. a user just before local midnight. dailyAct
+    // is absent so getStudyStreak() short-circuits to 0 without touching Date.
+    class DivergentDate {
+      static now() { return 0; }
+      getFullYear() { return 2026; }
+      getMonth() { return 6; }   // July (0-based)
+      getDate() { return 19; }   // LOCAL day
+      toISOString() { return "2026-07-20T00:30:00.000Z"; } // UTC already on the 20th
+    }
+    const r = runUpdate({ streak: 5, lastDay: "2026-07-01" }, DivergentDate);
+    expect(r.S.lastDay).toBe("2026-07-19");     // local date, NOT the UTC "2026-07-20"
+    expect(r.S.streak).toBe(0);                 // no activity tracked
+  });
+});


### PR DESCRIPTION
Round-2 held items. FSRS difficulty anchor corrected to D0_Easy~3.28 (was FSRS_W[4]~7.21) via byte-identical shared/fsrs.js master (md5 7cb675ea..., pinned) - authorized reschedule. G7 streak now activity-based + local date. G6 autopsy renders in displayed shuffle order. G8 invalidate+re-mint proxy JWT on 401 (personal key untouched, happy path unchanged). G5 HELD (no safe regex separates real refs from vitamin-D/degC). +15 tests. npm run verify green.