### PR TITLE
G5: keyword-anchored explanation-letter remap (zero medical-token corruption) + tidy

### DIFF
--- a/shlav-a-mega.html
+++ b/shlav-a-mega.html
@@ -3232,28 +3232,19 @@ function remapExplanationLetters(text,shuf){
     if(i===-1||inv[i]===undefined)return orig;
     return arr[inv[i]];
   };
-  // (1) Latin "B"/"Answer C" — ASCII word boundaries work fine here.
-  // (2) Hebrew "תשובה ב'" form — letter directly after "תשובה" + optional whitespace.
-  // (3) Hebrew bare label "א'/ג'/ד' שגויה" — letter+geresh used as bullet label.
-  //     Lookbehind (?<![א-ת]) excludes mid-word gershayim like "מג'ורי" (Major)
-  //     where Hebrew letters precede the apostrophe. Lookahead requires geresh
-  //     followed by whitespace/punct/EOL so foreign-sound markers like
-  //     "ג'נטיקה" (genetics — letter+geresh+more Hebrew) are also rejected.
-  // Single regex with alternation prevents double-remap of the same letter.
-  // v10.64.22 — was missing form (3), making explanations show wrong letter
-  //   refs whenever the option-shuffle moved labels (e.g., "אקו (תשובה ב')"
-  //   stayed as ב' even after echo got shuffled to display position ד').
-  // Lookahead `(?=[^א-ת]|$)` = "next char is not a Hebrew letter (or EOL)".
-  // Catches: geresh `'`, whitespace, ASCII letters, punct, EOL.
-  // Excludes: another Hebrew letter (so "תשובה בא" / "ג'נטיקה" stay untouched).
-  // Generalized in v10.64.23 — was a narrower char class missing
-  // "תשובה אcorrect" form (Hebrew letter directly followed by Latin).
-  return text
-    .replace(/\b([A-E])\b/g,(m,l)=>remap(l,latin))
-    .replace(
-      /(?:(תשובה\s*)([א-ה])(?=[^א-ת]|$)|(?<![א-ת])([א-ה])(['׳’])(?=[^א-ת]|$))/g,
-      (m,p,l1,l2,ger)=>p?p+remap(l1,heb):remap(l2,heb)+ger
-    );
+  // REMOVED (G5, 2026-07-18): the unguarded Latin `\b[A-E]\b` remap corrupted
+  // clinical tokens ("vitamin D"->"vitamin A", "hepatitis B", "34.2°C" C,
+  // "class A", SARC-F "**C**"...); the bare Hebrew label `[א-ה]'` could corrupt
+  // "יום ב'"/"שלב ג'"/"דרגה א'". A prior analysis proved no free-text regex can
+  // separate real bare-letter refs from such tokens, so BOTH bare forms are gone.
+  // Bare, un-anchored letter refs are now HELD (left byte-for-byte): the correct
+  // option is already marked green (isOk), so a desynced letter is
+  // confusing-but-not-wrong, whereas a corrupted clinical token is unacceptable.
+  // G5 (2026-07-18): remap ONLY where a letter is UNAMBIGUOUSLY an option ref —
+  // anchored to an explicit option keyword. In those contexts a clinical token
+  // can never appear, so the orig->display translation is provably safe.
+  const KW=/(תשוב(?:ה|ות)(?:\s+נכונה)?|סעיף|אפשרות|מסיח|[Aa]nswer|[Oo]ption|[Cc]hoice)(\s*)(?:([א-ה])(['׳’]?)(?=[^א-ת]|$)|([A-E])(?![A-Za-z]))/g;
+  return text.replace(KW,(m,kw,ws,hl,ger,ll)=>hl!==undefined?kw+ws+remap(hl,heb)+(ger||''):kw+ws+remap(ll,latin));
 }
 function getOptShuffle(qIdx,q){
   // Return stable shuffle for this question in this session

--- a/tests/appLogic.test.js
+++ b/tests/appLogic.test.js
@@ -17,6 +17,11 @@ const FSRS_W = [
 const FSRS_DECAY = -0.5;
 const FSRS_FACTOR = 19 / 81;
 const FSRS_RETENTION = 0.90;
+// Canonical FSRS-4.5 initial difficulty for rating "Easy" (~3.28 = fsrsInitNew(4).d).
+// 2026-07-18 correction (matches shared/fsrs.js): fsrsUpdate mean-reverts difficulty
+// toward this D0_Easy anchor, NOT toward FSRS_W[4] (~7.21) which inflated D over
+// repeated reviews and (via the (11-D) stability factor) roughly halved interval growth.
+const FSRS_D0_EASY = Math.min(10, Math.max(1, FSRS_W[4] - Math.exp(FSRS_W[5] * 3) + 1));
 
 // ─── Extracted pure functions ─────────────────────────────────────────────────
 
@@ -53,7 +58,7 @@ function fsrsUpdate(s, d, rPrev, rating) {
     newS = Math.max(0.1, newS);
   }
   const deltaD = -FSRS_W[6] * (rating - 3);
-  const mr = FSRS_W[7] * (FSRS_W[4] - d);
+  const mr = FSRS_W[7] * (FSRS_D0_EASY - d); // revert toward D0_Easy (~3.28), not FSRS_W[4] (~7.21)
   newD = Math.min(10, Math.max(1, d + deltaD + mr));
   return { s: newS, d: newD };
 }
@@ -304,13 +309,23 @@ describe("FSRS-4.5 — fsrsUpdate", () => {
     expect(s).toBeGreaterThanOrEqual(0.1);
   });
 
-  it("mean reversion pulls difficulty toward W[4]", () => {
-    // Very high difficulty should decrease toward center
+  it("mean reversion pulls difficulty toward D0_Easy (~3.28), not FSRS_W[4]", () => {
+    // 2026-07-18: anchor corrected to D0_Easy (= fsrsInitNew(4).d ~3.28) to match
+    // canonical FSRS-4.5 and shared/fsrs.js. It previously reverted toward FSRS_W[4] (~7.21).
+    expect(FSRS_D0_EASY).toBeCloseTo(3.28, 1);
+    // Very high difficulty decreases toward the anchor
     const { d: d1 } = fsrsUpdate(5, 10, 0.9, 3);
     expect(d1).toBeLessThan(10);
-    // Very low difficulty should increase toward center
+    // Very low difficulty increases toward the anchor
     const { d: d2 } = fsrsUpdate(5, 1, 0.9, 3);
     expect(d2).toBeGreaterThan(1);
+    // Discriminating check: at d = FSRS_W[4] (~7.21) with rating=3 (deltaD=0) the
+    // corrected anchor pulls difficulty DOWN; the old FSRS_W[4] anchor would leave it flat.
+    const { d: d3 } = fsrsUpdate(5, FSRS_W[4], 0.9, 3);
+    expect(d3).toBeLessThan(FSRS_W[4]);
+    // A card already at the anchor stays put (rating=3 => deltaD=0, mr=0).
+    const { d: d4 } = fsrsUpdate(5, FSRS_D0_EASY, 0.9, 3);
+    expect(d4).toBeCloseTo(FSRS_D0_EASY, 5);
   });
 });
 

--- a/tests/remapExplanationLetters.test.js
+++ b/tests/remapExplanationLetters.test.js
@@ -1,24 +1,33 @@
 /**
- * v10.64.22 regression: remapExplanationLetters must remap option-letter
- * references in explanations after option shuffle, including BARE LABEL
- * forms like "א' שגויה" / "ב' נכונה" (not just the "תשובה X" form).
+ * G5 (2026-07-18) — remapExplanationLetters is now KEYWORD-ANCHORED.
  *
- * Original bug: the regex only caught (תשובה\s*)([א-ה])\b which misses:
- *   - bare bullet labels: "**א' שגויה** — ..."
- *   - JS \b after Hebrew is unreliable (Hebrew chars not in ASCII \w)
+ * remapExplanationLetters(text, shuf) translates option-letter references from a
+ * question's ORIGINAL option order to the deterministic display order. The
+ * translation is correct; the DEFECT was that the Latin form matched ANY
+ * standalone A-E (\b[A-E]\b), so it corrupted clinical tokens whenever the
+ * shuffle moved that index: "vitamin D"->"vitamin A", "34.2°C" (the C),
+ * "hepatitis B", "class A", SARC-F "**C**", "type A/B", "grade A-C". The bare
+ * Hebrew label form ([א-ה]') could likewise corrupt "יום ב'"/"שלב ג'"/"דרגה א'".
+ * A prior analysis proved NO free-text regex can separate real bare-letter refs
+ * from these medical tokens.
  *
- * Real-world impact: explanations showed wrong option letter references
- * whenever options got shuffled. Example from idx=2841 (2024-May-Basic
- * stroke Q): the dataset's correct answer is "echo" at orig position ב=1.
- * After display shuffle, echo lands at display position ד=3. The
- * explanation said "אקו (תשובה ב')" but the user sees ECHO under ד —
- * mismatch, confusing.
+ * APPROVED FIX: remap ONLY where a letter is UNAMBIGUOUSLY an option reference
+ * because it is immediately anchored to an explicit option keyword —
+ *   Hebrew: תשובה / תשובות / (תשובה) נכונה / סעיף / אפשרות / מסיח
+ *   Latin:  answer / option / choice
+ * In those contexts a clinical token can never appear, so remap is provably safe.
+ * BARE letters with no keyword anchor are HELD (left byte-for-byte): the correct
+ * option is already marked green (isOk), so a desynced letter is
+ * confusing-but-not-wrong, whereas a corrupted clinical token is unacceptable.
+ *
+ * (Full-corpus proof — every shipped explanation × identity + seeded shuffles —
+ * lives in .work/captain/g5-corpus-validate.mjs: NEW changes ZERO medical tokens.)
  */
 import { describe, it, expect, beforeAll } from "vitest";
 import { readFileSync } from "fs";
 import { resolve } from "path";
 
-let remapExplanationLetters;
+let remap;
 
 beforeAll(() => {
   // Extract the function from the monolith via a function-string snapshot.
@@ -26,100 +35,138 @@ beforeAll(() => {
   const m = html.match(/function remapExplanationLetters\(text,shuf\)\{[\s\S]+?\n\}/);
   if (!m) throw new Error("remapExplanationLetters not found in shlav-a-mega.html");
   // eslint-disable-next-line no-new-func
-  remapExplanationLetters = new Function(`${m[0]}\nreturn remapExplanationLetters;`)();
+  remap = new Function(`${m[0]}\nreturn remapExplanationLetters;`)();
 });
 
-describe("remapExplanationLetters — v10.64.22 fix", () => {
-  // identity shuffle: orig 0,1,2,3 → display 0,1,2,3 — no remap should occur
-  const identity = [0, 1, 2, 3];
-
+describe("remapExplanationLetters — G5 positive (keyword-anchored refs remap)", () => {
   it("identity shuffle leaves text unchanged", () => {
-    const text = "התשובה הנכונה היא ב'. א' שגויה. Answer C.";
-    expect(remapExplanationLetters(text, identity)).toBe(text);
+    const text = "תשובה C. answer B. סעיף A.";
+    expect(remap(text, [0, 1, 2, 3])).toBe(text);
   });
 
-  it("does not remap mid-word gershayim like \"מג'ורי\" (Major)", () => {
-    const swap = [1, 0, 2, 3]; // א<>ב swap
-    const text = "מאופיין על ידי דיכאון מג'ורי (Major Depression)";
-    expect(remapExplanationLetters(text, swap)).toBe(text);
+  it("remaps 'תשובה C' (Hebrew keyword + Latin letter — the corpus-common form)", () => {
+    // shuf[disp]=orig: [2,0,1,3] => inv[C=2]=0=A
+    expect(remap("תשובה C שגויה", [2, 0, 1, 3])).toBe("תשובה A שגויה");
   });
 
-  it("does not remap foreign-sound-at-word-start like \"ג'נטיקה\" (genetics)", () => {
-    const swap = [1, 0, 2, 3];
-    const text = "ג'נטיקה היא חשובה";
-    expect(remapExplanationLetters(text, swap)).toBe(text);
+  it("remaps 'answer C' (Latin keyword + Latin letter)", () => {
+    expect(remap("answer C", [2, 0, 1, 3])).toBe("answer A");
   });
 
-  it("remaps \"תשובה ב'\" form when option shuffled", () => {
-    // shuf[disp]=orig: display position 3 holds original ב (idx=1). So inv[1]=3.
+  it("remaps 'תשובה ב'' (Hebrew keyword + Hebrew letter + geresh)", () => {
+    // shuf [3,2,0,1] => inv[ב=1]=3=ד
+    expect(remap("האפשרות הנכונה היא תשובה ב'.", [3, 2, 0, 1])).toContain("תשובה ד'");
+    expect(remap("האפשרות הנכונה היא תשובה ב'.", [3, 2, 0, 1])).not.toContain("תשובה ב'");
+  });
+
+  it("remaps 'סעיף' / 'אפשרות' / 'מסיח' anchors", () => {
+    const swap = [1, 0, 2, 3]; // א<->ב, A<->B
+    expect(remap("סעיף A", swap)).toBe("סעיף B");
+    expect(remap("אפשרות B", swap)).toBe("אפשרות A");
+    expect(remap("מסיח A", swap)).toBe("מסיח B");
+  });
+
+  it("remaps 'Choice B' / 'Option C'", () => {
+    const shuf = [2, 0, 1, 3]; // inv[B=1]=2=C, inv[C=2]=0=A
+    expect(remap("Choice B is correct.", shuf)).toBe("Choice C is correct.");
+    expect(remap("Option C is wrong.", shuf)).toBe("Option A is wrong.");
+  });
+
+  it("remaps Hebrew letter directly followed by ASCII letter 'תשובה אcorrect'", () => {
+    // shuf [1,2,0,3] => inv[א=0]=2=ג
+    expect(remap("תשובה אcorrect", [1, 2, 0, 3])).toBe("תשובה גcorrect");
+  });
+
+  it("remaps Hebrew letter directly followed by whitespace 'תשובה א נכונה'", () => {
+    expect(remap("תשובה א נכונה", [1, 2, 0, 3])).toBe("תשובה ג נכונה");
+  });
+
+  it("does not double-remap 'תשובה ב'' in alternated patterns", () => {
+    const swap = [1, 0, 2, 3]; // ב(1) -> disp 0 = א
+    expect(remap("תשובה ב' היא הנכונה", swap)).toBe("תשובה א' היא הנכונה");
+  });
+});
+
+describe("remapExplanationLetters — G5 held (bare refs, no keyword anchor)", () => {
+  const shuf = [3, 2, 0, 1];
+
+  it("HOLDS bare Hebrew label 'א' שגויה' (no keyword anchor)", () => {
+    const text = "- **א' שגויה** — דופלר צוואר\n- **ד' שגויה** — אנטיקואגולציה";
+    expect(remap(text, shuf)).toBe(text);
+  });
+
+  it("HOLDS bare Latin bullet labels '**A** —' / '**B** —'", () => {
+    const text = "- **A** — דלוזיות\n- **B** — נפילות\n- **C** — דיכאון";
+    expect(remap(text, [2, 0, 1, 3])).toBe(text);
+  });
+
+  it("HOLDS 'The answer is A' (keyword not immediately adjacent to the letter)", () => {
+    expect(remap("The answer is A.", [2, 0, 1, 3])).toBe("The answer is A.");
+  });
+});
+
+describe("remapExplanationLetters — G5 negative (medical tokens NEVER corrupted)", () => {
+  // Maps chosen so that, if the old bare-letter forms were still active, the
+  // token's letter WOULD move — these assertions prove the corruption is gone.
+  const maps = [[3, 2, 0, 1], [1, 2, 3, 4, 0], [2, 0, 1, 3]];
+
+  const unchanged = (s) => {
+    for (const map of maps) expect(remap(s, map), `token corrupted under map ${JSON.stringify(map)}`).toBe(s);
+  };
+
+  it("does not corrupt 'ויטמין A'..'ויטמין E' / 'vitamin A'..'vitamin E'", () => {
+    for (const L of ["A", "B", "C", "D", "E"]) { unchanged("ויטמין " + L); unchanged("vitamin " + L); }
+  });
+
+  it("does not corrupt '34.2°C' / '°C' / '°F'", () => {
+    unchanged("34.2°C"); unchanged("°C"); unchanged("°F"); unchanged("חום 34.2°C בקבלה");
+  });
+
+  it("does not corrupt 'hepatitis A'..'hepatitis E'", () => {
+    for (const L of ["A", "B", "C", "D", "E"]) unchanged("hepatitis " + L);
+  });
+
+  it("does not corrupt SARC-F incl. the bare '**C**' mnemonic", () => {
+    unchanged("SARC-F");
+    unchanged("שאלון SARC-F כולל **S**trength ו-**C**limb stairs ו-**F**alls");
+  });
+
+  it("does not corrupt 'class A' / 'type A/B' / 'grade A'-'grade C' / 'part A/B'", () => {
+    unchanged("class A"); unchanged("type A/B"); unchanged("grade A"); unchanged("grade B");
+    unchanged("grade C"); unchanged("part A"); unchanged("Medicare part A/B");
+  });
+
+  it("does not corrupt Hebrew 'שלב ב'' / 'דרגה א'' / 'יום ב'' (day-of-week)", () => {
+    unchanged("המחלה בשלב ב'"); unchanged("כוויה מדרגה א'"); unchanged("ביום ב' התייצב");
+  });
+
+  it("does not remap mid-word gershayim 'מג'ורי' or foreign-sound 'ג'נטיקה'", () => {
+    unchanged("דיכאון מג'ורי (Major Depression)");
+    unchanged("ג'נטיקה היא חשובה");
+  });
+});
+
+describe("remapExplanationLetters — G5 end-to-end (real bug case idx=2841)", () => {
+  it("remaps the keyword-anchored 'תשובה ב'' to display ד' and HOLDS bare labels", () => {
+    // Dataset original order: [doppler, echo*, no-CT, anticoag] (c=1=echo).
+    // Display shuffle puts echo at display ד=3 → shuf[disp]=orig = [3,2,0,1].
     const shuf = [3, 2, 0, 1];
-    const text = "האפשרות הנכונה היא תשובה ב'.";
-    const result = remapExplanationLetters(text, shuf);
-    expect(result).toContain("תשובה ד'");
-    expect(result).not.toContain("תשובה ב'");
-  });
-
-  it("remaps bare label \"א' שגויה\" form when option shuffled", () => {
-    // shuf[0]=3 → inv[3]=0; shuf[2]=0 → inv[0]=2
-    const shuf = [3, 2, 0, 1];
-    const text = "- **א' שגויה** — דופלר צוואר רלוונטי\n- **ד' שגויה** — אנטיקואגולציה";
-    const result = remapExplanationLetters(text, shuf);
-    // א (orig 0) → display 2 = ג; ד (orig 3) → display 0 = א
-    expect(result).toContain("ג' שגויה");
-    expect(result).toContain("א' שגויה");
-    expect(result).not.toMatch(/^- \*\*א' שגויה\*\* — דופלר/m);
-  });
-
-  it("remaps Latin standalone letters: \"Answer A\" / \"B is correct\"", () => {
-    // shuf[disp]=orig: [2,0,1,3] → display 0 holds C, display 1 holds A, etc.
-    // So inv[origA=0]=1=B, inv[origB=1]=2=C, inv[origC=2]=0=A.
-    const shuf = [2, 0, 1, 3];
-    expect(remapExplanationLetters("The answer is A.", shuf)).toBe("The answer is B.");
-    expect(remapExplanationLetters("Choice B is correct.", shuf)).toBe("Choice C is correct.");
-    expect(remapExplanationLetters("Option C is wrong.", shuf)).toBe("Option A is wrong.");
-  });
-
-  it("remaps Hebrew letter directly followed by ASCII letter (v10.64.23)", () => {
-    // "תשובה אcorrect" form — caught by FM's existing utilsExtras.test.js;
-    // earlier v10.64.22 narrower lookahead missed it.
-    const shuf = [1, 2, 0, 3];
-    expect(remapExplanationLetters("תשובה אcorrect", shuf)).toBe("תשובה גcorrect");
-  });
-
-  it("remaps Hebrew letter directly followed by whitespace (v10.64.23)", () => {
-    const shuf = [1, 2, 0, 3];
-    expect(remapExplanationLetters("תשובה א נכונה", shuf)).toBe("תשובה ג נכונה");
-  });
-
-  it("does not double-remap a letter in alternated patterns", () => {
-    // "תשובה ב'" — first branch matches "תשובה ב", consumes through ב.
-    // The trailing geresh + lookbehind keeps the second branch from firing.
-    const swap = [1, 0, 2, 3]; // א<>ב swap
-    const text = "תשובה ב' היא הנכונה";
-    const result = remapExplanationLetters(text, swap);
-    expect(result).toBe("תשובה א' היא הנכונה");
-  });
-
-  it("end-to-end on the v10.64.22 bug case (idx=2841 stroke explanation)", () => {
-    // Dataset original order: [doppler, echo*, no-CT, anticoag] (c=1=echo)
-    // Display shuffle puts: [anticoag, no-CT, doppler, echo] (echo at pos 3)
-    // shuf[disp]=orig: [3, 2, 0, 1]
-    const shuf = [3, 2, 0, 1];
-    const e = `
-לכן **אקו-לב (תשובה ב')** היא הבדיקה החשובה ביותר.
-
-- **א' שגויה** — דופלר צוואר רלוונטי לאתרוסקלרוזיס.
-- **ג' שגויה** — חובה לשלול דימום ב-CT.
-- **ד' שגויה** — אנטיקואגולציה לא מתחילים אוטומטית.
-`.trim();
-    const result = remapExplanationLetters(e, shuf);
-    // The correct answer (echo) was orig ב=1 → display ד=3
-    expect(result).toContain("תשובה ד'");
-    // Doppler (orig א=0) → display ג=2
-    expect(result).toContain("ג' שגויה");
-    // No-CT (orig ג=2) → display ב=1
-    expect(result).toContain("ב' שגויה");
-    // Anticoag (orig ד=3) → display א=0
-    expect(result).toContain("א' שגויה");
+    const text = [
+      "לכן **אקו-לב (תשובה ב')** היא הבדיקה החשובה ביותר.",
+      "",
+      "- **א' שגויה** — דופלר צוואר רלוונטי לאתרוסקלרוזיס.",
+      "- **ג' שגויה** — חובה לשלול דימום ב-CT.",
+      "- **ד' שגויה** — אנטיקואגולציה לא מתחילים אוטומטית.",
+    ].join("\n");
+    const expected = [
+      "לכן **אקו-לב (תשובה ד')** היא הבדיקה החשובה ביותר.",
+      "",
+      "- **א' שגויה** — דופלר צוואר רלוונטי לאתרוסקלרוזיס.",
+      "- **ג' שגויה** — חובה לשלול דימום ב-CT.",
+      "- **ד' שגויה** — אנטיקואגולציה לא מתחילים אוטומטית.",
+    ].join("\n");
+    // Only the keyword-anchored "תשובה ב'" moves (ב orig=1 -> display ד=3);
+    // the bare "א'/ג'/ד' שגויה" bullet labels are HELD byte-for-byte.
+    expect(remap(text, shuf)).toBe(expected);
   });
 });


### PR DESCRIPTION
G5 (medical-content, provably-correct-or-hold): remapExplanationLetters now remaps option letters ONLY when anchored to an explicit option keyword (Hebrew tshuva/seif/efshar/masiach, Latin answer/option/choice); removed the unguarded bare-Latin and bare-Hebrew forms that corrupted clinical tokens (vitamin D, degC, hepatitis B, SARC-F **C**, day/stage/grade labels). Bare un-anchored letters HELD (never corrupted). Corpus-validated: 4647 explanations x 23 shuffle maps, ZERO medical-token changes (OLD corrupted 5549). Plus remap tests. Tidy: appLogic inline fsrsUpdate reconciled to D0_Easy. shared/fsrs.js/auth/scoring untouched; npm run verify green.