### PR TITLE
fix(content): 10 hand-adjudicated Tier-B answer-key corrections

### DIFF
--- a/data/questions.json
+++ b/data/questions.json
@@ -27786,7 +27786,7 @@
 "רמות טסטוסטרון נמוכות גבוליות",
 "היעדר תסמינים ספציפיים של hypogonadism"
 ],
-"c": 0,
+"c": 1,
 "t": "Hazzard",
 "ti": 43,
 "ref": "Hazzard Ch 37 — SEXUALITY , SEXUAL FUNCTION, AND THE AGING MAN",
@@ -28098,7 +28098,7 @@
 "התחלת bethanechol 25 mg TID לשיפור תפקוד ה-detrusor",
 "קביעת scheduled voiding עם טכניקת double-void"
 ],
-"c": 0,
+"c": 3,
 "t": "Hazzard",
 "ti": 11,
 "ref": "Hazzard Ch 47 — INCONTINENCE",
@@ -29158,7 +29158,7 @@
 "New ADL dependence בשבועיים הראשונים",
 "שימוש ב-tramadol לשליטה בכאב"
 ],
-"c": 2,
+"c": 1,
 "t": "Hazzard",
 "ti": 3,
 "ref": "Hazzard Ch 49 — MUSCLE AGING AND SARCOPENIA",
@@ -30580,7 +30580,7 @@
 "הפחתת furosemide ל-20mg בימים הקבועים",
 "הוספת midodrine 5mg לפני הקימה"
 ],
-"c": 0,
+"c": 2,
 "t": "Hazzard",
 "ti": 18,
 "ref": "Hazzard Ch 76 — HEART FAILURE· Harrison Ch 26 — Neurologic Causes of Weakness and Paralysis",
@@ -31900,7 +31900,7 @@
 "לסקור fear of falling ו-functional decline",
 "להזמין MRI לשלילת occult hip fracture"
 ],
-"c": 1,
+"c": 2,
 "t": "Hazzard",
 "ti": 4,
 "ref": "Hazzard Ch 53 — HIP FRACTURES · Harrison Ch 26 — Neurologic Causes of Weakness and Paralysis",
@@ -32833,7 +32833,7 @@
 "family meeting לגבי placement",
 "ביקור טיפולי ניסיוני בבית"
 ],
-"c": 3,
+"c": 0,
 "t": "Hazzard",
 "ti": 2,
 "ref": "Hazzard Ch 8 — PRINCIPLES OF GERIATRIC ASSESSMENT",
@@ -36746,7 +36746,7 @@
 "הפחתת escitalopram ל-5mg יומי",
 "הפסקת escitalopram ומעקב אחר מצב הרוח"
 ],
-"c": 2,
+"c": 3,
 "t": "Hazzard",
 "ti": 7,
 "ref": "Hazzard Ch 65 — MAJOR DEPRESSION",
@@ -39647,7 +39647,7 @@
 "להתחיל sacubitril/valsartan 49/51mg BID באופן מיידי",
 "להעלות lisinopril ל-10mg daily במקום"
 ],
-"c": 0,
+"c": 1,
 "t": "Hazzard",
 "ti": 18,
 "ref": "Hazzard Ch 76 — HEART FAILURE· Harrison Ch 286 — ST-Segment Elevation Myocardial Infarction",
@@ -42130,7 +42130,7 @@
 "Laryngospasm מ-haloperidol",
 "Hospital-acquired pneumonia"
 ],
-"c": 0,
+"c": 2,
 "t": "Hazzard",
 "ti": 8,
 "ref": "Hazzard Ch 22 — MEDICATION PRESCRIBING AND DE-PRESCRIBING· Harrison Ch 295 — Approach to the Patient with Disease of the Respiratory System",
@@ -45034,7 +45034,7 @@
 "Transurethral resection of prostate",
 "Finasteride 5 mg ביום עם monitoring צמוד"
 ],
-"c": 1,
+"c": 3,
 "t": "Hazzard",
 "ti": 26,
 "ref": "Hazzard Ch 67 — PALLIATIVE CARE AND SPECIAL MANAGEMENT ISSUES · Harrison Ch 13 — Palliative and End-of-Life Care",


### PR DESCRIPTION
## Second-tier key fixes (hand-adjudicated)
Follow-up to #422. These are the Tier-B candidates (LLM + 2-pass-verifier flagged) that I then **hand-read against each explanation**. I flipped `c` only where the explanation explicitly names the current key as the trap AND defends a clinically-correct answer. Diff = exactly 10 `"c"` lines; **`npm run verify` green (1829 tests)**.

### The 10 flips
| idx | c -> | rationale |
|---|---|---|
| 1273 | 0->1 | testosterone Rx: Hgb>16 g/dL is the absolute contraindication (erythrocytosis); treated prostate ca is no longer absolute per current guidelines |
| 1285 | 0->3 | recurrent UTI + dementia + retention: scheduled/double-void; teaching self-cath fails without the cognition/dexterity she lacks |
| 1326 | 2->1 | hip-fx recovery: albumin <3.0 is the strongest predictor of poor recovery; 2 weeks is too early to call ADL dependence prognostic |
| 1381 | 0->2 | CHF orthostatic only on diuretic days + weight gain: reduce furosemide on those days; switching to daily torsemide worsens orthostasis |
| 1432 | 1->2 | 4-hr long lie + 'do not want to be a burden': screen fear-of-falling/functional decline; mild CPK without renal dysfunction needs no admission |
| 1468 | 3->0 | post-hip-fx placement: formal IADL assessment gives objective safety data; a trial home visit is resource-intensive and less predictive |
| 1620 | 2->3 | SSRI-induced hyponatremia + falls: stop the SSRI and monitor mood; dose reduction may not resolve the hyponatremia |
| 1732 | 0->1 | HFrEF + eGFR 26 + K 5.2: hold ARNI (PARADIGM-HF excluded eGFR<30 + hyperkalemia risk); starting it is the trap [softer call] |
| 1828 | 0->2 | acute dyspnea minutes after haloperidol with accessory-muscle use: laryngospasm/acute dystonia; COPD exac develops over days, not acutely |
| 1940 | 1->3 | advanced dementia + prostate ca + retention (Foley in), comfort goals: finasteride is least-burdensome; leuprolide/TURP more invasive [comfort-framed] |

### 13 candidates deliberately NOT flipped
The verifier flagged these too, but on reading them they should stay as-is — flipping would teach a *worse* answer or misfire:

**Verifier misfired — the explanation actually supports the key (no change needed)**
- 1371 — explanation defends conservative med adjustment (= the key, reduce amlodipine), naming domperidone the trap
- 1693 — explanation explicitly states 'option 2 is correct' (= the key: evidence-based prognosis with variability)
- 3821 — explanation's stated target is 7.5-8.0%; key <8.0% is inside that range (you relax, not tighten, after hypoglycemia)

**The explanation is clinically wrong — fix the explanation, NOT the key**
- 1655 — duloxetine (key) is first-line for painful diabetic neuropathy; capsaicin (explanation) is a weaker topical adjunct
- 2152 — Type 4 RTA (key) is the classic NAGMA + hyperkalemia picture in a diabetic with CKD; 'CKD' (explanation) is the weaker read
- 2225 — enoxaparin 1mg/kg BID (key) is standard for CrCl 30-50; the once-daily reduction (explanation) is the CrCl<30 rule
- 1856 — cipro 500mg q12h (key) is acceptable at CrCl 32; 250 (explanation) is also acceptable but not required
- 2237 — at 140-min transfer (>120), fibrinolysis (key) is guideline-indicated; 'transfer to PCI' (explanation) contradicts the threshold it cites
- 2351 — levetiracetam->lamotrigine switch (key) addresses the likely AED-induced psychiatric SE; neuropsych referral (explanation) does not address acute SI

**Genuinely debatable / goals-of-care / internally inconsistent (your call)**
- 1370 — glyburide replacement (explanation) vs meal-timing + water bolus (key): both valid here
- 2306 — reduce metoprolol + recheck orthostatics (key) vs blister-pack for adherence (explanation): both valid
- 2330 — BiPAP (explanation) vs morphine for dyspnea (key): depends on the advance-directive detail
- 2046 — explanation declares option 2 but its prose describes the option-1 (saline->D5W) sequence: internally inconsistent

## Notes
- No version bump (mirrors #422). After you merge, I will cache-bust (v192 -> v193) + deploy so clients re-fetch.
- Not self-merged — these are clinical-judgment calls; 1732 and 1940 are the softer two, easy to drop in review if you disagree.
